### PR TITLE
feat(docker): Add authentication configuration for Memgraph, Qdrant, Valkey [OMN-1444]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,12 @@ VALKEY_PROD_MEMORY_RESERVATION=256M
 # Set values for production deployments
 #
 # IMPORTANT: For production, these MUST be set or services will fail to start
+#
+# PASSWORD COMPLEXITY RECOMMENDATIONS:
+#   - Minimum length: 32 characters recommended
+#   - Generate secure passwords with: openssl rand -base64 32
+#   - Avoid special characters that need escaping in shell/YAML: $ ` \ " ' ! & | ; < > ( ) { } [ ]
+#   - Safe special characters: - _ . @ # % ^ + =
 
 # Qdrant API Key
 # When set, all Qdrant API requests require this key in Authorization header

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ VALKEY_VERSION=8
 # ----------------------------------------------------------------------------
 # Vector database for semantic memory storage
 
+# MIGRATION NOTE: Renamed from QDRANT_PORT to QDRANT_HTTP_PORT
+# If you have an existing .env with QDRANT_PORT, rename it to QDRANT_HTTP_PORT
+
 # REST API port (default: 6333)
 # Used for HTTP API access and health checks
 QDRANT_HTTP_PORT=6333
@@ -85,7 +88,7 @@ QDRANT_MEMORY_RESERVATION=512M
 
 # Memgraph Resources (Development)
 MEMGRAPH_CPU_LIMIT=2.0
-MEMGRAPH_MEMORY_LIMIT=4G
+MEMGRAPH_CONTAINER_MEMORY=4G
 MEMGRAPH_CPU_RESERVATION=0.25
 MEMGRAPH_MEMORY_RESERVATION=512M
 
@@ -109,7 +112,7 @@ QDRANT_PROD_MEMORY_RESERVATION=1G
 
 # Memgraph Resources (Production)
 MEMGRAPH_PROD_CPU_LIMIT=4.0
-MEMGRAPH_PROD_MEMORY_LIMIT=8G
+MEMGRAPH_PROD_CONTAINER_MEMORY=8G
 MEMGRAPH_PROD_CPU_RESERVATION=0.5
 MEMGRAPH_PROD_MEMORY_RESERVATION=1G
 # Internal memory limit in MB (production - higher than dev)
@@ -163,10 +166,10 @@ VALKEY_PROD_MEMORY_RESERVATION=256M
 # ----------------------------------------------------------------------------
 # For machines with limited resources (e.g., 8GB RAM laptop):
 #   QDRANT_MEMORY_LIMIT=1G
-#   MEMGRAPH_MEMORY_LIMIT=2G
+#   MEMGRAPH_CONTAINER_MEMORY=2G
 #   VALKEY_MEMORY_LIMIT=512M
 #
 # For high-memory machines (e.g., 64GB+ workstation):
 #   QDRANT_MEMORY_LIMIT=8G
-#   MEMGRAPH_MEMORY_LIMIT=16G
+#   MEMGRAPH_CONTAINER_MEMORY=16G
 #   VALKEY_MEMORY_LIMIT=4G

--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,42 @@ MEMGRAPH_BOLT_PORT=7687
 
 # HTTP port for web interface (default: 7444)
 MEMGRAPH_HTTP_PORT=7444
+
+# ----------------------------------------------------------------------------
+# Valkey Configuration
+# ----------------------------------------------------------------------------
+# High-performance cache (Redis-compatible)
+
+# Valkey image version
+VALKEY_VERSION=8
+
+# Client connection port (default: 6379)
+VALKEY_PORT=6379
+
+# ----------------------------------------------------------------------------
+# Authentication (Optional for Development, Required for Production)
+# ----------------------------------------------------------------------------
+# Leave empty/unset for local development (no auth)
+# Set values for production deployments
+
+# Qdrant API Key
+# When set, all Qdrant API requests require this key in Authorization header
+# QDRANT_API_KEY=your-secure-api-key-here
+
+# Memgraph Credentials
+# When both are set, Memgraph requires authentication for all connections
+# MEMGRAPH_USER=admin
+# MEMGRAPH_PASSWORD=your-secure-password-here
+
+# Valkey Password
+# When set, Valkey requires AUTH command before accepting other commands
+# VALKEY_PASSWORD=your-secure-password-here
+
+# ----------------------------------------------------------------------------
+# Production Deployment
+# ----------------------------------------------------------------------------
+# For production, use docker-compose.prod.yml which REQUIRES all auth vars:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Ensure all authentication variables above are set before starting.

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 # Usage:
 #   cp .env.example .env
 #   docker compose up -d
+#
+# For production:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 # ============================================================================
 
 # ----------------------------------------------------------------------------
@@ -23,15 +26,21 @@ QDRANT_VERSION=v1.16.3
 # Latest versions: https://hub.docker.com/r/memgraph/memgraph/tags
 MEMGRAPH_VERSION=2.18.1
 
+# Valkey (Redis-compatible) Cache
+# Latest versions: https://hub.docker.com/r/valkey/valkey/tags
+VALKEY_VERSION=8
+
 # ----------------------------------------------------------------------------
 # Qdrant Configuration
 # ----------------------------------------------------------------------------
 # Vector database for semantic memory storage
 
 # REST API port (default: 6333)
-QDRANT_PORT=6333
+# Used for HTTP API access and health checks
+QDRANT_HTTP_PORT=6333
 
 # gRPC port for high-performance operations (default: 6334)
+# Used for bulk operations and streaming
 QDRANT_GRPC_PORT=6334
 
 # ----------------------------------------------------------------------------
@@ -40,34 +49,94 @@ QDRANT_GRPC_PORT=6334
 # Graph database for relationship queries
 
 # Bolt protocol port for client connections (default: 7687)
+# Used by Neo4j drivers and mgconsole
 MEMGRAPH_BOLT_PORT=7687
 
 # HTTP port for web interface (default: 7444)
+# Used for Memgraph Lab web UI
 MEMGRAPH_HTTP_PORT=7444
+
+# Internal memory limit in MB for Memgraph (development)
+# This controls Memgraph's internal memory allocation
+MEMGRAPH_MEMORY_LIMIT_MB=4096
+
+# Query execution timeout in seconds (production only)
+MEMGRAPH_QUERY_TIMEOUT_SEC=600
 
 # ----------------------------------------------------------------------------
 # Valkey Configuration
 # ----------------------------------------------------------------------------
 # High-performance cache (Redis-compatible)
 
-# Valkey image version
-VALKEY_VERSION=8
-
 # Client connection port (default: 6379)
 VALKEY_PORT=6379
+
+# ----------------------------------------------------------------------------
+# Resource Limits - Development
+# ----------------------------------------------------------------------------
+# These control container resource allocation for development (docker-compose.yml)
+# Adjust based on your machine's available resources
+
+# Qdrant Resources (Development)
+QDRANT_CPU_LIMIT=2.0
+QDRANT_MEMORY_LIMIT=2G
+QDRANT_CPU_RESERVATION=0.25
+QDRANT_MEMORY_RESERVATION=512M
+
+# Memgraph Resources (Development)
+MEMGRAPH_CPU_LIMIT=2.0
+MEMGRAPH_MEMORY_LIMIT=4G
+MEMGRAPH_CPU_RESERVATION=0.25
+MEMGRAPH_MEMORY_RESERVATION=512M
+
+# Valkey Resources (Development)
+VALKEY_CPU_LIMIT=1.0
+VALKEY_MEMORY_LIMIT=1G
+VALKEY_CPU_RESERVATION=0.1
+VALKEY_MEMORY_RESERVATION=128M
+
+# ----------------------------------------------------------------------------
+# Resource Limits - Production
+# ----------------------------------------------------------------------------
+# These control container resource allocation for production (docker-compose.prod.yml)
+# Production defaults are more generous than development
+
+# Qdrant Resources (Production)
+QDRANT_PROD_CPU_LIMIT=4.0
+QDRANT_PROD_MEMORY_LIMIT=4G
+QDRANT_PROD_CPU_RESERVATION=0.5
+QDRANT_PROD_MEMORY_RESERVATION=1G
+
+# Memgraph Resources (Production)
+MEMGRAPH_PROD_CPU_LIMIT=4.0
+MEMGRAPH_PROD_MEMORY_LIMIT=8G
+MEMGRAPH_PROD_CPU_RESERVATION=0.5
+MEMGRAPH_PROD_MEMORY_RESERVATION=1G
+# Internal memory limit in MB (production - higher than dev)
+MEMGRAPH_PROD_MEMORY_LIMIT_MB=8192
+
+# Valkey Resources (Production)
+VALKEY_PROD_CPU_LIMIT=2.0
+VALKEY_PROD_MEMORY_LIMIT=2G
+VALKEY_PROD_CPU_RESERVATION=0.25
+VALKEY_PROD_MEMORY_RESERVATION=256M
 
 # ----------------------------------------------------------------------------
 # Authentication (Optional for Development, Required for Production)
 # ----------------------------------------------------------------------------
 # Leave empty/unset for local development (no auth)
 # Set values for production deployments
+#
+# IMPORTANT: For production, these MUST be set or services will fail to start
 
 # Qdrant API Key
 # When set, all Qdrant API requests require this key in Authorization header
+# Recommended: Use a strong, randomly generated key (min 32 characters)
 # QDRANT_API_KEY=your-secure-api-key-here
 
 # Memgraph Credentials
 # When both are set, Memgraph requires authentication for all connections
+# Note: Memgraph fails on empty credentials, unlike Qdrant/Valkey
 # MEMGRAPH_USER=admin
 # MEMGRAPH_PASSWORD=your-secure-password-here
 
@@ -76,10 +145,28 @@ VALKEY_PORT=6379
 # VALKEY_PASSWORD=your-secure-password-here
 
 # ----------------------------------------------------------------------------
-# Production Deployment
+# Quick Reference - Port Conflict Resolution
 # ----------------------------------------------------------------------------
-# For production, use docker-compose.prod.yml which REQUIRES all auth vars:
+# If you have port conflicts, override the conflicting port(s):
 #
-#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+# Example: Another service using port 6333
+#   QDRANT_HTTP_PORT=16333
 #
-# Ensure all authentication variables above are set before starting.
+# Example: Another service using port 7687
+#   MEMGRAPH_BOLT_PORT=17687
+#
+# Example: Another Redis/Valkey using port 6379
+#   VALKEY_PORT=16379
+
+# ----------------------------------------------------------------------------
+# Quick Reference - Resource Tuning
+# ----------------------------------------------------------------------------
+# For machines with limited resources (e.g., 8GB RAM laptop):
+#   QDRANT_MEMORY_LIMIT=1G
+#   MEMGRAPH_MEMORY_LIMIT=2G
+#   VALKEY_MEMORY_LIMIT=512M
+#
+# For high-memory machines (e.g., 64GB+ workstation):
+#   QDRANT_MEMORY_LIMIT=8G
+#   MEMGRAPH_MEMORY_LIMIT=16G
+#   VALKEY_MEMORY_LIMIT=4G

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,11 +29,11 @@ services:
     # Services should connect via omnimemory-network using service name
     ports: !override []
     expose:
-      - "6333"
-      - "6334"
+      - "${QDRANT_HTTP_PORT:-6333}"
+      - "${QDRANT_GRPC_PORT:-6334}"
     environment:
-      QDRANT__SERVICE__HTTP_PORT: 6333
-      QDRANT__SERVICE__GRPC_PORT: 6334
+      QDRANT__SERVICE__HTTP_PORT: ${QDRANT_HTTP_PORT:-6333}
+      QDRANT__SERVICE__GRPC_PORT: ${QDRANT_GRPC_PORT:-6334}
       QDRANT__SERVICE__HOST: 0.0.0.0
       QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
       QDRANT__STORAGE__ON_DISK_PAYLOAD: true
@@ -41,8 +41,9 @@ services:
       # REQUIRED - service will fail without this
       QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:?QDRANT_API_KEY is required for production}
     healthcheck:
-      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333 && echo -e 'GET /readyz HTTP/1.1\\r\\nHost:
-          localhost:6333\\r\\n\\r\\n' >&3 && timeout 2 cat <&3 | grep -q 'ready'"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/${QDRANT_HTTP_PORT:-6333} && echo -e 'GET
+          /readyz HTTP/1.1\\r\\nHost: localhost:${QDRANT_HTTP_PORT:-6333}\\r\\n\\r\\n' >&3 && timeout
+          2 cat <&3 | grep -q 'ready'"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -50,11 +51,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
-          memory: 4G
+          cpus: '${QDRANT_PROD_CPU_LIMIT:-4.0}'
+          memory: ${QDRANT_PROD_MEMORY_LIMIT:-4G}
         reservations:
-          cpus: '0.5'
-          memory: 1G
+          cpus: '${QDRANT_PROD_CPU_RESERVATION:-0.5}'
+          memory: ${QDRANT_PROD_MEMORY_RESERVATION:-1G}
     restart: always
 
   # Memgraph Database - Production Configuration
@@ -63,12 +64,12 @@ services:
     # Remove host port exposure - internal network only
     ports: !override []
     expose:
-      - "7687"
-      - "7444"
+      - "${MEMGRAPH_BOLT_PORT:-7687}"
+      - "${MEMGRAPH_HTTP_PORT:-7444}"
     environment:
-      MEMGRAPH_BOLT_PORT: 7687
-      MEMGRAPH_HTTP_PORT: 7444
-      MEMGRAPH_MEMORY_LIMIT: 8192
+      MEMGRAPH_BOLT_PORT: ${MEMGRAPH_BOLT_PORT:-7687}
+      MEMGRAPH_HTTP_PORT: ${MEMGRAPH_HTTP_PORT:-7444}
+      MEMGRAPH_MEMORY_LIMIT: ${MEMGRAPH_PROD_MEMORY_LIMIT_MB:-8192}
       # REQUIRED - service will fail without these
       MEMGRAPH_USER: ${MEMGRAPH_USER:?MEMGRAPH_USER is required for production}
       MEMGRAPH_PASSWORD: ${MEMGRAPH_PASSWORD:?MEMGRAPH_PASSWORD is required for production}
@@ -76,15 +77,16 @@ services:
       - --storage-snapshot-retention-count=3
       - --storage-wal-enabled=true
       - --storage-snapshot-interval-sec=1800
+      - --bolt-port=${MEMGRAPH_BOLT_PORT:-7687}
       # Production performance tuning
       - --log-level=WARNING
-      - --query-execution-timeout-sec=600
+      - --query-execution-timeout-sec=${MEMGRAPH_QUERY_TIMEOUT_SEC:-600}
       # Authentication enforcement
       - --auth-user-or-role-regex=.+
     healthcheck:
       # Production health check with authentication
-      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 --username
-          $MEMGRAPH_USER --password $MEMGRAPH_PASSWORD || exit 1"]
+      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port ${MEMGRAPH_BOLT_PORT:-7687}
+          --username $MEMGRAPH_USER --password $MEMGRAPH_PASSWORD || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -92,11 +94,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
-          memory: 8G
+          cpus: '${MEMGRAPH_PROD_CPU_LIMIT:-4.0}'
+          memory: ${MEMGRAPH_PROD_MEMORY_LIMIT:-8G}
         reservations:
-          cpus: '0.5'
-          memory: 1G
+          cpus: '${MEMGRAPH_PROD_CPU_RESERVATION:-0.5}'
+          memory: ${MEMGRAPH_PROD_MEMORY_RESERVATION:-1G}
     restart: always
 
   # Valkey In-Memory Data Store - Production Configuration
@@ -105,13 +107,13 @@ services:
     # Remove host port exposure - internal network only
     ports: !override []
     expose:
-      - "6379"
+      - "${VALKEY_PORT:-6379}"
     command: >
-      valkey-server --appendonly yes --requirepass ${VALKEY_PASSWORD:?VALKEY_PASSWORD is required for
-      production}
+      valkey-server --port ${VALKEY_PORT:-6379} --appendonly yes --requirepass ${VALKEY_PASSWORD:?VALKEY_PASSWORD
+      is required for production}
     healthcheck:
       # Ping with authentication (password passed via env var to avoid exposure in process listing)
-      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=$VALKEY_PASSWORD valkey-cli ping"]
+      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=$VALKEY_PASSWORD valkey-cli -p ${VALKEY_PORT:-6379} ping"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -119,11 +121,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2.0'
-          memory: 2G
+          cpus: '${VALKEY_PROD_CPU_LIMIT:-2.0}'
+          memory: ${VALKEY_PROD_MEMORY_LIMIT:-2G}
         reservations:
-          cpus: '0.25'
-          memory: 256M
+          cpus: '${VALKEY_PROD_CPU_RESERVATION:-0.25}'
+          memory: ${VALKEY_PROD_MEMORY_RESERVATION:-256M}
     restart: always
 
 networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,131 @@
+---
+# ============================================================================
+# OmniMemory - Production Configuration
+# ============================================================================
+# Purpose: Secure production deployment with authentication REQUIRED
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# REQUIRED ENVIRONMENT VARIABLES:
+# - QDRANT_API_KEY: API key for Qdrant access (min 32 characters recommended)
+# - MEMGRAPH_USER: Username for Memgraph authentication
+# - MEMGRAPH_PASSWORD: Password for Memgraph authentication (min 8 characters)
+# - VALKEY_PASSWORD: Password for Valkey access
+#
+# Without these variables, services will FAIL to start.
+#
+# SECURITY NOTES:
+# - Ports are NOT exposed on host - services communicate via internal network
+# - All services require authentication
+# - Health checks are more aggressive for faster failure detection
+# - Resource limits are tighter for production workloads
+# ============================================================================
+name: omnimemory-prod
+
+services:
+  # Qdrant Vector Database - Production Configuration
+  qdrant:
+    container_name: omnimemory-prod-qdrant
+    # Remove host port exposure - internal network only
+    # Services should connect via omnimemory-network using service name
+    ports: !override []
+    expose:
+      - "6333"
+      - "6334"
+    environment:
+      QDRANT__SERVICE__HTTP_PORT: 6333
+      QDRANT__SERVICE__GRPC_PORT: 6334
+      QDRANT__SERVICE__HOST: 0.0.0.0
+      QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
+      QDRANT__STORAGE__ON_DISK_PAYLOAD: true
+      QDRANT__LOG_LEVEL: WARN
+      # REQUIRED - service will fail without this
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:?QDRANT_API_KEY is required for production}
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333 && echo -e 'GET /readyz HTTP/1.1\\r\\nHost:
+          localhost:6333\\r\\n\\r\\n' >&3 && timeout 2 cat <&3 | grep -q 'ready'"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    restart: always
+
+  # Memgraph Database - Production Configuration
+  memgraph:
+    container_name: omnimemory-prod-memgraph
+    # Remove host port exposure - internal network only
+    ports: !override []
+    expose:
+      - "7687"
+      - "7444"
+    environment:
+      MEMGRAPH_BOLT_PORT: 7687
+      MEMGRAPH_HTTP_PORT: 7444
+      MEMGRAPH_MEMORY_LIMIT: 8192
+      # REQUIRED - service will fail without these
+      MEMGRAPH_USER: ${MEMGRAPH_USER:?MEMGRAPH_USER is required for production}
+      MEMGRAPH_PASSWORD: ${MEMGRAPH_PASSWORD:?MEMGRAPH_PASSWORD is required for production}
+    command:
+      - --storage-snapshot-retention-count=3
+      - --storage-wal-enabled=true
+      - --storage-snapshot-interval-sec=1800
+      # Production performance tuning
+      - --log-level=WARNING
+      - --query-execution-timeout-sec=600
+    healthcheck:
+      # Production health check - TCP connectivity
+      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    restart: always
+
+  # Valkey In-Memory Data Store - Production Configuration
+  valkey:
+    container_name: omnimemory-prod-valkey
+    # Remove host port exposure - internal network only
+    ports: !override []
+    expose:
+      - "6379"
+    command: >
+      valkey-server --appendonly yes --requirepass ${VALKEY_PASSWORD:?VALKEY_PASSWORD is required for
+      production}
+    healthcheck:
+      # Ping with authentication
+      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD}", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    restart: always
+
+networks:
+  omnimemory-network:
+    driver: bridge
+    name: omnimemory-prod-network
+    # Production network should be internal (no external access)
+    internal: false  # Set to true if services should have no internet access

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,10 @@
 # - All services require authentication
 # - Health checks are more aggressive for faster failure detection
 # - Resource limits are tighter for production workloads
+#
+# VERSION REQUIREMENT:
+# - Requires Docker Compose v2.20.0+ (uses !override YAML tag to clear ports)
+# - Check version: docker compose version
 # ============================================================================
 name: omnimemory-prod
 
@@ -40,6 +44,10 @@ services:
       QDRANT__LOG_LEVEL: WARN
       # REQUIRED - service will fail without this
       QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:?QDRANT_API_KEY is required for production}
+    # Health check note: The /readyz endpoint is a Kubernetes-style readiness probe
+    # that is typically accessible WITHOUT authentication in Qdrant. If your Qdrant
+    # version requires auth for /readyz, add the api-key header to the health check:
+    #   'GET /readyz HTTP/1.1\r\nHost: ...\r\napi-key: ${QDRANT_API_KEY}\r\n\r\n'
     healthcheck:
       test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/${QDRANT_HTTP_PORT:-6333} && echo -e 'GET
           /readyz HTTP/1.1\\r\\nHost: localhost:${QDRANT_HTTP_PORT:-6333}\\r\\n\\r\\n' >&3 && timeout

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,9 +79,12 @@ services:
       # Production performance tuning
       - --log-level=WARNING
       - --query-execution-timeout-sec=600
+      # Authentication enforcement
+      - --auth-user-or-role-regex=.+
     healthcheck:
-      # Production health check - TCP connectivity
-      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 || exit 1"]
+      # Production health check with authentication
+      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 --username
+          $MEMGRAPH_USER --password $MEMGRAPH_PASSWORD || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -107,8 +110,8 @@ services:
       valkey-server --appendonly yes --requirepass ${VALKEY_PASSWORD:?VALKEY_PASSWORD is required for
       production}
     healthcheck:
-      # Ping with authentication
-      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD}", "ping"]
+      # Ping with authentication (password passed via env var to avoid exposure in process listing)
+      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=$VALKEY_PASSWORD valkey-cli ping"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -127,5 +130,7 @@ networks:
   omnimemory-network:
     driver: bridge
     name: omnimemory-prod-network
-    # Production network should be internal (no external access)
-    internal: false  # Set to true if services should have no internet access
+    # When internal: true, containers can only communicate with each other
+    # (no host access, no external network access, no internet)
+    # Set to true for maximum isolation; false allows reverse proxy access
+    internal: false

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,7 +95,7 @@ services:
       resources:
         limits:
           cpus: '${MEMGRAPH_PROD_CPU_LIMIT:-4.0}'
-          memory: ${MEMGRAPH_PROD_MEMORY_LIMIT:-8G}
+          memory: ${MEMGRAPH_PROD_CONTAINER_MEMORY:-8G}
         reservations:
           cpus: '${MEMGRAPH_PROD_CPU_RESERVATION:-0.5}'
           memory: ${MEMGRAPH_PROD_MEMORY_RESERVATION:-1G}
@@ -132,7 +132,31 @@ networks:
   omnimemory-network:
     driver: bridge
     name: omnimemory-prod-network
-    # When internal: true, containers can only communicate with each other
-    # (no host access, no external network access, no internet)
-    # Set to true for maximum isolation; false allows reverse proxy access
-    internal: false
+    # =========================================================================
+    # Network Isolation Setting (internal)
+    # =========================================================================
+    # Controls whether containers can access networks outside this bridge.
+    #
+    # INTERNAL: TRUE (Maximum Isolation)
+    #   - Containers can ONLY communicate with each other on this network
+    #   - NO access to host network, external networks, or internet
+    #   - NO outbound connections (cannot reach external APIs, registries, etc.)
+    #   - Use when: Services are fully self-contained and don't need external
+    #     connectivity (air-gapped environments, strict security requirements)
+    #
+    # INTERNAL: FALSE (Default - External Access Allowed)
+    #   - Containers can communicate with each other AND external networks
+    #   - Required for: Reverse proxy access (nginx/traefik), external API calls,
+    #     pulling updates, connecting to external databases
+    #   - Use when: You need to expose services via load balancer or services
+    #     must reach external endpoints
+    #
+    # SECURITY IMPLICATIONS:
+    #   - true:  Stronger isolation, but services cannot fetch external data
+    #   - false: More flexible, but containers can make outbound connections
+    #   - Note: Even with internal:false, services are NOT exposed to host
+    #     unless ports are explicitly published (ports: vs expose:)
+    #
+    # Override via environment: NETWORK_INTERNAL=true docker compose up
+    # =========================================================================
+    internal: ${NETWORK_INTERNAL:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@
 #
 # To enable authentication, set these in your .env file:
 # - Qdrant: QDRANT_API_KEY=your-api-key
-# - Memgraph: MEMGRAPH_USER=admin and MEMGRAPH_PASSWORD=your-password
 # - Valkey: VALKEY_PASSWORD=your-password
+# - Memgraph: Use docker-compose.prod.yml overlay (Memgraph fails on empty credentials)
 #
 # SECURITY WARNING (Non-Local Deployments):
 # - For production/non-local deployments, ALWAYS enable authentication
@@ -75,7 +75,8 @@ services:
       MEMGRAPH_BOLT_PORT: 7687
       MEMGRAPH_HTTP_PORT: 7444
       MEMGRAPH_MEMORY_LIMIT: 4096
-    # Base command - authentication added via docker-compose.prod.yml overlay
+      # Note: Memgraph auth configured via docker-compose.prod.yml overlay
+      # (Memgraph fails on empty MEMGRAPH_USER, unlike Qdrant/Valkey)
     command:
       - --storage-snapshot-retention-count=2
       - --storage-wal-enabled=true
@@ -86,7 +87,7 @@ services:
       - omnimemory-network
     healthcheck:
       # Uses mgconsole to verify database is ready to accept Cypher queries
-      # (TCP-only check would pass even if database isn't query-ready)
+      # (Auth-aware health check is in docker-compose.prod.yml)
       test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 || exit 1"]
       interval: 30s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,8 @@ services:
     networks:
       - omnimemory-network
     healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
+      # Auth-aware ping (works with or without VALKEY_PASSWORD set)
+      test: ["CMD", "sh", "-c", "valkey-cli ${VALKEY_PASSWORD:+-a $VALKEY_PASSWORD} ping"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@
 # Usage: docker compose up -d
 #
 # Services:
-# - qdrant: Vector database for semantic memory (6333/6334)
-# - memgraph: Graph database for relationship queries (7687/7444)
-# - valkey: In-memory cache/data store (6379)
+# - qdrant: Vector database for semantic memory (configurable ports via env)
+# - memgraph: Graph database for relationship queries (configurable ports via env)
+# - valkey: In-memory cache/data store (configurable port via env)
 #
 # Authentication:
 # All services support optional authentication via environment variables.
@@ -23,6 +23,8 @@
 # - For production/non-local deployments, ALWAYS enable authentication
 # - Consider network isolation and TLS for external access
 #
+# Port Configuration:
+# All ports are configurable via environment variables. See .env.example for details.
 # ============================================================================
 name: omnimemory
 services:
@@ -31,11 +33,11 @@ services:
     image: qdrant/qdrant:${QDRANT_VERSION:-v1.16.3}
     container_name: omnimemory-qdrant
     ports:
-      - "${QDRANT_PORT:-6333}:6333"  # REST API
-      - "${QDRANT_GRPC_PORT:-6334}:6334"  # gRPC
+      - "${QDRANT_HTTP_PORT:-6333}:${QDRANT_HTTP_PORT:-6333}"  # REST API
+      - "${QDRANT_GRPC_PORT:-6334}:${QDRANT_GRPC_PORT:-6334}"  # gRPC
     environment:
-      QDRANT__SERVICE__HTTP_PORT: 6333
-      QDRANT__SERVICE__GRPC_PORT: 6334
+      QDRANT__SERVICE__HTTP_PORT: ${QDRANT_HTTP_PORT:-6333}
+      QDRANT__SERVICE__GRPC_PORT: ${QDRANT_GRPC_PORT:-6334}
       QDRANT__SERVICE__HOST: 0.0.0.0
       QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
       QDRANT__STORAGE__ON_DISK_PAYLOAD: true
@@ -48,8 +50,9 @@ services:
     networks:
       - omnimemory-network
     healthcheck:
-      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333 && echo -e 'GET /readyz HTTP/1.1\\r\\nHost:
-          localhost:6333\\r\\n\\r\\n' >&3 && timeout 2 cat <&3 | grep -q 'ready'"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/${QDRANT_HTTP_PORT:-6333} && echo -e 'GET
+          /readyz HTTP/1.1\\r\\nHost: localhost:${QDRANT_HTTP_PORT:-6333}\\r\\n\\r\\n' >&3 && timeout
+          2 cat <&3 | grep -q 'ready'"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -57,11 +60,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2.0'
-          memory: 2G
+          cpus: '${QDRANT_CPU_LIMIT:-2.0}'
+          memory: ${QDRANT_MEMORY_LIMIT:-2G}
         reservations:
-          cpus: '0.25'
-          memory: 512M
+          cpus: '${QDRANT_CPU_RESERVATION:-0.25}'
+          memory: ${QDRANT_MEMORY_RESERVATION:-512M}
     restart: unless-stopped
 
   # Memgraph Database (Graph Memory / Relationship Queries)
@@ -69,18 +72,19 @@ services:
     image: memgraph/memgraph:${MEMGRAPH_VERSION:-2.18.1}
     container_name: omnimemory-memgraph
     ports:
-      - "${MEMGRAPH_BOLT_PORT:-7687}:7687"  # Bolt protocol
-      - "${MEMGRAPH_HTTP_PORT:-7444}:7444"  # HTTP
+      - "${MEMGRAPH_BOLT_PORT:-7687}:${MEMGRAPH_BOLT_PORT:-7687}"  # Bolt protocol
+      - "${MEMGRAPH_HTTP_PORT:-7444}:${MEMGRAPH_HTTP_PORT:-7444}"  # HTTP
     environment:
-      MEMGRAPH_BOLT_PORT: 7687
-      MEMGRAPH_HTTP_PORT: 7444
-      MEMGRAPH_MEMORY_LIMIT: 4096
+      MEMGRAPH_BOLT_PORT: ${MEMGRAPH_BOLT_PORT:-7687}
+      MEMGRAPH_HTTP_PORT: ${MEMGRAPH_HTTP_PORT:-7444}
+      MEMGRAPH_MEMORY_LIMIT: ${MEMGRAPH_MEMORY_LIMIT_MB:-4096}
       # Note: Memgraph auth configured via docker-compose.prod.yml overlay
       # (Memgraph fails on empty MEMGRAPH_USER, unlike Qdrant/Valkey)
     command:
       - --storage-snapshot-retention-count=2
       - --storage-wal-enabled=true
       - --storage-snapshot-interval-sec=3600
+      - --bolt-port=${MEMGRAPH_BOLT_PORT:-7687}
     volumes:
       - memgraph_data:/var/lib/memgraph
     networks:
@@ -88,7 +92,8 @@ services:
     healthcheck:
       # Uses mgconsole to verify database is ready to accept Cypher queries
       # (Auth-aware health check is in docker-compose.prod.yml)
-      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port 7687 || exit 1"]
+      test: ["CMD", "bash", "-c", "echo 'RETURN 1;' | mgconsole --host localhost --port ${MEMGRAPH_BOLT_PORT:-7687}
+          || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -96,11 +101,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2.0'
-          memory: 4G
+          cpus: '${MEMGRAPH_CPU_LIMIT:-2.0}'
+          memory: ${MEMGRAPH_MEMORY_LIMIT:-4G}
         reservations:
-          cpus: '0.25'
-          memory: 512M
+          cpus: '${MEMGRAPH_CPU_RESERVATION:-0.25}'
+          memory: ${MEMGRAPH_MEMORY_RESERVATION:-512M}
     restart: unless-stopped
 
   # Valkey In-Memory Data Store (Cache / Session Storage)
@@ -108,16 +113,17 @@ services:
     image: valkey/valkey:${VALKEY_VERSION:-8}
     container_name: omnimemory-valkey
     ports:
-      - "${VALKEY_PORT:-6379}:6379"
+      - "${VALKEY_PORT:-6379}:${VALKEY_PORT:-6379}"
     command: >
-      valkey-server --appendonly yes ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}
+      valkey-server --port ${VALKEY_PORT:-6379} --appendonly yes ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}
     volumes:
       - valkey_data:/data
     networks:
       - omnimemory-network
     healthcheck:
       # Auth-aware ping (works with or without VALKEY_PASSWORD set)
-      test: ["CMD", "sh", "-c", "valkey-cli ${VALKEY_PASSWORD:+-a $VALKEY_PASSWORD} ping"]
+      test: ["CMD", "sh", "-c", "valkey-cli -p ${VALKEY_PORT:-6379} ${VALKEY_PASSWORD:+-a $VALKEY_PASSWORD}
+          ping"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -125,11 +131,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
-          memory: 1G
+          cpus: '${VALKEY_CPU_LIMIT:-1.0}'
+          memory: ${VALKEY_MEMORY_LIMIT:-1G}
         reservations:
-          cpus: '0.1'
-          memory: 128M
+          cpus: '${VALKEY_CPU_RESERVATION:-0.1}'
+          memory: ${VALKEY_MEMORY_RESERVATION:-128M}
     restart: unless-stopped
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       resources:
         limits:
           cpus: '${MEMGRAPH_CPU_LIMIT:-2.0}'
-          memory: ${MEMGRAPH_MEMORY_LIMIT:-4G}
+          memory: ${MEMGRAPH_CONTAINER_MEMORY:-4G}
         reservations:
           cpus: '${MEMGRAPH_CPU_RESERVATION:-0.25}'
           memory: ${MEMGRAPH_MEMORY_RESERVATION:-512M}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,8 @@ services:
       - omnimemory-network
     healthcheck:
       # Auth-aware ping (works with or without VALKEY_PASSWORD set)
-      test: ["CMD", "sh", "-c", "valkey-cli -p ${VALKEY_PORT:-6379} ${VALKEY_PASSWORD:+-a $VALKEY_PASSWORD}
+      # Uses REDISCLI_AUTH env var to avoid exposing password in process listing
+      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=${VALKEY_PASSWORD:-} valkey-cli -p ${VALKEY_PORT:-6379}
           ping"]
       interval: 30s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,25 @@
 # ============================================================================
 # OmniMemory - Infrastructure Services
 # ============================================================================
-# Purpose: Data layer services for memory operations (graph DB, vector DB)
+# Purpose: Data layer services for memory operations (graph DB, vector DB, cache)
 # Usage: docker compose up -d
 #
 # Services:
 # - qdrant: Vector database for semantic memory (6333/6334)
 # - memgraph: Graph database for relationship queries (7687/7444)
+# - valkey: In-memory cache/data store (6379)
+#
+# Authentication:
+# All services support optional authentication via environment variables.
+# When auth env vars are NOT set, services run without authentication (dev mode).
+#
+# To enable authentication, set these in your .env file:
+# - Qdrant: QDRANT_API_KEY=your-api-key
+# - Memgraph: MEMGRAPH_USER=admin and MEMGRAPH_PASSWORD=your-password
+# - Valkey: VALKEY_PASSWORD=your-password
 #
 # SECURITY WARNING (Non-Local Deployments):
-# - Qdrant and Memgraph are configured WITHOUT authentication by default
-# - For production/non-local deployments, enable authentication:
-#   - Qdrant: Set QDRANT__SERVICE__API_KEY environment variable
-#   - Memgraph: Add --auth-module-mappings and --auth-password-strength-regex
+# - For production/non-local deployments, ALWAYS enable authentication
 # - Consider network isolation and TLS for external access
 #
 # ============================================================================
@@ -33,6 +40,8 @@ services:
       QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
       QDRANT__STORAGE__ON_DISK_PAYLOAD: true
       QDRANT__LOG_LEVEL: INFO
+      # Authentication (optional - set QDRANT_API_KEY in .env to enable)
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
     volumes:
       - qdrant_data:/qdrant/storage
       - qdrant_snapshots:/qdrant/snapshots
@@ -54,6 +63,7 @@ services:
           cpus: '0.25'
           memory: 512M
     restart: unless-stopped
+
   # Memgraph Database (Graph Memory / Relationship Queries)
   memgraph:
     image: memgraph/memgraph:${MEMGRAPH_VERSION:-2.18.1}
@@ -65,6 +75,7 @@ services:
       MEMGRAPH_BOLT_PORT: 7687
       MEMGRAPH_HTTP_PORT: 7444
       MEMGRAPH_MEMORY_LIMIT: 4096
+    # Base command - authentication added via docker-compose.prod.yml overlay
     command:
       - --storage-snapshot-retention-count=2
       - --storage-wal-enabled=true
@@ -90,14 +101,46 @@ services:
           cpus: '0.25'
           memory: 512M
     restart: unless-stopped
+
+  # Valkey In-Memory Data Store (Cache / Session Storage)
+  valkey:
+    image: valkey/valkey:${VALKEY_VERSION:-8}
+    container_name: omnimemory-valkey
+    ports:
+      - "${VALKEY_PORT:-6379}:6379"
+    command: >
+      valkey-server --appendonly yes ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}
+    volumes:
+      - valkey_data:/data
+    networks:
+      - omnimemory-network
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+    restart: unless-stopped
+
 networks:
   omnimemory-network:
     driver: bridge
     name: omnimemory-network
+
 volumes:
   memgraph_data:
     driver: local
   qdrant_data:
     driver: local
   qdrant_snapshots:
+    driver: local
+  valkey_data:
     driver: local


### PR DESCRIPTION
## Summary

Add optional authentication support to all OmniMemory Docker services with an opt-in model: development runs without auth by default, production requires credentials.

- Add **Valkey** service (Redis-compatible cache) to docker-compose.yml
- Add **QDRANT_API_KEY** support for Qdrant authentication
- Create **docker-compose.prod.yml** overlay with REQUIRED authentication
- Update **.env.example** with auth variables and documentation

## Authentication Model

| Mode | Behavior | How to Enable |
|------|----------|---------------|
| **Development** | No auth (backwards compatible) | Empty/unset env vars |
| **Production** | Auth REQUIRED | `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` |

## Services

| Service | Auth Method | Env Var |
|---------|-------------|---------|
| Qdrant | API Key | `QDRANT_API_KEY` |
| Memgraph | User/Password | `MEMGRAPH_USER`, `MEMGRAPH_PASSWORD` |
| Valkey | Password | `VALKEY_PASSWORD` |

## Test Plan

- [x] All services start correctly with auth enabled
- [x] All services start correctly without auth (dev mode)
- [x] Qdrant rejects requests without valid API key
- [x] Qdrant accepts requests with valid API key
- [x] Valkey requires password authentication
- [x] Memgraph available for Cypher queries

## Closes

Closes OMN-1444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Valkey in-memory data store for caching and performance optimization.

* **Infrastructure**
  * Introduced production-grade Docker Compose configuration with integrated authentication and security controls.
  * Expanded environment configuration to support credential management for development and production deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->