### PR TITLE
feat(lifecycle): Add memory_lifecycle_orchestrator node with database integration [OMN-1453]

### DIFF
--- a/deployment/database/migrations/002_create_memories_table.sql
+++ b/deployment/database/migrations/002_create_memories_table.sql
@@ -20,6 +20,10 @@ CREATE TABLE IF NOT EXISTS memories (
     expires_at TIMESTAMPTZ,
     archived_at TIMESTAMPTZ,
     lifecycle_revision INTEGER NOT NULL DEFAULT 1,
+    archive_path TEXT,
+
+    -- Optional metadata
+    metadata JSONB,
 
     -- Timestamps
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -106,6 +110,12 @@ COMMENT ON COLUMN memories.archived_at IS
 
 COMMENT ON COLUMN memories.lifecycle_revision IS
     'Optimistic locking revision. Incremented on each lifecycle state change.';
+
+COMMENT ON COLUMN memories.archive_path IS
+    'Path to the archive file after memory is archived. NULL if not archived.';
+
+COMMENT ON COLUMN memories.metadata IS
+    'Optional JSONB metadata for storing additional memory attributes.';
 
 COMMENT ON COLUMN memories.created_at IS
     'Timestamp when the memory was created';

--- a/deployment/database/migrations/002_create_memories_table.sql
+++ b/deployment/database/migrations/002_create_memories_table.sql
@@ -72,6 +72,11 @@ CREATE INDEX IF NOT EXISTS idx_memories_active_content_type
     ON memories(content_type)
     WHERE lifecycle_state = 'active';
 
+-- Optimizes: SELECT * FROM memories WHERE updated_at < NOW() - INTERVAL '30 days'
+-- Index for cleanup and maintenance queries based on last update time
+CREATE INDEX IF NOT EXISTS idx_memories_updated_at
+    ON memories(updated_at);
+
 -- ============================================================================
 -- Trigger for updated_at Auto-Update
 -- ============================================================================

--- a/deployment/database/migrations/002_create_memories_table.sql
+++ b/deployment/database/migrations/002_create_memories_table.sql
@@ -17,7 +17,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 -- Memories Table
 -- ============================================================================
 -- Stores memory content with lifecycle state management.
--- Lifecycle states: active -> expired -> archived -> deleted
+-- Lifecycle states: active -> stale -> expired -> archived -> deleted
 -- Supports optimistic locking via lifecycle_revision column.
 
 CREATE TABLE IF NOT EXISTS memories (
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS memories (
 
     -- Constraints
     CONSTRAINT chk_memories_lifecycle_state CHECK (
-        lifecycle_state IN ('active', 'expired', 'archived', 'deleted')
+        lifecycle_state IN ('active', 'stale', 'expired', 'archived', 'deleted')
     )
 );
 
@@ -63,6 +63,23 @@ CREATE INDEX IF NOT EXISTS idx_memories_archive_candidates
 
 -- Optimizes: UPDATE memories SET ... WHERE id = $1 AND lifecycle_revision = $2
 -- Index for optimistic locking queries (concurrent update protection)
+--
+-- Purpose: This composite index enables efficient optimistic locking patterns where
+-- updates include both the primary key (id) and the expected revision number.
+-- When multiple concurrent processes attempt to update the same memory, only one
+-- succeeds (the one with the matching revision). Others get rows_affected=0,
+-- indicating a conflict that requires retry or conflict resolution.
+--
+-- Why needed despite id being PRIMARY KEY:
+--   The primary key index only covers (id). For queries like:
+--     UPDATE memories SET ... WHERE id = $1 AND lifecycle_revision = $2
+--   PostgreSQL must check lifecycle_revision after finding the row by id.
+--   This index allows the query planner to verify both conditions in a single
+--   index lookup, improving performance for high-contention workloads.
+--
+-- Trade-off: This index adds storage overhead and write amplification.
+-- Keep if: High-concurrency lifecycle state transitions are expected.
+-- Remove if: Single-writer patterns or low update frequency.
 CREATE INDEX IF NOT EXISTS idx_memories_id_revision
     ON memories(id, lifecycle_revision);
 
@@ -103,7 +120,7 @@ CREATE TRIGGER omnimemory_trigger_memories_updated_at
 -- ============================================================================
 
 COMMENT ON TABLE memories IS
-    'Memory storage with lifecycle management. States: active, expired, archived, deleted.';
+    'Memory storage with lifecycle management. States: active, stale, expired, archived, deleted.';
 
 COMMENT ON COLUMN memories.id IS
     'Unique identifier for the memory (UUID v4)';
@@ -115,7 +132,7 @@ COMMENT ON COLUMN memories.content_type IS
     'MIME type of the content (e.g., text/plain, application/json)';
 
 COMMENT ON COLUMN memories.lifecycle_state IS
-    'Current lifecycle state: active (in use), expired (past TTL), archived (cold storage), deleted (soft delete)';
+    'Current lifecycle state: active (in use), stale (outdated), expired (past TTL), archived (cold storage), deleted (soft delete)';
 
 COMMENT ON COLUMN memories.expires_at IS
     'Optional expiration timestamp. NULL means no expiration.';

--- a/deployment/database/migrations/002_create_memories_table.sql
+++ b/deployment/database/migrations/002_create_memories_table.sql
@@ -1,0 +1,114 @@
+-- Migration: 002_create_memories_table
+-- Description: Create memories table with lifecycle management columns
+-- Created: 2026-01-25
+-- Ticket: OMN-1453
+
+-- ============================================================================
+-- Memories Table
+-- ============================================================================
+-- Stores memory content with lifecycle state management.
+-- Lifecycle states: active -> expired -> archived -> deleted
+-- Supports optimistic locking via lifecycle_revision column.
+
+CREATE TABLE IF NOT EXISTS memories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    content TEXT NOT NULL,
+    content_type VARCHAR(50) NOT NULL DEFAULT 'text/plain',
+
+    -- Lifecycle management (OMN-1453)
+    lifecycle_state VARCHAR(20) NOT NULL DEFAULT 'active',
+    expires_at TIMESTAMPTZ,
+    archived_at TIMESTAMPTZ,
+    lifecycle_revision INTEGER NOT NULL DEFAULT 1,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT chk_memories_lifecycle_state CHECK (
+        lifecycle_state IN ('active', 'expired', 'archived', 'deleted')
+    )
+);
+
+-- ============================================================================
+-- Indexes for Lifecycle Queries
+-- ============================================================================
+
+-- Optimizes: SELECT * FROM memories WHERE lifecycle_state = 'active' AND expires_at < NOW()
+-- Partial index for finding active memories that need expiration processing
+CREATE INDEX IF NOT EXISTS idx_memories_lifecycle_expires
+    ON memories(lifecycle_state, expires_at)
+    WHERE lifecycle_state = 'active' AND expires_at IS NOT NULL;
+
+-- Optimizes: SELECT * FROM memories WHERE lifecycle_state = 'expired' AND archived_at IS NULL
+-- Partial index for finding expired memories pending archival
+CREATE INDEX IF NOT EXISTS idx_memories_archive_candidates
+    ON memories(lifecycle_state, archived_at)
+    WHERE lifecycle_state = 'expired' AND archived_at IS NULL;
+
+-- Optimizes: UPDATE memories SET ... WHERE id = $1 AND lifecycle_revision = $2
+-- Index for optimistic locking queries (concurrent update protection)
+CREATE INDEX IF NOT EXISTS idx_memories_id_revision
+    ON memories(id, lifecycle_revision);
+
+-- ============================================================================
+-- Additional Indexes for Common Access Patterns
+-- ============================================================================
+
+-- Optimizes: SELECT * FROM memories WHERE lifecycle_state = 'active' ORDER BY created_at DESC
+-- Index for listing active memories (most common query pattern)
+CREATE INDEX IF NOT EXISTS idx_memories_active_created
+    ON memories(created_at DESC)
+    WHERE lifecycle_state = 'active';
+
+-- Optimizes: SELECT * FROM memories WHERE content_type = $1 AND lifecycle_state = 'active'
+-- Index for content type filtering on active memories
+CREATE INDEX IF NOT EXISTS idx_memories_active_content_type
+    ON memories(content_type)
+    WHERE lifecycle_state = 'active';
+
+-- ============================================================================
+-- Trigger for updated_at Auto-Update
+-- ============================================================================
+-- Note: omnimemory_update_updated_at_column() function created in 001_create_subscription_tables.sql
+
+DROP TRIGGER IF EXISTS omnimemory_trigger_memories_updated_at ON memories;
+CREATE TRIGGER omnimemory_trigger_memories_updated_at
+    BEFORE UPDATE ON memories
+    FOR EACH ROW
+    EXECUTE FUNCTION omnimemory_update_updated_at_column();
+
+-- ============================================================================
+-- Comments
+-- ============================================================================
+
+COMMENT ON TABLE memories IS
+    'Memory storage with lifecycle management. States: active, expired, archived, deleted.';
+
+COMMENT ON COLUMN memories.id IS
+    'Unique identifier for the memory (UUID v4)';
+
+COMMENT ON COLUMN memories.content IS
+    'The actual memory content (text, JSON, etc.)';
+
+COMMENT ON COLUMN memories.content_type IS
+    'MIME type of the content (e.g., text/plain, application/json)';
+
+COMMENT ON COLUMN memories.lifecycle_state IS
+    'Current lifecycle state: active (in use), expired (past TTL), archived (cold storage), deleted (soft delete)';
+
+COMMENT ON COLUMN memories.expires_at IS
+    'Optional expiration timestamp. NULL means no expiration.';
+
+COMMENT ON COLUMN memories.archived_at IS
+    'Timestamp when memory was archived. NULL if not archived.';
+
+COMMENT ON COLUMN memories.lifecycle_revision IS
+    'Optimistic locking revision. Incremented on each lifecycle state change.';
+
+COMMENT ON COLUMN memories.created_at IS
+    'Timestamp when the memory was created';
+
+COMMENT ON COLUMN memories.updated_at IS
+    'Timestamp of last update (auto-updated via trigger)';

--- a/deployment/database/migrations/002_create_memories_table.sql
+++ b/deployment/database/migrations/002_create_memories_table.sql
@@ -4,6 +4,16 @@
 -- Ticket: OMN-1453
 
 -- ============================================================================
+-- Extension: pgcrypto
+-- ============================================================================
+-- Required for gen_random_uuid() function on PostgreSQL versions < 13.
+-- PostgreSQL 13+ includes gen_random_uuid() natively, but this extension
+-- ensures compatibility with PostgreSQL 12 and earlier versions.
+-- Using IF NOT EXISTS to avoid errors if already enabled.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ============================================================================
 -- Memories Table
 -- ============================================================================
 -- Stores memory content with lifecycle state management.

--- a/src/omnimemory/enums/__init__.py
+++ b/src/omnimemory/enums/__init__.py
@@ -6,6 +6,7 @@ All enums are centralized here for better maintainability and ONEX compliance.
 
 from .enum_error_code import EnumOmniMemoryErrorCode
 from .enum_intelligence_operation_type import EnumIntelligenceOperationType
+from .enum_lifecycle_state import EnumLifecycleState
 from .enum_memory_operation_type import EnumMemoryOperationType
 from .enum_memory_storage_type import EnumMemoryStorageType
 from .enum_migration_status import (
@@ -21,6 +22,7 @@ __all__ = [
     "EnumDecayFunction",
     "EnumFileProcessingStatus",
     "EnumIntelligenceOperationType",
+    "EnumLifecycleState",
     "EnumMemoryOperationType",
     "EnumMemoryStorageType",
     "EnumMigrationPriority",

--- a/src/omnimemory/enums/enum_lifecycle_state.py
+++ b/src/omnimemory/enums/enum_lifecycle_state.py
@@ -11,12 +11,22 @@ class EnumLifecycleState(str, Enum):
 
     Represents the current lifecycle state of a memory entity:
     - ACTIVE: Memory is live and accessible for reads/writes
+    - STALE: Memory is outdated but still accessible (soft TTL exceeded)
     - EXPIRED: Memory TTL has passed, pending archive transition
     - ARCHIVED: Memory moved to cold storage, read-only access
     - DELETED: Memory permanently removed (soft delete marker for audit trail)
+
+    Lifecycle transitions:
+        ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED
+
+    STALE is an intermediate state between ACTIVE and EXPIRED that indicates
+    the memory's soft TTL has been exceeded but it remains accessible. This
+    allows for graceful degradation where consumers can be notified of staleness
+    before hard expiration occurs.
     """
 
     ACTIVE = "active"
+    STALE = "stale"
     EXPIRED = "expired"
     ARCHIVED = "archived"
     DELETED = "deleted"

--- a/src/omnimemory/enums/enum_lifecycle_state.py
+++ b/src/omnimemory/enums/enum_lifecycle_state.py
@@ -1,0 +1,22 @@
+"""
+Lifecycle state enumeration following ONEX standards.
+"""
+
+from enum import Enum
+
+
+class EnumLifecycleState(str, Enum):
+    """
+    Memory lifecycle states for the lifecycle orchestrator.
+
+    Represents the current lifecycle state of a memory entity:
+    - ACTIVE: Memory is live and accessible for reads/writes
+    - EXPIRED: Memory TTL has passed, pending archive transition
+    - ARCHIVED: Memory moved to cold storage, read-only access
+    - DELETED: Memory permanently removed (soft delete marker for audit trail)
+    """
+
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    ARCHIVED = "archived"
+    DELETED = "deleted"

--- a/src/omnimemory/models/memory/model_memory_item.py
+++ b/src/omnimemory/models/memory/model_memory_item.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ...enums import EnumLifecycleState
 from ...enums.enum_memory_storage_type import EnumMemoryStorageType  # noqa: TC001
 
 
@@ -78,6 +79,21 @@ class ModelMemoryItem(BaseModel):
     expires_at: datetime | None = Field(
         default=None,
         description="When the memory item expires (optional)",
+    )
+
+    # Lifecycle management
+    lifecycle_state: EnumLifecycleState = Field(
+        default=EnumLifecycleState.ACTIVE,
+        description="Current lifecycle state of the memory",
+    )
+    archived_at: datetime | None = Field(
+        default=None,
+        description="Timestamp when memory was archived to cold storage",
+    )
+    lifecycle_revision: int = Field(
+        default=1,
+        ge=1,
+        description="Revision number for optimistic locking (incremented on each state change)",
     )
 
     # Usage tracking

--- a/src/omnimemory/nodes/intent_storage_effect/__init__.py
+++ b/src/omnimemory/nodes/intent_storage_effect/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent Storage Effect - ONEX Node (Demo Critical Path).
+
+Stores intent classifications in Memgraph, linking them to sessions
+for analytics and pattern learning.
+
+This is a fully declarative ONEX node:
+- Node behavior defined in contract.yaml
+- Business logic implemented in adapters/
+- No node.py class needed
+
+Node Type: EFFECT
+"""
+
+from .adapters import HandlerIntentStorageAdapter
+from .models import ModelIntentStorageRequest, ModelIntentStorageResponse
+
+__all__ = [
+    # Models
+    "ModelIntentStorageRequest",
+    "ModelIntentStorageResponse",
+    # Handlers
+    "HandlerIntentStorageAdapter",
+]

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/__init__.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent storage effect adapters."""
+
+from .adapter_intent_storage import HandlerIntentStorageAdapter
+
+__all__ = [
+    "HandlerIntentStorageAdapter",
+]

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -47,12 +47,19 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+import structlog
+
 from omnimemory.handlers.adapters.models import ModelAdapterIntentGraphConfig
+from omnimemory.models.utils.model_circuit_breaker_config import (
+    ModelCircuitBreakerConfig,
+)
 from omnimemory.nodes.intent_storage_effect.models import (
     ModelIntentRecordResponse,
     ModelIntentStorageRequest,
     ModelIntentStorageResponse,
 )
+from omnimemory.utils.concurrency import CircuitBreaker, CircuitBreakerOpenError
+from omnimemory.utils.pii_detector import PIIDetector
 
 if TYPE_CHECKING:
     from omnimemory.handlers.adapters import AdapterIntentGraph
@@ -80,35 +87,62 @@ except ImportError as e:
 
 
 logger = logging.getLogger(__name__)
+structured_logger = structlog.get_logger(__name__)
 
 __all__ = ["HandlerIntentStorageAdapter"]
+
+# Default circuit breaker configuration for external adapter calls
+_DEFAULT_CIRCUIT_BREAKER_CONFIG = ModelCircuitBreakerConfig(
+    failure_threshold=5,
+    recovery_timeout=60,
+    success_threshold=3,
+    timeout=30.0,
+)
 
 
 class HandlerIntentStorageAdapter:
     """Handler adapter for intent storage operations.
 
     Wraps AdapterIntentGraph to provide the execute() interface expected
-    by the ONEX node framework.
+    by the ONEX node framework. Includes circuit breaker protection to
+    prevent cascading failures when the underlying adapter is unavailable.
 
     Attributes:
         _adapter: The underlying AdapterIntentGraph instance.
         _initialized: Whether the adapter has been initialized.
         _config: Configuration for the intent graph adapter.
+        _circuit_breaker: Circuit breaker for external adapter calls.
+        _pii_detector: PII detector for user input sanitization.
     """
 
     def __init__(
         self,
         config: ModelAdapterIntentGraphConfig | None = None,
+        circuit_breaker_config: ModelCircuitBreakerConfig | None = None,
     ) -> None:
         """Initialize the handler adapter.
 
         Args:
             config: Optional configuration for the intent graph adapter.
                 If not provided, uses default configuration.
+            circuit_breaker_config: Optional circuit breaker configuration.
+                If not provided, uses default configuration with 5 failure
+                threshold, 60s recovery timeout, and 3 success threshold.
         """
         self._config = config or ModelAdapterIntentGraphConfig()
         self._adapter: AdapterIntentGraph | None = None
         self._initialized = False
+
+        # Initialize circuit breaker for external adapter calls
+        cb_config = circuit_breaker_config or _DEFAULT_CIRCUIT_BREAKER_CONFIG
+        self._circuit_breaker = CircuitBreaker(
+            failure_threshold=cb_config.failure_threshold,
+            recovery_timeout=float(cb_config.recovery_timeout),
+            success_threshold=cb_config.success_threshold,
+        )
+
+        # Initialize PII detector for user input sanitization
+        self._pii_detector = PIIDetector()
 
     async def initialize(
         self,
@@ -160,6 +194,9 @@ class HandlerIntentStorageAdapter:
         - get_session: Get intents for a session
         - get_distribution: Get intent category distribution
 
+        Uses circuit breaker protection to prevent cascading failures when
+        the underlying adapter is unavailable.
+
         Args:
             request: The storage request.
 
@@ -167,6 +204,12 @@ class HandlerIntentStorageAdapter:
             Response with operation results. If adapter is not initialized,
             returns a response with status="error" and error_message
             instructing to call initialize() first.
+
+        Note:
+            This method catches and handles the following exceptions:
+            - CircuitBreakerOpenError: When circuit breaker is open
+            - ValueError: Invalid input data or configuration
+            - Exception: Any other unexpected errors
         """
         if not self._initialized or self._adapter is None:
             return ModelIntentStorageResponse(
@@ -175,49 +218,43 @@ class HandlerIntentStorageAdapter:
             )
 
         start_time = time.perf_counter()
+        response: ModelIntentStorageResponse
 
         try:
+            # Route to appropriate handler with circuit breaker protection
             if request.operation == "store":
-                response = await self._store_intent(request)
+                response = await self._circuit_breaker.call(self._store_intent, request)
             elif request.operation == "get_session":
-                response = await self._get_session_intents(request)
+                response = await self._circuit_breaker.call(
+                    self._get_session_intents, request
+                )
             elif request.operation == "get_distribution":
-                response = await self._get_distribution(request)
+                response = await self._circuit_breaker.call(
+                    self._get_distribution, request
+                )
             else:
                 response = ModelIntentStorageResponse(
                     status="error",
                     error_message=f"Unknown operation: {request.operation}",
                 )
-        except AssertionError as e:
-            # AssertionError indicates a programming bug - missing validation or
-            # incorrect adapter state. Log at ERROR level with full traceback.
-            logger.exception(
-                "Assertion failed in intent storage operation '%s'. "
-                "This indicates a programming error - request validation may be incomplete.",
-                request.operation,
+        except CircuitBreakerOpenError as e:
+            # Circuit breaker is open - external service unavailable
+            structured_logger.warning(
+                "circuit_breaker_open",
+                operation=request.operation,
+                failure_count=self._circuit_breaker.failure_count,
+                state=self._circuit_breaker.state.value,
             )
             response = ModelIntentStorageResponse(
                 status="error",
-                error_message=f"Internal error: assertion failed - {e}",
-            )
-        except RuntimeError as e:
-            # RuntimeError typically indicates adapter initialization issues
-            # or infrastructure problems that the underlying adapter couldn't handle
-            logger.error(
-                "Runtime error during intent storage operation '%s': %s",
-                request.operation,
-                e,
-            )
-            response = ModelIntentStorageResponse(
-                status="error",
-                error_message=f"Runtime error: {e}",
+                error_message=f"Service temporarily unavailable: {e}",
             )
         except ValueError as e:
             # ValueError indicates invalid input data or configuration
-            logger.warning(
-                "Validation error during intent storage operation '%s': %s",
-                request.operation,
-                e,
+            structured_logger.warning(
+                "validation_error",
+                operation=request.operation,
+                error=str(e),
             )
             response = ModelIntentStorageResponse(
                 status="error",
@@ -227,11 +264,10 @@ class HandlerIntentStorageAdapter:
             # Safety net for truly unexpected errors - log at ERROR level with
             # full traceback to aid debugging. These should be rare since the
             # underlying adapter handles most exceptions internally.
-            logger.exception(
-                "Unexpected error (%s) during intent storage operation '%s'. "
-                "This may indicate a bug or unhandled edge case.",
-                type(e).__name__,
-                request.operation,
+            structured_logger.exception(
+                "unexpected_error",
+                error_type=type(e).__name__,
+                operation=request.operation,
             )
             response = ModelIntentStorageResponse(
                 status="error",
@@ -247,20 +283,49 @@ class HandlerIntentStorageAdapter:
         self,
         request: ModelIntentStorageRequest,
     ) -> ModelIntentStorageResponse:
-        """Store a classified intent."""
-        assert self._adapter is not None
-        assert request.session_id is not None
-        assert request.intent_data is not None
+        """Store a classified intent.
+
+        Args:
+            request: The storage request with session_id and intent_data.
+
+        Returns:
+            Response with storage result.
+
+        Raises:
+            ValueError: If adapter is not initialized or required fields are missing.
+        """
+        # Explicit validation (asserts can be disabled with python -O)
+        if self._adapter is None:
+            raise ValueError("Adapter not initialized")
+        if request.session_id is None:
+            raise ValueError("session_id is required for store operation")
+        if request.intent_data is None:
+            raise ValueError("intent_data is required for store operation")
+
+        # PII detection/redaction for user_context before persistence
+        sanitized_context = request.user_context
+        if sanitized_context:
+            pii_result = self._pii_detector.detect_pii(
+                sanitized_context, sensitivity_level="medium"
+            )
+            if pii_result.has_pii:
+                # Use sanitized content with PII redacted
+                sanitized_context = pii_result.sanitized_content
+                structured_logger.info(
+                    "pii_redacted_before_storage",
+                    pii_types=[t.value for t in pii_result.pii_types_detected],
+                    session_id=request.session_id,
+                )
 
         # Generate correlation_id if not provided
         correlation_id = request.correlation_id or uuid4()
 
-        # Call the adapter
+        # Call the adapter with sanitized context
         result = await self._adapter.store_intent(
             session_id=request.session_id,
             intent_data=request.intent_data,
             correlation_id=correlation_id,
-            user_context=request.user_context,
+            user_context=sanitized_context,
         )
 
         if result.status == "success":
@@ -282,9 +347,22 @@ class HandlerIntentStorageAdapter:
         self,
         request: ModelIntentStorageRequest,
     ) -> ModelIntentStorageResponse:
-        """Get intents for a specific session."""
-        assert self._adapter is not None
-        assert request.session_id is not None
+        """Get intents for a specific session.
+
+        Args:
+            request: The query request with session_id.
+
+        Returns:
+            Response with list of intents for the session.
+
+        Raises:
+            ValueError: If adapter is not initialized or session_id is missing.
+        """
+        # Explicit validation (asserts can be disabled with python -O)
+        if self._adapter is None:
+            raise ValueError("Adapter not initialized")
+        if request.session_id is None:
+            raise ValueError("session_id is required for get_session operation")
 
         result = await self._adapter.get_session_intents(
             session_id=request.session_id,
@@ -332,8 +410,20 @@ class HandlerIntentStorageAdapter:
         self,
         request: ModelIntentStorageRequest,
     ) -> ModelIntentStorageResponse:
-        """Get intent category distribution."""
-        assert self._adapter is not None
+        """Get intent category distribution.
+
+        Args:
+            request: The query request with time_range_hours.
+
+        Returns:
+            Response with intent category distribution.
+
+        Raises:
+            ValueError: If adapter is not initialized.
+        """
+        # Explicit validation (asserts can be disabled with python -O)
+        if self._adapter is None:
+            raise ValueError("Adapter not initialized")
 
         result = await self._adapter.get_intent_distribution(
             time_range_hours=request.time_range_hours,

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -49,7 +50,7 @@ from omnimemory.handlers.adapters.models import (
     ModelIntentClassificationOutput,
 )
 from omnimemory.nodes.intent_storage_effect.models import (
-    IntentRecordResponse,
+    ModelIntentRecordResponse,
     ModelIntentStorageRequest,
     ModelIntentStorageResponse,
 )
@@ -113,13 +114,16 @@ class HandlerIntentStorageAdapter:
     async def initialize(
         self,
         connection_uri: str = "bolt://localhost:7687",
-        **kwargs: object,
+        auth: tuple[str, str] | None = None,
+        *,
+        options: Mapping[str, object] | None = None,
     ) -> None:
         """Initialize the underlying adapter.
 
         Args:
             connection_uri: Memgraph connection URI.
-            **kwargs: Additional configuration passed to adapter.
+            auth: Optional (username, password) tuple for authentication.
+            options: Additional options passed to the graph handler.
         """
         if self._initialized:
             return
@@ -130,7 +134,11 @@ class HandlerIntentStorageAdapter:
             )
 
         self._adapter = AdapterIntentGraph(self._config)
-        await self._adapter.initialize(connection_uri=connection_uri, **kwargs)
+        await self._adapter.initialize(
+            connection_uri=connection_uri,
+            auth=auth,
+            options=options,
+        )
         self._initialized = True
         logger.info("HandlerIntentStorageAdapter initialized")
 
@@ -249,7 +257,7 @@ class HandlerIntentStorageAdapter:
         if result.status == "success":
             # Convert to response model format
             intents = [
-                IntentRecordResponse(
+                ModelIntentRecordResponse(
                     intent_id=intent.intent_id,
                     intent_category=intent.intent_category,
                     confidence=intent.confidence,

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -164,10 +164,9 @@ class HandlerIntentStorageAdapter:
             request: The storage request.
 
         Returns:
-            Response with operation results.
-
-        Raises:
-            RuntimeError: If adapter not initialized.
+            Response with operation results. If adapter is not initialized,
+            returns a response with status="error" and error_message
+            instructing to call initialize() first.
         """
         if not self._initialized or self._adapter is None:
             return ModelIntentStorageResponse(

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -14,6 +14,8 @@ Example::
         ModelIntentStorageRequest,
     )
 
+    from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
+
     async def example():
         adapter = HandlerIntentStorageAdapter()
         await adapter.initialize(connection_uri="bolt://localhost:7687")
@@ -22,11 +24,11 @@ Example::
         request = ModelIntentStorageRequest(
             operation="store",
             session_id="session_123",
-            intent_data={
-                "intent_category": "debugging",
-                "confidence": 0.92,
-                "keywords": ["error", "fix"],
-            },
+            intent_data=ModelIntentClassificationOutput(
+                intent_category="debugging",
+                confidence=0.92,
+                keywords=["error", "fix"],
+            ),
         )
         response = await adapter.execute(request)
         print(f"Stored intent: {response.intent_id}")
@@ -45,10 +47,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from omnimemory.handlers.adapters.models import (
-    ModelAdapterIntentGraphConfig,
-    ModelIntentClassificationOutput,
-)
+from omnimemory.handlers.adapters.models import ModelAdapterIntentGraphConfig
 from omnimemory.nodes.intent_storage_effect.models import (
     ModelIntentRecordResponse,
     ModelIntentStorageRequest,
@@ -211,16 +210,13 @@ class HandlerIntentStorageAdapter:
         assert request.session_id is not None
         assert request.intent_data is not None
 
-        # Convert dict to ModelIntentClassificationOutput
-        intent_output = ModelIntentClassificationOutput(**request.intent_data)
-
         # Generate correlation_id if not provided
         correlation_id = request.correlation_id or uuid4()
 
         # Call the adapter
         result = await self._adapter.store_intent(
             session_id=request.session_id,
-            intent_data=intent_output,
+            intent_data=request.intent_data,
             correlation_id=correlation_id,
             user_context=request.user_context,
         )

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent Storage Handler Adapter for the intent_storage_effect node.
+
+This adapter wraps `AdapterIntentGraph` to implement the node's execute() interface,
+translating between the storage request/response models and the underlying
+graph adapter operations.
+
+Example::
+
+    import asyncio
+    from omnimemory.nodes.intent_storage_effect import (
+        HandlerIntentStorageAdapter,
+        ModelIntentStorageRequest,
+    )
+
+    async def example():
+        adapter = HandlerIntentStorageAdapter()
+        await adapter.initialize(connection_uri="bolt://localhost:7687")
+
+        # Store an intent
+        request = ModelIntentStorageRequest(
+            operation="store",
+            session_id="session_123",
+            intent_data={
+                "intent_category": "debugging",
+                "confidence": 0.92,
+                "keywords": ["error", "fix"],
+            },
+        )
+        response = await adapter.execute(request)
+        print(f"Stored intent: {response.intent_id}")
+
+    asyncio.run(example())
+
+.. versionadded:: 0.1.0
+    Initial implementation for demo critical path.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from omnimemory.handlers.adapters.models import (
+    ModelAdapterIntentGraphConfig,
+    ModelIntentClassificationOutput,
+)
+from omnimemory.nodes.intent_storage_effect.models import (
+    IntentRecordResponse,
+    ModelIntentStorageRequest,
+    ModelIntentStorageResponse,
+)
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+
+# Runtime conditional import
+_ADAPTER_AVAILABLE = False
+_ADAPTER_IMPORT_ERROR: str | None = None
+
+try:
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+
+    _ADAPTER_AVAILABLE = True
+except ImportError as e:
+    _ADAPTER_IMPORT_ERROR = str(e)
+
+    class AdapterIntentGraph:  # type: ignore[no-redef]
+        """Stub for AdapterIntentGraph when dependencies not installed."""
+
+        def __init__(self, config: object) -> None:
+            raise ImportError(
+                f"AdapterIntentGraph dependencies not available. "
+                f"Ensure omnibase_infra is installed. "
+                f"Original error: {_ADAPTER_IMPORT_ERROR}"
+            )
+
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HandlerIntentStorageAdapter"]
+
+
+class HandlerIntentStorageAdapter:
+    """Handler adapter for intent storage operations.
+
+    Wraps AdapterIntentGraph to provide the execute() interface expected
+    by the ONEX node framework.
+
+    Attributes:
+        _adapter: The underlying AdapterIntentGraph instance.
+        _initialized: Whether the adapter has been initialized.
+        _config: Configuration for the intent graph adapter.
+    """
+
+    def __init__(
+        self,
+        config: ModelAdapterIntentGraphConfig | None = None,
+    ) -> None:
+        """Initialize the handler adapter.
+
+        Args:
+            config: Optional configuration for the intent graph adapter.
+                If not provided, uses default configuration.
+        """
+        self._config = config or ModelAdapterIntentGraphConfig()
+        self._adapter: AdapterIntentGraph | None = None
+        self._initialized = False
+
+    async def initialize(
+        self,
+        connection_uri: str = "bolt://localhost:7687",
+        **kwargs: object,
+    ) -> None:
+        """Initialize the underlying adapter.
+
+        Args:
+            connection_uri: Memgraph connection URI.
+            **kwargs: Additional configuration passed to adapter.
+        """
+        if self._initialized:
+            return
+
+        if not _ADAPTER_AVAILABLE:
+            raise ImportError(
+                f"AdapterIntentGraph dependencies not available: {_ADAPTER_IMPORT_ERROR}"
+            )
+
+        self._adapter = AdapterIntentGraph(self._config)
+        await self._adapter.initialize(connection_uri=connection_uri, **kwargs)
+        self._initialized = True
+        logger.info("HandlerIntentStorageAdapter initialized")
+
+    async def shutdown(self) -> None:
+        """Shutdown the underlying adapter."""
+        if self._adapter is not None:
+            await self._adapter.shutdown()
+            self._adapter = None
+            self._initialized = False
+            logger.info("HandlerIntentStorageAdapter shutdown")
+
+    async def execute(
+        self,
+        request: ModelIntentStorageRequest,
+    ) -> ModelIntentStorageResponse:
+        """Execute an intent storage operation.
+
+        Routes to the appropriate method based on request.operation:
+        - store: Store a classified intent
+        - get_session: Get intents for a session
+        - get_distribution: Get intent category distribution
+
+        Args:
+            request: The storage request.
+
+        Returns:
+            Response with operation results.
+
+        Raises:
+            RuntimeError: If adapter not initialized.
+        """
+        if not self._initialized or self._adapter is None:
+            return ModelIntentStorageResponse(
+                status="error",
+                error_message="Adapter not initialized. Call initialize() first.",
+            )
+
+        start_time = time.perf_counter()
+
+        try:
+            if request.operation == "store":
+                response = await self._store_intent(request)
+            elif request.operation == "get_session":
+                response = await self._get_session_intents(request)
+            elif request.operation == "get_distribution":
+                response = await self._get_distribution(request)
+            else:
+                response = ModelIntentStorageResponse(
+                    status="error",
+                    error_message=f"Unknown operation: {request.operation}",
+                )
+        except Exception as e:
+            logger.exception("Error executing intent storage operation")
+            response = ModelIntentStorageResponse(
+                status="error",
+                error_message=str(e),
+            )
+
+        # Set execution time
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+        response = response.model_copy(update={"execution_time_ms": elapsed_ms})
+        return response
+
+    async def _store_intent(
+        self,
+        request: ModelIntentStorageRequest,
+    ) -> ModelIntentStorageResponse:
+        """Store a classified intent."""
+        assert self._adapter is not None
+        assert request.session_id is not None
+        assert request.intent_data is not None
+
+        # Convert dict to ModelIntentClassificationOutput
+        intent_output = ModelIntentClassificationOutput(**request.intent_data)
+
+        # Generate correlation_id if not provided
+        correlation_id = request.correlation_id or uuid4()
+
+        # Call the adapter
+        result = await self._adapter.store_intent(
+            session_id=request.session_id,
+            intent_data=intent_output,
+            correlation_id=correlation_id,
+            user_context=request.user_context,
+        )
+
+        if result.status == "success":
+            return ModelIntentStorageResponse(
+                status="success",
+                intent_id=result.intent_id,
+                session_id=request.session_id,
+                created=result.created,
+                execution_time_ms=result.execution_time_ms,
+            )
+        else:
+            return ModelIntentStorageResponse(
+                status="error",
+                session_id=request.session_id,
+                error_message=result.error_message,
+            )
+
+    async def _get_session_intents(
+        self,
+        request: ModelIntentStorageRequest,
+    ) -> ModelIntentStorageResponse:
+        """Get intents for a specific session."""
+        assert self._adapter is not None
+        assert request.session_id is not None
+
+        result = await self._adapter.get_session_intents(
+            session_id=request.session_id,
+            min_confidence=request.min_confidence,
+            limit=request.limit,
+        )
+
+        if result.status == "success":
+            # Convert to response model format
+            intents = [
+                IntentRecordResponse(
+                    intent_id=intent.intent_id,
+                    intent_category=intent.intent_category,
+                    confidence=intent.confidence,
+                    keywords=intent.keywords,
+                    created_at_utc=intent.created_at_utc.isoformat(),
+                    correlation_id=intent.correlation_id,
+                )
+                for intent in result.intents
+            ]
+            return ModelIntentStorageResponse(
+                status="success",
+                intents=intents,
+                total_count=result.total_count,
+                execution_time_ms=result.execution_time_ms,
+            )
+        elif result.status == "not_found":
+            return ModelIntentStorageResponse(
+                status="not_found",
+                error_message=f"Session not found: {request.session_id}",
+            )
+        elif result.status == "no_results":
+            return ModelIntentStorageResponse(
+                status="no_results",
+                intents=[],
+                total_count=0,
+            )
+        else:
+            return ModelIntentStorageResponse(
+                status="error",
+                error_message=result.error_message,
+            )
+
+    async def _get_distribution(
+        self,
+        request: ModelIntentStorageRequest,
+    ) -> ModelIntentStorageResponse:
+        """Get intent category distribution."""
+        assert self._adapter is not None
+
+        result = await self._adapter.get_intent_distribution(
+            time_range_hours=request.time_range_hours,
+        )
+
+        if result.status == "success":
+            return ModelIntentStorageResponse(
+                status="success",
+                distribution=result.distribution,
+                total_intents=result.total_intents,
+                time_range_hours=result.time_range_hours,
+                execution_time_ms=result.execution_time_ms,
+            )
+        else:
+            return ModelIntentStorageResponse(
+                status="error",
+                error_message=result.error_message,
+            )

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -189,11 +189,54 @@ class HandlerIntentStorageAdapter:
                     status="error",
                     error_message=f"Unknown operation: {request.operation}",
                 )
-        except Exception as e:
-            logger.exception("Error executing intent storage operation")
+        except AssertionError as e:
+            # AssertionError indicates a programming bug - missing validation or
+            # incorrect adapter state. Log at ERROR level with full traceback.
+            logger.exception(
+                "Assertion failed in intent storage operation '%s'. "
+                "This indicates a programming error - request validation may be incomplete.",
+                request.operation,
+            )
             response = ModelIntentStorageResponse(
                 status="error",
-                error_message=str(e),
+                error_message=f"Internal error: assertion failed - {e}",
+            )
+        except RuntimeError as e:
+            # RuntimeError typically indicates adapter initialization issues
+            # or infrastructure problems that the underlying adapter couldn't handle
+            logger.error(
+                "Runtime error during intent storage operation '%s': %s",
+                request.operation,
+                e,
+            )
+            response = ModelIntentStorageResponse(
+                status="error",
+                error_message=f"Runtime error: {e}",
+            )
+        except ValueError as e:
+            # ValueError indicates invalid input data or configuration
+            logger.warning(
+                "Validation error during intent storage operation '%s': %s",
+                request.operation,
+                e,
+            )
+            response = ModelIntentStorageResponse(
+                status="error",
+                error_message=f"Validation error: {e}",
+            )
+        except Exception as e:
+            # Safety net for truly unexpected errors - log at ERROR level with
+            # full traceback to aid debugging. These should be rare since the
+            # underlying adapter handles most exceptions internally.
+            logger.exception(
+                "Unexpected error (%s) during intent storage operation '%s'. "
+                "This may indicate a bug or unhandled edge case.",
+                type(e).__name__,
+                request.operation,
+            )
+            response = ModelIntentStorageResponse(
+                status="error",
+                error_message=f"Unexpected error ({type(e).__name__}): {e}",
             )
 
         # Set execution time

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -37,15 +37,33 @@ service_configuration:
   requires_external_dependencies: true
 
 # === INPUT/OUTPUT STATE ===
+# Aligned with ModelIntentStorageRequest and ModelIntentStorageResponse Pydantic models
 input_state:
   object_type: "object"
-  required: ["operation", "session_id"]
-  optional: ["intent_data", "min_confidence", "limit", "time_range_hours"]
+  required: ["operation"]
+  optional:
+    - "session_id"  # Required for 'store' and 'get_session' operations
+    - "intent_data"  # Required for 'store' operation (ModelIntentClassificationOutput)
+    - "correlation_id"  # Optional UUID for request tracing
+    - "min_confidence"  # float 0.0-1.0, default 0.0
+    - "limit"  # int 1-1000, default 100
+    - "time_range_hours"  # int 1-720, default 24
+    - "user_context"  # string, max 10000 chars, PII-validated
 
 output_state:
   object_type: "object"
   required: ["status"]
-  optional: ["intent_id", "intents", "distribution", "error_message"]
+  optional:
+    - "intent_id"  # UUID for store operations
+    - "session_id"  # Session identifier echo
+    - "created"  # bool, True if new intent created
+    - "intents"  # list[ModelIntentRecordResponse] for get_session
+    - "total_count"  # int for get_session results
+    - "distribution"  # dict[str, int] for get_distribution
+    - "total_intents"  # int for get_distribution
+    - "time_range_hours"  # int for get_distribution echo
+    - "execution_time_ms"  # float, operation timing
+    - "error_message"  # string, error details
 
 # === ACTIONS ===
 actions:
@@ -100,14 +118,17 @@ validation_rules:
   input_validation_enabled: true
   output_validation_enabled: true
   performance_validation_enabled: true
+  pii_validation_enabled: true  # user_context is PII-validated
   constraint_definitions:
     operation: "Literal['store', 'get_session', 'get_distribution']"
     status: "Literal['success', 'error', 'not_found', 'no_results']"
-    session_id: "string type for session identifier"
-    intent_data: "ModelIntentClassificationOutput for storage operations"
-    min_confidence: "float from 0.0 to 1.0 for filtering"
-    limit: "int for pagination limit"
-    time_range_hours: "int for distribution query time range"
+    session_id: "str | None, min_length=1, required for store and get_session"
+    intent_data: "ModelIntentClassificationOutput | None, required for store"
+    correlation_id: "UUID | None, optional request tracing identifier"
+    min_confidence: "float, ge=0.0, le=1.0, default=0.0"
+    limit: "int, ge=1, le=1000, default=100"
+    time_range_hours: "int, ge=1, le=720, default=24"
+    user_context: "str, max_length=10000, PII-validated before processing"
 
 # === TAGS ===
 tags:

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -1,0 +1,119 @@
+---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+
+# Intent Storage EFFECT - ONEX Contract
+# EFFECT node for storing intent classifications in Memgraph.
+
+# === REQUIRED ROOT FIELDS ===
+name: "intent_storage_effect"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: "Intent storage effect node for persisting classified intents to Memgraph. Links intents
+  to sessions for analytics and pattern learning."
+node_type: "EFFECT"
+input_model: "ModelIntentStorageRequest"
+output_model: "ModelIntentStorageResponse"
+
+# === IO OPERATIONS (Required for EFFECT nodes) ===
+io_operations:
+  - operation_type: "database_write"
+    atomic: true
+    timeout_seconds: 10
+    validation_enabled: true
+  - operation_type: "database_read"
+    atomic: false
+    timeout_seconds: 5
+    validation_enabled: true
+
+# === NODE CONFIGURATION ===
+tool_specification:
+  tool_name: "intent_storage_effect"
+  main_tool_class: "NodeIntentStorageEffect"
+
+# === SERVICE CONFIGURATION ===
+service_configuration:
+  is_persistent_service: false
+  requires_external_dependencies: true
+
+# === INPUT/OUTPUT STATE ===
+input_state:
+  object_type: "object"
+  required: ["operation", "session_id"]
+  optional: ["intent_data", "min_confidence", "limit", "time_range_hours"]
+
+output_state:
+  object_type: "object"
+  required: ["status"]
+  optional: ["intent_id", "intents", "distribution", "error_message"]
+
+# === ACTIONS ===
+actions:
+  - name: "store_intent"
+    description: "Store a classified intent linked to a session"
+    inputs: ["session_id", "intent_data"]
+    outputs: ["intent_id", "status"]
+
+  - name: "get_session_intents"
+    description: "Retrieve intents for a specific session"
+    inputs: ["session_id", "min_confidence", "limit"]
+    outputs: ["intents", "status"]
+
+  - name: "get_intent_distribution"
+    description: "Get aggregate intent category distribution"
+    inputs: ["time_range_hours"]
+    outputs: ["distribution", "status"]
+
+  - name: "health_check"
+    description: "Check node health status"
+    inputs: []
+    outputs: ["status"]
+
+# === DEPENDENCIES ===
+dependencies:
+  - name: memgraph
+    dependency_type: service
+    description: Memgraph graph database for intent storage
+    required: true
+
+  - name: AdapterIntentGraph
+    dependency_type: adapter
+    description: Intent graph adapter for Cypher operations
+    required: true
+
+# === PERFORMANCE ===
+performance:
+  max_response_time_ms: 100
+
+# === EVENT TYPE CONFIGURATION ===
+event_type:
+  version: {major: 1, minor: 0, patch: 0}
+  primary_events: ["intent.stored", "intent.store_failed"]
+  event_categories: ["intent", "effect", "memory"]
+  publish_events: true
+  subscribe_events: false
+  event_routing: "intent"
+
+# === VALIDATION RULES ===
+validation_rules:
+  strict_typing_enabled: true
+  input_validation_enabled: true
+  output_validation_enabled: true
+  performance_validation_enabled: true
+  constraint_definitions:
+    operation: "Literal['store', 'get_session', 'get_distribution']"
+    status: "Literal['success', 'error', 'not_found', 'no_results']"
+    session_id: "string type for session identifier"
+    intent_data: "ModelIntentClassificationOutput for storage operations"
+    min_confidence: "float from 0.0 to 1.0 for filtering"
+    limit: "int for pagination limit"
+    time_range_hours: "int for distribution query time range"
+
+# === TAGS ===
+tags:
+  - intent
+  - storage
+  - effect
+  - memgraph
+  - graph
+  - analytics

--- a/src/omnimemory/nodes/intent_storage_effect/models/__init__.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent storage effect models."""
+
+from .model_intent_storage_request import ModelIntentStorageRequest
+from .model_intent_storage_response import ModelIntentStorageResponse
+
+__all__ = [
+    "ModelIntentStorageRequest",
+    "ModelIntentStorageResponse",
+]

--- a/src/omnimemory/nodes/intent_storage_effect/models/__init__.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/__init__.py
@@ -3,9 +3,13 @@
 """Intent storage effect models."""
 
 from .model_intent_storage_request import ModelIntentStorageRequest
-from .model_intent_storage_response import ModelIntentStorageResponse
+from .model_intent_storage_response import (
+    ModelIntentRecordResponse,
+    ModelIntentStorageResponse,
+)
 
 __all__ = [
+    "ModelIntentRecordResponse",
     "ModelIntentStorageRequest",
     "ModelIntentStorageResponse",
 ]

--- a/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
@@ -8,10 +8,13 @@ Supports store, query, and distribution operations.
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal, Self
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
 
 __all__ = ["ModelIntentStorageRequest"]
 
@@ -49,9 +52,9 @@ class ModelIntentStorageRequest(BaseModel):
         min_length=1,
         description="Session identifier (required for store and get_session)",
     )
-    intent_data: dict[str, object] | None = Field(
+    intent_data: ModelIntentClassificationOutput | None = Field(
         default=None,
-        description="Intent classification data as dict (required for store)",
+        description="Intent classification output (required for store)",
     )
     correlation_id: UUID | None = Field(
         default=None,

--- a/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
@@ -8,15 +8,26 @@ Supports store, query, and distribution operations.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Self
+import logging
+from typing import Literal, Self
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-if TYPE_CHECKING:
-    from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
+# Runtime import required for Pydantic model validation
+# (TYPE_CHECKING imports are not available at runtime for field type resolution)
+from omnimemory.handlers.adapters.models import (
+    ModelIntentClassificationOutput,  # noqa: TC001
+)
+from omnimemory.utils.pii_detector import PIIDetector
 
 __all__ = ["ModelIntentStorageRequest"]
+
+logger = logging.getLogger(__name__)
+
+# Module-level PII detector instance for validation
+# Using medium sensitivity for user context to balance security and usability
+_pii_detector = PIIDetector()
 
 
 class ModelIntentStorageRequest(BaseModel):
@@ -80,8 +91,40 @@ class ModelIntentStorageRequest(BaseModel):
     )
     user_context: str = Field(
         default="",
+        max_length=10000,
         description="Optional user context for storage operations",
     )
+
+    @model_validator(mode="after")
+    def validate_user_context_pii(self) -> Self:
+        """Validate user_context does not contain PII.
+
+        User-facing input must be checked for PII before processing/storage
+        to ensure compliance with privacy regulations.
+
+        Raises:
+            ValueError: If PII is detected in user_context.
+        """
+        if self.user_context:
+            # Use medium sensitivity to balance security and usability
+            result = _pii_detector.detect_pii(
+                self.user_context, sensitivity_level="medium"
+            )
+            if result.has_pii:
+                pii_types = ", ".join(t.value for t in result.pii_types_detected)
+                logger.warning(
+                    "PII detected in user_context",
+                    extra={
+                        "pii_types_detected": pii_types,
+                        "operation": self.operation,
+                    },
+                )
+                msg = (
+                    f"user_context contains PII ({pii_types}). "
+                    "Please remove sensitive information before submission."
+                )
+                raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def validate_operation_fields(self) -> Self:

--- a/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Request model for intent storage operations.
+
+This model defines the input contract for the intent_storage_effect node.
+Supports store, query, and distribution operations.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = ["ModelIntentStorageRequest"]
+
+
+class ModelIntentStorageRequest(BaseModel):
+    """Request model for intent storage operations.
+
+    Supports three operation types:
+    - store: Store a classified intent linked to a session
+    - get_session: Retrieve intents for a specific session
+    - get_distribution: Get aggregate intent category distribution
+
+    Attributes:
+        operation: The operation to perform.
+        session_id: Session identifier (required for store and get_session).
+        intent_data: Intent classification data (required for store).
+        correlation_id: Optional correlation ID for request tracing.
+        min_confidence: Minimum confidence threshold for filtering (queries).
+        limit: Maximum results to return (queries).
+        time_range_hours: Lookback period for distribution queries.
+        user_context: Optional user context string for storage.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    operation: Literal["store", "get_session", "get_distribution"] = Field(
+        ...,
+        description="Operation type: 'store', 'get_session', or 'get_distribution'",
+    )
+    session_id: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Session identifier (required for store and get_session)",
+    )
+    intent_data: dict | None = Field(
+        default=None,
+        description="Intent classification data as dict (required for store)",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Correlation ID for request tracing",
+    )
+    min_confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Minimum confidence threshold for filtering",
+    )
+    limit: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Maximum results to return",
+    )
+    time_range_hours: int = Field(
+        default=24,
+        ge=1,
+        le=720,
+        description="Lookback period in hours for distribution queries",
+    )
+    user_context: str = Field(
+        default="",
+        description="Optional user context for storage operations",
+    )
+
+    @model_validator(mode="after")
+    def validate_operation_fields(self) -> Self:
+        """Validate that required fields are present for each operation type."""
+        if self.operation == "store":
+            if self.session_id is None:
+                msg = "session_id is required for store operation"
+                raise ValueError(msg)
+            if self.intent_data is None:
+                msg = "intent_data is required for store operation"
+                raise ValueError(msg)
+        elif self.operation == "get_session":
+            if self.session_id is None:
+                msg = "session_id is required for get_session operation"
+                raise ValueError(msg)
+        # get_distribution doesn't require session_id
+        return self

--- a/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_request.py
@@ -49,7 +49,7 @@ class ModelIntentStorageRequest(BaseModel):
         min_length=1,
         description="Session identifier (required for store and get_session)",
     )
-    intent_data: dict | None = Field(
+    intent_data: dict[str, object] | None = Field(
         default=None,
         description="Intent classification data as dict (required for store)",
     )

--- a/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_response.py
+++ b/src/omnimemory/nodes/intent_storage_effect/models/model_intent_storage_response.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Response model for intent storage operations.
+
+This model defines the output contract for the intent_storage_effect node.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelIntentStorageResponse", "ModelIntentRecordResponse"]
+
+
+class ModelIntentRecordResponse(BaseModel):
+    """Embedded intent record in query responses."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    intent_id: UUID = Field(
+        ...,
+        description="Unique identifier for the intent",
+    )
+    intent_category: str = Field(
+        ...,
+        description="The classified intent category",
+    )
+    confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Confidence score",
+    )
+    keywords: list[str] = Field(
+        default_factory=list,
+        description="Keywords associated with the intent",
+    )
+    created_at_utc: str = Field(
+        ...,
+        description="UTC timestamp when the intent was created (ISO format)",
+    )
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Correlation ID linking to a specific request",
+    )
+
+
+class ModelIntentStorageResponse(BaseModel):
+    """Response model for intent storage operations.
+
+    The response fields populated depend on the operation:
+    - store: status, intent_id, created, execution_time_ms
+    - get_session: status, intents, total_count, execution_time_ms
+    - get_distribution: status, distribution, total_intents, execution_time_ms
+
+    Attributes:
+        status: Operation status.
+        intent_id: For store operations, the created/updated intent ID.
+        created: For store operations, whether a new intent was created.
+        intents: For get_session operations, list of intent records.
+        total_count: For queries, total number of results.
+        distribution: For get_distribution, category -> count mapping.
+        total_intents: For get_distribution, total intents counted.
+        time_range_hours: For get_distribution, the queried time range.
+        execution_time_ms: Operation execution time in milliseconds.
+        error_message: Error details if status is 'error'.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    status: Literal["success", "error", "not_found", "no_results"] = Field(
+        ...,
+        description="Operation status",
+    )
+    intent_id: UUID | None = Field(
+        default=None,
+        description="For store operations, the created/updated intent ID",
+    )
+    session_id: str | None = Field(
+        default=None,
+        description="Session identifier",
+    )
+    created: bool = Field(
+        default=False,
+        description="For store operations, True if new intent created",
+    )
+    intents: list[ModelIntentRecordResponse] = Field(
+        default_factory=list,
+        description="For get_session operations, list of intent records",
+    )
+    total_count: int = Field(
+        default=0,
+        ge=0,
+        description="Total number of results",
+    )
+    distribution: dict[str, int] = Field(
+        default_factory=dict,
+        description="For get_distribution, category -> count mapping",
+    )
+    total_intents: int = Field(
+        default=0,
+        ge=0,
+        description="For get_distribution, total intents counted",
+    )
+    time_range_hours: int = Field(
+        default=24,
+        ge=1,
+        description="For get_distribution, the queried time range",
+    )
+    execution_time_ms: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Operation execution time in milliseconds",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error details if status is 'error'",
+    )

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Memory Lifecycle Orchestrator - ONEX Node (Core 8 Foundation).
 
-Manages memory lifecycle transitions: ACTIVE -> EXPIRED -> ARCHIVED -> DELETED.
+Manages memory lifecycle transitions: ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED.
 Handles TTL expiration via RuntimeTick events and optimistic locking
 for concurrent safety.
 
@@ -18,8 +18,9 @@ Time Injection:
     than system clock, enabling deterministic testing and consistent behavior
     across distributed deployments.
 
-Lifecycle States:
+Lifecycle States (EnumLifecycleState):
     - ACTIVE: Memory is available for retrieval and actively used
+    - STALE: Memory is outdated but still accessible (soft TTL exceeded)
     - EXPIRED: Memory has exceeded TTL, pending cleanup
     - ARCHIVED: Memory has been moved to cold storage
     - DELETED: Memory has been permanently removed (terminal state)
@@ -27,7 +28,7 @@ Lifecycle States:
 ONEX 4.0 Declarative Pattern:
     This node follows the fully declarative ONEX pattern:
     - contract.yaml defines the node type, inputs, outputs, and dependencies
-    - Business logic lives in handlers (handler_memory_tick, handler_archive_memory, etc.)
+    - Business logic lives in handlers (HandlerMemoryTick, HandlerMemoryArchive, etc.)
     - No node.py class needed - the contract IS the node definition
 
 Handlers::
@@ -36,18 +37,19 @@ Handlers::
         HandlerMemoryTick,
         HandlerMemoryArchive,
         HandlerMemoryExpire,
-        HandlerRestoreMemory,
-        HandlerMemoryAccessed,
     )
+
+    # Planned handlers (not yet implemented):
+    # HandlerRestoreMemory, HandlerMemoryAccessed
 
 Models::
 
     from omnimemory.nodes.memory_lifecycle_orchestrator import (
-        ModelLifecycleOrchestratorInput,
-        ModelLifecycleOrchestratorOutput,
         ModelArchiveMemoryCommand,
         ModelExpireMemoryCommand,
-        ModelRestoreMemoryCommand,
+        ModelMemoryArchiveResult,
+        ModelMemoryExpireResult,
+        ModelMemoryTickResult,
     )
 
 .. versionadded:: 0.1.0
@@ -58,27 +60,41 @@ Ticket: OMN-1453
 
 # Implemented handler imports
 from .handlers import (
+    HandlerMemoryArchive,
     HandlerMemoryExpire,
     HandlerMemoryTick,
+    ModelArchiveMemoryCommand,
+    ModelArchiveRecord,
     ModelExpireMemoryCommand,
+    ModelMemoryArchiveResult,
     ModelMemoryCurrentState,
     ModelMemoryExpireResult,
     ModelMemoryTickResult,
+    ProtocolOrphanedArchiveTracker,
 )
 
 # TODO(OMN-1453): Add handler imports as implemented:
-#   HandlerMemoryArchive, HandlerRestoreMemory, HandlerMemoryAccessed
+#   HandlerRestoreMemory, HandlerMemoryAccessed
 
 # TODO(OMN-1453): Add model imports as implemented:
 #   ModelLifecycleOrchestratorInput, ModelLifecycleOrchestratorOutput,
-#   ModelArchiveMemoryCommand, ModelRestoreMemoryCommand
+#   ModelRestoreMemoryCommand
 
 __all__: list[str] = [
     # Implemented handlers
     "HandlerMemoryTick",
     "HandlerMemoryExpire",
+    "HandlerMemoryArchive",
+    # Tick handler models
     "ModelMemoryTickResult",
+    # Expire handler models
     "ModelExpireMemoryCommand",
     "ModelMemoryExpireResult",
     "ModelMemoryCurrentState",
+    # Archive handler models
+    "ModelArchiveMemoryCommand",
+    "ModelMemoryArchiveResult",
+    "ModelArchiveRecord",
+    # Protocols
+    "ProtocolOrphanedArchiveTracker",
 ]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Memory Lifecycle Orchestrator - ONEX Node (Core 8 Foundation).
 
-Manages memory lifecycle transitions: ACTIVE -> STALE -> EXPIRED -> ARCHIVED.
+Manages memory lifecycle transitions: ACTIVE -> EXPIRED -> ARCHIVED -> DELETED.
 Handles TTL expiration via RuntimeTick events and optimistic locking
 for concurrent safety.
 
@@ -20,11 +20,9 @@ Time Injection:
 
 Lifecycle States:
     - ACTIVE: Memory is available for retrieval and actively used
-    - STALE: Memory hasn't been accessed recently, candidate for expiration
-    - PENDING_ARCHIVE: Memory is queued for archival to cold storage
     - EXPIRED: Memory has exceeded TTL, pending cleanup
     - ARCHIVED: Memory has been moved to cold storage
-    - DELETED: Memory has been permanently removed
+    - DELETED: Memory has been permanently removed (terminal state)
 
 ONEX 4.0 Declarative Pattern:
     This node follows the fully declarative ONEX pattern:
@@ -36,8 +34,8 @@ Handlers::
 
     from omnimemory.nodes.memory_lifecycle_orchestrator import (
         HandlerMemoryTick,
-        HandlerArchiveMemory,
-        HandlerExpireMemory,
+        HandlerMemoryArchive,
+        HandlerMemoryExpire,
         HandlerRestoreMemory,
         HandlerMemoryAccessed,
     )
@@ -69,7 +67,7 @@ from .handlers import (
 )
 
 # TODO(OMN-1453): Add handler imports as implemented:
-#   HandlerArchiveMemory, HandlerRestoreMemory, HandlerMemoryAccessed
+#   HandlerMemoryArchive, HandlerRestoreMemory, HandlerMemoryAccessed
 
 # TODO(OMN-1453): Add model imports as implemented:
 #   ModelLifecycleOrchestratorInput, ModelLifecycleOrchestratorOutput,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/__init__.py
@@ -2,9 +2,85 @@
 # Copyright (c) 2025 OmniNode Team
 """Memory Lifecycle Orchestrator - ONEX Node (Core 8 Foundation).
 
-Full lifecycle management: store -> analyze -> consolidate -> archive.
+Manages memory lifecycle transitions: ACTIVE -> STALE -> EXPIRED -> ARCHIVED.
+Handles TTL expiration via RuntimeTick events and optimistic locking
+for concurrent safety.
 
-Status: Scaffold only - implementation pending.
+Node Type: ORCHESTRATOR
+- Workflow coordination for memory lifecycle state transitions
+- TTL expiration evaluation triggered by RuntimeTick events
+- Explicit archival, expiration, and restoration commands
+- Access tracking for TTL extension and pattern analysis
+
+Time Injection:
+    The orchestrator receives deterministic timestamps from RuntimeTick events
+    via the `now` parameter. All timeout evaluation uses injected time rather
+    than system clock, enabling deterministic testing and consistent behavior
+    across distributed deployments.
+
+Lifecycle States:
+    - ACTIVE: Memory is available for retrieval and actively used
+    - STALE: Memory hasn't been accessed recently, candidate for expiration
+    - PENDING_ARCHIVE: Memory is queued for archival to cold storage
+    - EXPIRED: Memory has exceeded TTL, pending cleanup
+    - ARCHIVED: Memory has been moved to cold storage
+    - DELETED: Memory has been permanently removed
+
+ONEX 4.0 Declarative Pattern:
+    This node follows the fully declarative ONEX pattern:
+    - contract.yaml defines the node type, inputs, outputs, and dependencies
+    - Business logic lives in handlers (handler_memory_tick, handler_archive_memory, etc.)
+    - No node.py class needed - the contract IS the node definition
+
+Handlers::
+
+    from omnimemory.nodes.memory_lifecycle_orchestrator import (
+        HandlerMemoryTick,
+        HandlerArchiveMemory,
+        HandlerExpireMemory,
+        HandlerRestoreMemory,
+        HandlerMemoryAccessed,
+    )
+
+Models::
+
+    from omnimemory.nodes.memory_lifecycle_orchestrator import (
+        ModelLifecycleOrchestratorInput,
+        ModelLifecycleOrchestratorOutput,
+        ModelArchiveMemoryCommand,
+        ModelExpireMemoryCommand,
+        ModelRestoreMemoryCommand,
+    )
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+
+Ticket: OMN-1453
 """
 
-__all__: list[str] = []
+# Implemented handler imports
+from .handlers import (
+    HandlerMemoryExpire,
+    HandlerMemoryTick,
+    ModelExpireMemoryCommand,
+    ModelMemoryCurrentState,
+    ModelMemoryExpireResult,
+    ModelMemoryTickResult,
+)
+
+# TODO(OMN-1453): Add handler imports as implemented:
+#   HandlerArchiveMemory, HandlerRestoreMemory, HandlerMemoryAccessed
+
+# TODO(OMN-1453): Add model imports as implemented:
+#   ModelLifecycleOrchestratorInput, ModelLifecycleOrchestratorOutput,
+#   ModelArchiveMemoryCommand, ModelRestoreMemoryCommand
+
+__all__: list[str] = [
+    # Implemented handlers
+    "HandlerMemoryTick",
+    "HandlerMemoryExpire",
+    "ModelMemoryTickResult",
+    "ModelExpireMemoryCommand",
+    "ModelMemoryExpireResult",
+    "ModelMemoryCurrentState",
+]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Memory Lifecycle Orchestrator Adapters.
+
+Storage adapters for memory lifecycle operations including archive storage
+and projection readers.
+
+Adapters (to be implemented):
+    - AdapterArchiveStorage: Cold storage adapter for archived memories
+    - ProjectionReaderMemoryLifecycle: Read-only projection state access
+
+Adapter Pattern:
+    Adapters wrap external dependencies (storage backends, databases) and
+    provide a consistent interface for handlers. All adapters implement
+    protocol-based interfaces for dependency injection and testing.
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+
+Ticket: OMN-1453
+"""
+
+# TODO(OMN-1453): Add adapter imports as implemented:
+#   AdapterArchiveStorage, ProjectionReaderMemoryLifecycle
+
+__all__: list[str] = []

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -1,0 +1,376 @@
+---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+# ONEX Node Contract - Memory Lifecycle Orchestrator Node
+#
+# =============================================================================
+# MEMORY LIFECYCLE ORCHESTRATOR
+# =============================================================================
+# Manages memory lifecycle transitions: expiration, archival, and cleanup.
+# Processes RuntimeTick events to evaluate timeout conditions and trigger
+# lifecycle state transitions for memory entities.
+#
+# Related to: OMN-1453 (OmniMemory P4b - Lifecycle Orchestrator Database Integration)
+#
+# Patterns derived from:
+#   - omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+#   - Handler routing with payload_type_match strategy
+#   - Time injection from RuntimeTick events
+# =============================================================================
+
+contract_version:
+  major: 0
+  minor: 1
+  patch: 0
+node_version: "0.1.0"
+name: "memory_lifecycle_orchestrator"
+node_type: "ORCHESTRATOR_GENERIC"
+description: "Memory lifecycle orchestrator that manages expiration, archival, and cleanup of memory entities
+  based on configurable TTL and retention policies."
+
+input_model:
+  name: "ModelLifecycleOrchestratorInput"
+  module: "omnimemory.nodes.memory_lifecycle_orchestrator.models"
+  description: "Input containing lifecycle event and orchestration configuration."
+output_model:
+  name: "ModelLifecycleOrchestratorOutput"
+  module: "omnimemory.nodes.memory_lifecycle_orchestrator.models"
+  description: "Output containing lifecycle transition results and workflow status."
+
+# =============================================================================
+# TIME INJECTION CONFIGURATION
+# =============================================================================
+# Enables deterministic timeout evaluation using injected timestamps from
+# RuntimeTick events. The DispatchContextEnforcer injects `now` timestamps
+# into orchestrator dispatch context, enabling deterministic lifecycle
+# expiration checks regardless of clock drift or test environments.
+time_injection:
+  enabled: true
+  source: "RuntimeTick"
+  field: "now"
+  description: "Use injected timestamp from RuntimeTick for TTL and expiration evaluation"
+
+# =============================================================================
+# PROJECTION READER CONFIGURATION
+# =============================================================================
+# Memory lifecycle decisions require reading current memory state projections.
+# The orchestrator queries memory_lifecycle_state to determine which memories
+# are eligible for expiration or archival based on TTL and access patterns.
+projection_reader:
+  protocol: "ProtocolProjectionReader"
+  module: "omnibase_spi.protocols"
+  projections:
+    - name: "memory_lifecycle_state"
+      description: "Current lifecycle state for all memory entities"
+    - name: "memory_access_patterns"
+      description: "Access frequency and recency patterns for consolidation decisions"
+
+# =============================================================================
+# CONSUMED EVENTS
+# =============================================================================
+# Events that trigger lifecycle orchestration logic.
+consumed_events:
+  # RuntimeTick - Periodic lifecycle evaluation trigger
+  - topic: "{env}.{namespace}.onex.internal.runtime-tick.v1"
+    event_type: "RuntimeTick"
+    internal: true
+    description: "Internal tick for TTL expiration and archival evaluation"
+
+  # Memory lifecycle command events
+  - topic: "{env}.{namespace}.memory.cmd.archive-memory.v1"
+    event_type: "ArchiveMemoryCommand"
+    message_category: "COMMAND"
+    description: "Explicit command to archive specific memory entities"
+
+  - topic: "{env}.{namespace}.memory.cmd.expire-memory.v1"
+    event_type: "ExpireMemoryCommand"
+    message_category: "COMMAND"
+    description: "Explicit command to expire specific memory entities"
+
+  - topic: "{env}.{namespace}.memory.cmd.restore-memory.v1"
+    event_type: "RestoreMemoryCommand"
+    message_category: "COMMAND"
+    description: "Command to restore archived memory back to active state"
+
+  # Memory access events for lifecycle tracking
+  - topic: "{env}.{namespace}.memory.evt.memory-accessed.v1"
+    event_type: "MemoryAccessedEvent"
+    description: "Memory access notification for TTL extension and access pattern tracking"
+    direct_handler: true
+
+# =============================================================================
+# HANDLER ROUTING CONFIGURATION
+# =============================================================================
+# Declarative mapping of consumed events to handler implementations.
+# Each handler is stateless and returns EVENTS only.
+#
+# Handler Pattern:
+#   async def handle(event, now, correlation_id) -> list[BaseModel]
+#
+# All handlers:
+#   - Receive `now` parameter for deterministic time-based decisions
+#   - Query projection state via ProtocolProjectionReader (read-only)
+#   - Return a list of event models (never intents or projections)
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    # ModelRuntimeTick -> HandlerMemoryTick
+    # Periodic lifecycle evaluation - evaluates memory entities for TTL expiration
+    # and archival eligibility. Queries all entities with active lifecycle states
+    # and emits expiration/archival events for those past their deadlines.
+    - event_model:
+        name: "ModelRuntimeTick"
+        module: "omnibase_infra.runtime.models.model_runtime_tick"
+      handler:
+        name: "HandlerMemoryTick"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick"
+      output_events:
+        - "ModelMemoryExpiredEvent"
+        - "ModelMemoryArchivedEvent"
+        - "ModelMemoryConsolidatedEvent"
+      timeout_evaluation:
+        uses_injected_now: true
+        queries_pending_entities: true
+        state_filters:
+          - "ACTIVE"
+          - "STALE"
+          - "PENDING_ARCHIVE"
+
+    # ArchiveMemoryCommand -> HandlerArchiveMemory
+    # Explicit archival request - validates memory state and initiates archival
+    - event_model:
+        name: "ModelArchiveMemoryCommand"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
+      handler:
+        name: "HandlerArchiveMemory"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_archive_memory"
+      message_category: "COMMAND"
+      output_events:
+        - "ModelMemoryArchiveInitiated"
+        - "ModelMemoryArchivedEvent"
+      state_transition:
+        valid_from_states:
+          - "ACTIVE"
+          - "STALE"
+          - "EXPIRED"
+        target_state: "ARCHIVED"
+
+    # ExpireMemoryCommand -> HandlerExpireMemory
+    # Explicit expiration request - marks memory as expired and triggers cleanup
+    - event_model:
+        name: "ModelExpireMemoryCommand"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
+      handler:
+        name: "HandlerExpireMemory"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_expire_memory"
+      message_category: "COMMAND"
+      output_events:
+        - "ModelMemoryExpiredEvent"
+      state_transition:
+        valid_from_states:
+          - "ACTIVE"
+          - "STALE"
+        target_state: "EXPIRED"
+
+    # RestoreMemoryCommand -> HandlerRestoreMemory
+    # Restore archived memory back to active state
+    - event_model:
+        name: "ModelRestoreMemoryCommand"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
+      handler:
+        name: "HandlerRestoreMemory"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_restore_memory"
+      message_category: "COMMAND"
+      output_events:
+        - "ModelMemoryRestoredEvent"
+      state_transition:
+        valid_from_states:
+          - "ARCHIVED"
+        target_state: "ACTIVE"
+
+    # MemoryAccessedEvent -> HandlerMemoryAccessed
+    # Updates access tracking for TTL extension and pattern analysis
+    - event_model:
+        name: "ModelMemoryAccessedEvent"
+        module: "omnimemory.models.events.model_memory_accessed_event"
+      handler:
+        name: "HandlerMemoryAccessed"
+        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_accessed"
+      output_events: []
+      direct_handler: true
+      description: "Updates memory access tracking and extends TTL if configured"
+
+  # Handler initialization configuration
+  handler_dependencies:
+    projection_reader:
+      protocol: "ProtocolProjectionReader"
+      implementation: "ProjectionReaderMemoryLifecycle"
+      module: "omnimemory.projectors.projection_reader_memory_lifecycle"
+      shared: true
+      description: "Shared projection reader for all lifecycle handlers"
+
+# =============================================================================
+# PUBLISHED EVENTS
+# =============================================================================
+# Events emitted by lifecycle orchestration handlers.
+published_events:
+  - topic: "{env}.{namespace}.memory.evt.memory-expired.v1"
+    event_type: "MemoryExpiredEvent"
+    description: "Memory entity has expired due to TTL or explicit expiration command"
+
+  - topic: "{env}.{namespace}.memory.evt.memory-archived.v1"
+    event_type: "MemoryArchivedEvent"
+    description: "Memory entity has been archived to cold storage"
+
+  - topic: "{env}.{namespace}.memory.evt.memory-archive-initiated.v1"
+    event_type: "MemoryArchiveInitiated"
+    description: "Archival process has started for memory entity"
+
+  - topic: "{env}.{namespace}.memory.evt.memory-restored.v1"
+    event_type: "MemoryRestoredEvent"
+    description: "Archived memory entity has been restored to active state"
+
+  - topic: "{env}.{namespace}.memory.evt.memory-consolidated.v1"
+    event_type: "MemoryConsolidatedEvent"
+    description: "Memory entities have been consolidated based on similarity or redundancy"
+
+  - topic: "{env}.{namespace}.memory.evt.lifecycle-transition-failed.v1"
+    event_type: "LifecycleTransitionFailedEvent"
+    description: "Lifecycle state transition failed due to validation or execution error"
+
+# =============================================================================
+# OPERATION BINDINGS (DOCUMENTATION ONLY)
+# =============================================================================
+# NOTE: This section documents the intended operation bindings for the lifecycle
+# orchestrator. The runtime interpreter for operation_bindings is NOT YET
+# IMPLEMENTED. This serves as validated documentation for future implementation.
+#
+# When implemented, these bindings will:
+# 1. Map high-level operations to handler invocations
+# 2. Define pre/post conditions for each operation
+# 3. Enable declarative workflow composition
+# =============================================================================
+operation_bindings:
+  # Operation: evaluate_expirations
+  # Triggered by RuntimeTick to check all active memories for TTL expiration
+  - operation: "evaluate_expirations"
+    description: "Evaluate all active memory entities for TTL expiration"
+    trigger:
+      event_type: "RuntimeTick"
+      condition: "periodic"
+    handler: "HandlerMemoryTick"
+    pre_conditions:
+      - "projection_reader_available"
+      - "time_injection_enabled"
+    post_conditions:
+      - "expired_memories_emit_events"
+      # NOTE: Runtime interpreter not yet implemented - this is documentation only
+
+  # Operation: archive_memory
+  # Explicitly archive a memory entity to cold storage
+  - operation: "archive_memory"
+    description: "Archive memory entity to cold storage"
+    trigger:
+      event_type: "ArchiveMemoryCommand"
+      condition: "on_command"
+    handler: "HandlerArchiveMemory"
+    pre_conditions:
+      - "memory_exists"
+      - "memory_state_allows_archive"
+    post_conditions:
+      - "memory_moved_to_archive_storage"
+      - "archive_event_emitted"
+      # NOTE: Runtime interpreter not yet implemented - this is documentation only
+
+  # Operation: restore_memory
+  # Restore archived memory back to active state
+  - operation: "restore_memory"
+    description: "Restore archived memory to active state"
+    trigger:
+      event_type: "RestoreMemoryCommand"
+      condition: "on_command"
+    handler: "HandlerRestoreMemory"
+    pre_conditions:
+      - "memory_exists_in_archive"
+      - "archive_storage_accessible"
+    post_conditions:
+      - "memory_restored_to_active"
+      - "restore_event_emitted"
+      # NOTE: Runtime interpreter not yet implemented - this is documentation only
+
+# =============================================================================
+# DEPENDENCIES
+# =============================================================================
+dependencies:
+  - name: "projection_reader"
+    type: "protocol"
+    module: "omnibase_spi.protocols"
+    description: "Protocol for reading memory lifecycle projection state."
+
+  - name: "memory_storage_effect"
+    type: "node"
+    module: "omnimemory.nodes.memory_storage_effect"
+    description: "Effect node for memory persistence operations."
+
+  - name: "archive_storage_adapter"
+    type: "adapter"
+    module: "omnimemory.nodes.memory_lifecycle_orchestrator.adapters"
+    description: "Adapter for cold/archive storage operations."
+
+# =============================================================================
+# ERROR HANDLING
+# =============================================================================
+error_handling:
+  retry_policy:
+    max_retries: 3
+    initial_delay_ms: 100
+    max_delay_ms: 5000
+    exponential_base: 2
+    retry_on:
+      - "StorageError"
+      - "ConnectionError"
+      - "TimeoutError"
+  circuit_breaker:
+    enabled: true
+    failure_threshold: 5
+    reset_timeout_ms: 60000
+  error_types:
+    - name: "LifecycleTransitionError"
+      description: "Error during lifecycle state transition"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "ArchiveStorageError"
+      description: "Error accessing archive storage"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "ProjectionReadError"
+      description: "Error reading lifecycle projection state"
+      recoverable: true
+      retry_strategy: "exponential_backoff"
+    - name: "InvalidStateTransition"
+      description: "Attempted invalid lifecycle state transition"
+      recoverable: false
+      retry_strategy: "none"
+
+# =============================================================================
+# HEALTH CHECK
+# =============================================================================
+health_check:
+  enabled: true
+  endpoint: "/health"
+  interval_seconds: 30
+
+# =============================================================================
+# METADATA
+# =============================================================================
+metadata:
+  author: "OmniNode Team"
+  created: "2026-01-25"
+  ticket: "OMN-1453"
+  tags:
+    - "orchestrator"
+    - "lifecycle"
+    - "memory"
+    - "ttl"
+    - "archival"
+    - "expiration"

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -12,365 +12,114 @@
 #
 # Related to: OMN-1453 (OmniMemory P4b - Lifecycle Orchestrator Database Integration)
 #
-# Patterns derived from:
-#   - omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
-#   - Handler routing with payload_type_match strategy
-#   - Time injection from RuntimeTick events
+# =============================================================================
+# ARCHITECTURAL NOTES (for documentation - not part of contract schema)
+# =============================================================================
+# Time Injection:
+#   - Uses injected timestamp from RuntimeTick for TTL and expiration evaluation
+#   - DispatchContextEnforcer injects `now` timestamps for deterministic checks
+#
+# Projection Reader:
+#   - Protocol: ProtocolProjectionReader from omnibase_spi.protocols
+#   - Projections: memory_lifecycle_state, memory_access_patterns
+#
+# Handler Routing:
+#   - ModelRuntimeTick -> HandlerMemoryTick (TTL expiration evaluation)
+#   - ModelArchiveMemoryCommand -> HandlerArchiveMemory
+#   - ModelExpireMemoryCommand -> HandlerExpireMemory
+#   - ModelRestoreMemoryCommand -> HandlerRestoreMemory
+#   - ModelMemoryAccessedEvent -> HandlerMemoryAccessed
+#
+# Published Event Topics:
+#   - {env}.{namespace}.memory.evt.memory-expired.v1
+#   - {env}.{namespace}.memory.evt.memory-archived.v1
+#   - {env}.{namespace}.memory.evt.memory-archive-initiated.v1
+#   - {env}.{namespace}.memory.evt.memory-restored.v1
+#   - {env}.{namespace}.memory.evt.memory-consolidated.v1
+#   - {env}.{namespace}.memory.evt.lifecycle-transition-failed.v1
 # =============================================================================
 
 contract_version:
   major: 0
   minor: 1
   patch: 0
-node_version: {major: 0, minor: 1, patch: 0}
+
+node_version:
+  major: 0
+  minor: 1
+  patch: 0
+
 name: "memory_lifecycle_orchestrator"
 node_type: "ORCHESTRATOR_GENERIC"
-description: "Memory lifecycle orchestrator that manages expiration, archival, and cleanup of memory entities
-  based on configurable TTL and retention policies."
+description: >-
+  Memory lifecycle orchestrator that manages expiration, archival, and cleanup of memory entities based
+  on configurable TTL and retention policies. #magic___^_^___line
+# Model specifications - fully qualified class names
+input_model: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleOrchestratorInput"
+output_model: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleOrchestratorOutput"
 
-input_model:
-  name: "ModelLifecycleOrchestratorInput"
-  module: "omnimemory.nodes.memory_lifecycle_orchestrator.models"
-  description: "Input containing lifecycle event and orchestration configuration."
-output_model:
-  name: "ModelLifecycleOrchestratorOutput"
-  module: "omnimemory.nodes.memory_lifecycle_orchestrator.models"
-  description: "Output containing lifecycle transition results and workflow status."
+# Performance requirements
+performance:
+  single_operation_max_ms: 1000
+  batch_operation_max_ms: 5000
+  throughput_min_ops_per_sec: 100
 
-# =============================================================================
-# TIME INJECTION CONFIGURATION
-# =============================================================================
-# Enables deterministic timeout evaluation using injected timestamps from
-# RuntimeTick events. The DispatchContextEnforcer injects `now` timestamps
-# into orchestrator dispatch context, enabling deterministic lifecycle
-# expiration checks regardless of clock drift or test environments.
-time_injection:
-  enabled: true
-  source: "RuntimeTick"
-  field: "now"
-  description: "Use injected timestamp from RuntimeTick for TTL and expiration evaluation"
-
-# =============================================================================
-# PROJECTION READER CONFIGURATION
-# =============================================================================
-# Memory lifecycle decisions require reading current memory state projections.
-# The orchestrator queries memory_lifecycle_state to determine which memories
-# are eligible for expiration or archival based on TTL and access patterns.
-projection_reader:
-  protocol: "ProtocolProjectionReader"
-  module: "omnibase_spi.protocols"
-  projections:
-    - name: "memory_lifecycle_state"
-      description: "Current lifecycle state for all memory entities"
-    - name: "memory_access_patterns"
-      description: "Access frequency and recency patterns for consolidation decisions"
-
-# =============================================================================
-# CONSUMED EVENTS
-# =============================================================================
-# Events that trigger lifecycle orchestration logic.
-consumed_events:
-  # RuntimeTick - Periodic lifecycle evaluation trigger
-  - topic: "{env}.{namespace}.onex.internal.runtime-tick.v1"
-    event_type: "RuntimeTick"
-    internal: true
-    description: "Internal tick for TTL expiration and archival evaluation"
-
-  # Memory lifecycle command events
-  - topic: "{env}.{namespace}.memory.cmd.archive-memory.v1"
-    event_type: "ArchiveMemoryCommand"
-    message_category: "COMMAND"
-    description: "Explicit command to archive specific memory entities"
-
-  - topic: "{env}.{namespace}.memory.cmd.expire-memory.v1"
-    event_type: "ExpireMemoryCommand"
-    message_category: "COMMAND"
-    description: "Explicit command to expire specific memory entities"
-
-  - topic: "{env}.{namespace}.memory.cmd.restore-memory.v1"
-    event_type: "RestoreMemoryCommand"
-    message_category: "COMMAND"
-    description: "Command to restore archived memory back to active state"
-
-  # Memory access events for lifecycle tracking
-  - topic: "{env}.{namespace}.memory.evt.memory-accessed.v1"
-    event_type: "MemoryAccessedEvent"
-    description: "Memory access notification for TTL extension and access pattern tracking"
-    direct_handler: true
-
-# =============================================================================
-# HANDLER ROUTING CONFIGURATION
-# =============================================================================
-# Declarative mapping of consumed events to handler implementations.
-# Each handler is stateless and returns EVENTS only.
-#
-# Handler Pattern:
-#   async def handle(event, now, correlation_id) -> list[BaseModel]
-#
-# All handlers:
-#   - Receive `now` parameter for deterministic time-based decisions
-#   - Query projection state via ProtocolProjectionReader (read-only)
-#   - Return a list of event models (never intents or projections)
-handler_routing:
-  routing_strategy: "payload_type_match"
-  handlers:
-    # ModelRuntimeTick -> HandlerMemoryTick
-    # Periodic lifecycle evaluation - evaluates memory entities for TTL expiration
-    # and archival eligibility. Queries all entities with active lifecycle states
-    # and emits expiration/archival events for those past their deadlines.
-    - event_model:
-        name: "ModelRuntimeTick"
-        module: "omnibase_infra.runtime.models.model_runtime_tick"
-      handler:
-        name: "HandlerMemoryTick"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick"
-      output_events:
-        - "ModelMemoryExpiredEvent"
-        - "ModelMemoryArchivedEvent"
-        - "ModelMemoryConsolidatedEvent"
-      timeout_evaluation:
-        uses_injected_now: true
-        queries_pending_entities: true
-        state_filters:
-          - "ACTIVE"
-          - "STALE"
-          - "PENDING_ARCHIVE"
-
-    # ArchiveMemoryCommand -> HandlerArchiveMemory
-    # Explicit archival request - validates memory state and initiates archival
-    - event_model:
-        name: "ModelArchiveMemoryCommand"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
-      handler:
-        name: "HandlerArchiveMemory"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_archive_memory"
-      message_category: "COMMAND"
-      output_events:
-        - "ModelMemoryArchiveInitiated"
-        - "ModelMemoryArchivedEvent"
-      state_transition:
-        valid_from_states:
-          - "ACTIVE"
-          - "STALE"
-          - "EXPIRED"
-        target_state: "ARCHIVED"
-
-    # ExpireMemoryCommand -> HandlerExpireMemory
-    # Explicit expiration request - marks memory as expired and triggers cleanup
-    - event_model:
-        name: "ModelExpireMemoryCommand"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
-      handler:
-        name: "HandlerExpireMemory"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_expire_memory"
-      message_category: "COMMAND"
-      output_events:
-        - "ModelMemoryExpiredEvent"
-      state_transition:
-        valid_from_states:
-          - "ACTIVE"
-          - "STALE"
-        target_state: "EXPIRED"
-
-    # RestoreMemoryCommand -> HandlerRestoreMemory
-    # Restore archived memory back to active state
-    - event_model:
-        name: "ModelRestoreMemoryCommand"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.models.commands"
-      handler:
-        name: "HandlerRestoreMemory"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_restore_memory"
-      message_category: "COMMAND"
-      output_events:
-        - "ModelMemoryRestoredEvent"
-      state_transition:
-        valid_from_states:
-          - "ARCHIVED"
-        target_state: "ACTIVE"
-
-    # MemoryAccessedEvent -> HandlerMemoryAccessed
-    # Updates access tracking for TTL extension and pattern analysis
-    - event_model:
-        name: "ModelMemoryAccessedEvent"
-        module: "omnimemory.models.events.model_memory_accessed_event"
-      handler:
-        name: "HandlerMemoryAccessed"
-        module: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_accessed"
-      output_events: []
-      direct_handler: true
-      description: "Updates memory access tracking and extends TTL if configured"
-
-  # Handler initialization configuration
-  handler_dependencies:
-    projection_reader:
-      protocol: "ProtocolProjectionReader"
-      implementation: "ProjectionReaderMemoryLifecycle"
-      module: "omnimemory.projectors.projection_reader_memory_lifecycle"
-      shared: true
-      description: "Shared projection reader for all lifecycle handlers"
-
-# =============================================================================
-# PUBLISHED EVENTS
-# =============================================================================
-# Events emitted by lifecycle orchestration handlers.
-published_events:
-  - topic: "{env}.{namespace}.memory.evt.memory-expired.v1"
-    event_type: "MemoryExpiredEvent"
-    description: "Memory entity has expired due to TTL or explicit expiration command"
-
-  - topic: "{env}.{namespace}.memory.evt.memory-archived.v1"
-    event_type: "MemoryArchivedEvent"
-    description: "Memory entity has been archived to cold storage"
-
-  - topic: "{env}.{namespace}.memory.evt.memory-archive-initiated.v1"
-    event_type: "MemoryArchiveInitiated"
-    description: "Archival process has started for memory entity"
-
-  - topic: "{env}.{namespace}.memory.evt.memory-restored.v1"
-    event_type: "MemoryRestoredEvent"
-    description: "Archived memory entity has been restored to active state"
-
-  - topic: "{env}.{namespace}.memory.evt.memory-consolidated.v1"
-    event_type: "MemoryConsolidatedEvent"
-    description: "Memory entities have been consolidated based on similarity or redundancy"
-
-  - topic: "{env}.{namespace}.memory.evt.lifecycle-transition-failed.v1"
-    event_type: "LifecycleTransitionFailedEvent"
-    description: "Lifecycle state transition failed due to validation or execution error"
-
-# =============================================================================
-# OPERATION BINDINGS (DOCUMENTATION ONLY)
-# =============================================================================
-# NOTE: This section documents the intended operation bindings for the lifecycle
-# orchestrator. The runtime interpreter for operation_bindings is NOT YET
-# IMPLEMENTED. This serves as validated documentation for future implementation.
-#
-# When implemented, these bindings will:
-# 1. Map high-level operations to handler invocations
-# 2. Define pre/post conditions for each operation
-# 3. Enable declarative workflow composition
-# =============================================================================
-operation_bindings:
-  # Operation: evaluate_expirations
-  # Triggered by RuntimeTick to check all active memories for TTL expiration
-  - operation: "evaluate_expirations"
-    description: "Evaluate all active memory entities for TTL expiration"
-    trigger:
-      event_type: "RuntimeTick"
-      condition: "periodic"
-    handler: "HandlerMemoryTick"
-    pre_conditions:
-      - "projection_reader_available"
-      - "time_injection_enabled"
-    post_conditions:
-      - "expired_memories_emit_events"
-      # NOTE: Runtime interpreter not yet implemented - this is documentation only
-
-  # Operation: archive_memory
-  # Explicitly archive a memory entity to cold storage
-  - operation: "archive_memory"
-    description: "Archive memory entity to cold storage"
-    trigger:
-      event_type: "ArchiveMemoryCommand"
-      condition: "on_command"
-    handler: "HandlerArchiveMemory"
-    pre_conditions:
-      - "memory_exists"
-      - "memory_state_allows_archive"
-    post_conditions:
-      - "memory_moved_to_archive_storage"
-      - "archive_event_emitted"
-      # NOTE: Runtime interpreter not yet implemented - this is documentation only
-
-  # Operation: restore_memory
-  # Restore archived memory back to active state
-  - operation: "restore_memory"
-    description: "Restore archived memory to active state"
-    trigger:
-      event_type: "RestoreMemoryCommand"
-      condition: "on_command"
-    handler: "HandlerRestoreMemory"
-    pre_conditions:
-      - "memory_exists_in_archive"
-      - "archive_storage_accessible"
-    post_conditions:
-      - "memory_restored_to_active"
-      - "restore_event_emitted"
-      # NOTE: Runtime interpreter not yet implemented - this is documentation only
-
-# =============================================================================
-# DEPENDENCIES
-# =============================================================================
+# Dependencies
 dependencies:
-  - name: "projection_reader"
-    type: "protocol"
+  - name: "ProtocolProjectionReader"
     module: "omnibase_spi.protocols"
+    dependency_type: "protocol"
     description: "Protocol for reading memory lifecycle projection state."
 
-  - name: "memory_storage_effect"
-    type: "node"
-    module: "omnimemory.nodes.memory_storage_effect"
+  - name: "ProtocolMemoryStorage"
+    module: "omnimemory.protocols"
+    dependency_type: "protocol"
     description: "Effect node for memory persistence operations."
 
-  - name: "archive_storage_adapter"
-    type: "adapter"
-    module: "omnimemory.nodes.memory_lifecycle_orchestrator.adapters"
+  - name: "ProtocolArchiveStorage"
+    module: "omnimemory.protocols"
+    dependency_type: "protocol"
     description: "Adapter for cold/archive storage operations."
 
-# =============================================================================
-# ERROR HANDLING
-# =============================================================================
-error_handling:
-  retry_policy:
-    max_retries: 3
-    initial_delay_ms: 100
-    max_delay_ms: 5000
-    exponential_base: 2
-    retry_on:
-      - "StorageError"
-      - "ConnectionError"
-      - "TimeoutError"
-  circuit_breaker:
-    enabled: true
-    failure_threshold: 5
-    reset_timeout_ms: 60000
-  error_types:
-    - name: "LifecycleTransitionError"
-      description: "Error during lifecycle state transition"
-      recoverable: true
-      retry_strategy: "exponential_backoff"
-    - name: "ArchiveStorageError"
-      description: "Error accessing archive storage"
-      recoverable: true
-      retry_strategy: "exponential_backoff"
-    - name: "ProjectionReadError"
-      description: "Error reading lifecycle projection state"
-      recoverable: true
-      retry_strategy: "exponential_backoff"
-    - name: "InvalidStateTransition"
-      description: "Attempted invalid lifecycle state transition"
-      recoverable: false
-      retry_strategy: "none"
+# Tags for discovery
+tags:
+  - "orchestrator"
+  - "lifecycle"
+  - "memory"
+  - "ttl"
+  - "archival"
+  - "expiration"
 
-# =============================================================================
-# HEALTH CHECK
-# =============================================================================
-health_check:
-  enabled: true
-  endpoint: "/health"
-  interval_seconds: 30
+# Author metadata
+author: "OmniNode Team"
 
-# =============================================================================
-# METADATA
-# =============================================================================
-metadata:
-  author: "OmniNode Team"
-  created: "2026-01-25"
-  ticket: "OMN-1453"
-  tags:
-    - "orchestrator"
-    - "lifecycle"
-    - "memory"
-    - "ttl"
-    - "archival"
-    - "expiration"
+# Consumed events - follows ModelEventSubscription schema
+consumed_events:
+  # RuntimeTick - Periodic lifecycle evaluation trigger
+  - event_pattern: "onex.internal.runtime-tick.v1"
+    handler_function: "handle_runtime_tick"
+
+  # Memory lifecycle command events
+  - event_pattern: "memory.cmd.archive-memory.v1"
+    handler_function: "handle_archive_memory"
+
+  - event_pattern: "memory.cmd.expire-memory.v1"
+    handler_function: "handle_expire_memory"
+
+  - event_pattern: "memory.cmd.restore-memory.v1"
+    handler_function: "handle_restore_memory"
+
+  # Memory access events for lifecycle tracking
+  - event_pattern: "memory.evt.memory-accessed.v1"
+    handler_function: "handle_memory_accessed"
+
+# Published events - empty list since ModelEventDescriptor requires complex
+# fields (UUIDs, enums, etc.) that are better defined at runtime
+# See ARCHITECTURAL NOTES above for the event topics this orchestrator publishes
+published_events: []
+
+# Orchestration configuration - use defaults
+load_balancing_enabled: true
+failure_isolation_enabled: true
+monitoring_enabled: true
+metrics_collection_enabled: true

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -25,8 +25,8 @@
 #
 # Handler Routing:
 #   - ModelRuntimeTick -> HandlerMemoryTick (TTL expiration evaluation)
-#   - ModelArchiveMemoryCommand -> HandlerArchiveMemory
-#   - ModelExpireMemoryCommand -> HandlerExpireMemory
+#   - ModelArchiveMemoryCommand -> HandlerMemoryArchive
+#   - ModelExpireMemoryCommand -> HandlerMemoryExpire
 #   - ModelRestoreMemoryCommand -> HandlerRestoreMemory
 #   - ModelMemoryAccessedEvent -> HandlerMemoryAccessed
 #

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -10,6 +10,13 @@
 # Processes RuntimeTick events to evaluate timeout conditions and trigger
 # lifecycle state transitions for memory entities.
 #
+# Lifecycle States (EnumLifecycleState):
+#   - ACTIVE: Memory is available for retrieval and actively used
+#   - STALE: Memory is outdated but still accessible (soft TTL exceeded)
+#   - EXPIRED: Memory has exceeded hard TTL, pending cleanup
+#   - ARCHIVED: Memory has been moved to cold storage
+#   - DELETED: Memory has been permanently removed (terminal state)
+#
 # Related to: OMN-1453 (OmniMemory P4b - Lifecycle Orchestrator Database Integration)
 #
 # =============================================================================
@@ -23,12 +30,14 @@
 #   - Protocol: ProtocolProjectionReader from omnibase_spi.protocols
 #   - Projections: memory_lifecycle_state, memory_access_patterns
 #
-# Handler Routing:
+# Handler Routing (Implemented):
 #   - ModelRuntimeTick -> HandlerMemoryTick (TTL expiration evaluation)
-#   - ModelArchiveMemoryCommand -> HandlerMemoryArchive
-#   - ModelExpireMemoryCommand -> HandlerMemoryExpire
-#   - ModelRestoreMemoryCommand -> HandlerRestoreMemory
-#   - ModelMemoryAccessedEvent -> HandlerMemoryAccessed
+#   - ModelArchiveMemoryCommand -> HandlerMemoryArchive (EXPIRED -> ARCHIVED)
+#   - ModelExpireMemoryCommand -> HandlerMemoryExpire (ACTIVE -> EXPIRED)
+#
+# Handler Routing (Planned - OMN-1453):
+#   - ModelRestoreMemoryCommand -> HandlerRestoreMemory (ARCHIVED -> ACTIVE)
+#   - ModelMemoryAccessedEvent -> HandlerMemoryAccessed (TTL extension tracking)
 #
 # Published Event Topics:
 #   - {env}.{namespace}.memory.evt.memory-expired.v1

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -22,7 +22,7 @@ contract_version:
   major: 0
   minor: 1
   patch: 0
-node_version: "0.1.0"
+node_version: {major: 0, minor: 1, patch: 0}
 name: "memory_lifecycle_orchestrator"
 node_type: "ORCHESTRATOR_GENERIC"
 description: "Memory lifecycle orchestrator that manages expiration, archival, and cleanup of memory entities

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/__init__.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Memory Lifecycle Orchestrator Handlers.
+
+This module exports handlers for the memory lifecycle orchestrator node.
+
+Handlers:
+    HandlerMemoryTick: Processes RuntimeTick events to evaluate memory TTL
+        expirations and archive candidates. Emits MemoryExpired and
+        ArchiveInitiated events for memories past their deadlines.
+
+    HandlerMemoryExpire: Performs state transition ACTIVE -> EXPIRED with
+        optimistic locking. Uses revision-based concurrency control to
+        handle concurrent access safely.
+
+    HandlerMemoryArchive: Archives EXPIRED memories to cold storage with
+        gzip compression and atomic writes. Uses optimistic locking to
+        prevent double-archive race conditions.
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+    - OMN-1524: Atomic write primitive (pending)
+"""
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_archive import (
+    HandlerMemoryArchive,
+    ModelArchiveMemoryCommand,
+    ModelArchiveRecord,
+    ModelMemoryArchiveResult,
+)
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
+    HandlerMemoryExpire,
+    ModelExpireMemoryCommand,
+    ModelMemoryCurrentState,
+    ModelMemoryExpireResult,
+)
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick import (
+    HandlerMemoryTick,
+    ModelMemoryTickResult,
+)
+
+__all__ = [
+    # Tick handler
+    "HandlerMemoryTick",
+    "ModelMemoryTickResult",
+    # Expire handler
+    "HandlerMemoryExpire",
+    "ModelExpireMemoryCommand",
+    "ModelMemoryCurrentState",
+    "ModelMemoryExpireResult",
+    # Archive handler
+    "HandlerMemoryArchive",
+    "ModelArchiveMemoryCommand",
+    "ModelArchiveRecord",
+    "ModelMemoryArchiveResult",
+]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/__init__.py
@@ -27,6 +27,7 @@ from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_arch
     ModelArchiveMemoryCommand,
     ModelArchiveRecord,
     ModelMemoryArchiveResult,
+    ProtocolOrphanedArchiveTracker,
 )
 from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
     HandlerMemoryExpire,
@@ -53,4 +54,5 @@ __all__ = [
     "ModelArchiveMemoryCommand",
     "ModelArchiveRecord",
     "ModelMemoryArchiveResult",
+    "ProtocolOrphanedArchiveTracker",
 ]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -73,6 +73,7 @@ import asyncio
 import gzip
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -403,6 +404,13 @@ class HandlerMemoryArchive:
     # content which already compresses well.
     _ARCHIVE_COMPRESSION_LEVEL: int = 6
 
+    # Query timeout for database operations (seconds).
+    #
+    # This timeout applies to individual database queries (SELECT, UPDATE),
+    # not connection acquisition. It prevents indefinite blocking when the
+    # database is under heavy load or experiencing issues.
+    _QUERY_TIMEOUT_SECONDS: float = 30.0
+
     def __init__(
         self,
         db_pool: Pool | None = None,
@@ -481,6 +489,17 @@ class HandlerMemoryArchive:
                 memory_id=command.memory_id,
                 success=False,
                 error_message=str(e),
+            )
+        except TimeoutError as e:
+            logger.error(
+                "Query timeout reading memory %s: %s",
+                command.memory_id,
+                e,
+            )
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                error_message=f"Query timeout reading memory: {e}",
             )
 
         if memory is None:
@@ -634,9 +653,9 @@ class HandlerMemoryArchive:
                 error_message=f"Client error during state update: {e}",
             )
         except TimeoutError as e:
-            # Handle pool acquisition timeout (pool exhaustion)
+            # Handle pool acquisition or query timeout
             logger.error(
-                "Pool timeout updating state for memory %s: %s",
+                "Timeout updating state for memory %s: %s",
                 command.memory_id,
                 e,
             )
@@ -646,7 +665,7 @@ class HandlerMemoryArchive:
                 await self._orphan_tracker.track_orphan(
                     memory_id=command.memory_id,
                     archive_path=archive_path,
-                    reason="pool_timeout_during_state_update",
+                    reason="timeout_during_state_update",
                 )
 
             return ModelMemoryArchiveResult(
@@ -655,7 +674,7 @@ class HandlerMemoryArchive:
                 orphaned=True,
                 archive_path=archive_path,
                 bytes_written=bytes_written,
-                error_message=f"Pool timeout during state update: {e}",
+                error_message=f"Timeout during state update: {e}",
             )
 
         logger.info(
@@ -835,6 +854,7 @@ class HandlerMemoryArchive:
         Raises:
             RuntimeError: If database pool is not configured.
             ValueError: If memory is not found.
+            TimeoutError: If database query exceeds timeout.
         """
         if self._db_pool is None:
             raise RuntimeError(
@@ -843,21 +863,24 @@ class HandlerMemoryArchive:
             )
 
         async with self._db_pool.acquire() as conn:
-            row = await conn.fetchrow(
-                """
-                SELECT
-                    id,
-                    content,
-                    content_type,
-                    created_at,
-                    expired_at,
-                    lifecycle_state,
-                    lifecycle_revision,
-                    metadata
-                FROM memories
-                WHERE id = $1
-                """,
-                memory_id,
+            row = await asyncio.wait_for(
+                conn.fetchrow(
+                    """
+                    SELECT
+                        id,
+                        content,
+                        content_type,
+                        created_at,
+                        expired_at,
+                        lifecycle_state,
+                        lifecycle_revision,
+                        metadata
+                    FROM memories
+                    WHERE id = $1
+                    """,
+                    memory_id,
+                ),
+                timeout=self._QUERY_TIMEOUT_SECONDS,
             )
 
             if row is None:
@@ -914,6 +937,7 @@ class HandlerMemoryArchive:
 
         Raises:
             RuntimeError: If database pool is not configured.
+            TimeoutError: If database query exceeds timeout.
         """
         if self._db_pool is None:
             raise RuntimeError(
@@ -922,27 +946,38 @@ class HandlerMemoryArchive:
             )
 
         async with self._db_pool.acquire() as conn:
-            result = await conn.execute(
-                """
-                UPDATE memories
-                SET
-                    lifecycle_state = $1,
-                    lifecycle_revision = lifecycle_revision + 1,
-                    archived_at = $2,
-                    archive_path = $3,
-                    updated_at = $2
-                WHERE id = $4
-                  AND lifecycle_revision = $5
-                  AND lifecycle_state = $6
-                """,
-                EnumLifecycleState.ARCHIVED.value,
-                archived_at,
-                str(archive_path),
-                memory_id,
-                expected_revision,
-                EnumLifecycleState.EXPIRED.value,
+            result = await asyncio.wait_for(
+                conn.execute(
+                    """
+                    UPDATE memories
+                    SET
+                        lifecycle_state = $1,
+                        lifecycle_revision = lifecycle_revision + 1,
+                        archived_at = $2,
+                        archive_path = $3,
+                        updated_at = $2
+                    WHERE id = $4
+                      AND lifecycle_revision = $5
+                      AND lifecycle_state = $6
+                    """,
+                    EnumLifecycleState.ARCHIVED.value,
+                    archived_at,
+                    str(archive_path),
+                    memory_id,
+                    expected_revision,
+                    EnumLifecycleState.EXPIRED.value,
+                ),
+                timeout=self._QUERY_TIMEOUT_SECONDS,
             )
 
             # Check if update affected any rows
-            rows_affected = int(result.split()[-1])
+            match = re.match(r"UPDATE (\d+)", result)
+            if not match:
+                logger.error(
+                    "Unexpected execute result format for memory %s: %r",
+                    memory_id,
+                    result,
+                )
+                raise RuntimeError(f"Unexpected DB result format: {result}")
+            rows_affected = int(match.group(1))
             return rows_affected > 0

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -69,6 +69,7 @@ Example::
 
 from __future__ import annotations
 
+import asyncio
 import gzip
 import logging
 import os
@@ -85,6 +86,14 @@ from omnimemory.enums import EnumLifecycleState
 
 if TYPE_CHECKING:
     from asyncpg import Pool
+    from asyncpg.exceptions import PostgresError
+else:
+    try:
+        from asyncpg.exceptions import PostgresError
+    except ImportError:
+        # Fallback if asyncpg not installed - use base Exception
+        # This allows the module to be imported even without asyncpg
+        PostgresError = Exception  # type: ignore[misc,assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -555,9 +564,9 @@ class HandlerMemoryArchive:
                         "Archive file written but state not updated."
                     ),
                 )
-        except Exception as e:
+        except PostgresError as e:
             logger.error(
-                "Failed to update state for memory %s: %s",
+                "Database error updating state for memory %s: %s",
                 command.memory_id,
                 e,
             )
@@ -576,7 +585,32 @@ class HandlerMemoryArchive:
                 orphaned=True,
                 archive_path=archive_path,
                 bytes_written=bytes_written,
-                error_message=f"State update failed: {e}",
+                error_message=f"Database error during state update: {e}",
+            )
+        except (OSError, RuntimeError) as e:
+            # Handle connection-related errors that may not be PostgresError
+            # (e.g., pool exhaustion, connection timeout)
+            logger.error(
+                "Connection error updating state for memory %s: %s",
+                command.memory_id,
+                e,
+            )
+
+            # Track orphaned file if tracker configured
+            if self._orphan_tracker is not None:
+                await self._orphan_tracker.track_orphan(
+                    memory_id=command.memory_id,
+                    archive_path=archive_path,
+                    reason="connection_error_during_state_update",
+                )
+
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                orphaned=True,
+                archive_path=archive_path,
+                bytes_written=bytes_written,
+                error_message=f"Connection error during state update: {e}",
             )
 
         logger.info(
@@ -644,18 +678,21 @@ class HandlerMemoryArchive:
         jsonl_line = record.model_dump_json() + "\n"
         return gzip.compress(jsonl_line.encode("utf-8"), compresslevel=6)
 
-    async def _write_archive_atomic(
+    def _write_archive_sync(
         self,
         archive_path: Path,
         compressed_bytes: bytes,
     ) -> int:
-        """Write archive file atomically.
+        """Synchronous atomic write - runs in thread pool.
 
         Uses the temp file + rename pattern to ensure atomic writes:
         1. Create parent directories if needed
         2. Write to temporary file in same directory
         3. fsync to ensure durability
         4. Atomic rename to final path
+
+        This method performs blocking I/O and should be called via
+        asyncio.to_thread() from async contexts.
 
         Note: This will be replaced by omnibase_infra.write_atomic_bytes()
         when OMN-1524 is implemented.
@@ -702,6 +739,32 @@ class HandlerMemoryArchive:
             if temp_path_obj.exists():
                 temp_path_obj.unlink()
             raise
+
+    async def _write_archive_atomic(
+        self,
+        archive_path: Path,
+        compressed_bytes: bytes,
+    ) -> int:
+        """Write archive file atomically using thread pool.
+
+        Delegates to _write_archive_sync via asyncio.to_thread() to avoid
+        blocking the event loop during file I/O operations.
+
+        Args:
+            archive_path: Target path for the archive file.
+            compressed_bytes: Compressed archive data to write.
+
+        Returns:
+            Number of bytes written.
+
+        Raises:
+            OSError: If directory creation or file write fails.
+        """
+        return await asyncio.to_thread(
+            self._write_archive_sync,
+            archive_path,
+            compressed_bytes,
+        )
 
     async def _read_memory(
         self,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -84,6 +84,7 @@ from omnibase_core.models.metadata.model_generic_metadata import ModelGenericMet
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.enums import EnumLifecycleState
+from omnimemory.utils.concurrency import CircuitBreaker
 
 if TYPE_CHECKING:
     from asyncpg import Pool
@@ -227,6 +228,7 @@ class ModelMemoryArchiveResult(BaseModel):  # omnimemory-model-exempt: handler r
     """
 
     model_config = ConfigDict(
+        frozen=True,
         extra="forbid",
         strict=True,
     )
@@ -411,11 +413,22 @@ class HandlerMemoryArchive:
     # database is under heavy load or experiencing issues.
     _QUERY_TIMEOUT_SECONDS: float = 30.0
 
+    # Circuit breaker configuration defaults.
+    #
+    # These defaults balance responsiveness with stability:
+    # - failure_threshold=5: Opens after 5 consecutive failures
+    # - recovery_timeout=60: Waits 60s before attempting recovery
+    # - success_threshold=2: Requires 2 successes to fully close
+    _CB_FAILURE_THRESHOLD: int = 5
+    _CB_RECOVERY_TIMEOUT: float = 60.0
+    _CB_SUCCESS_THRESHOLD: int = 2
+
     def __init__(
         self,
         db_pool: Pool | None = None,
         archive_base_path: Path | None = None,
         orphan_tracker: ProtocolOrphanedArchiveTracker | None = None,
+        db_circuit_breaker: CircuitBreaker | None = None,
     ) -> None:
         """Initialize the archive handler.
 
@@ -430,9 +443,19 @@ class HandlerMemoryArchive:
                 If provided, will be called when an archive file is written
                 but the database state update fails. This enables monitoring
                 and cleanup of orphaned files.
+            db_circuit_breaker: Optional circuit breaker for database operations.
+                If not provided, a default circuit breaker is created.
+                Protects against cascading failures when database is unhealthy.
         """
         self._db_pool = db_pool
         self._orphan_tracker = orphan_tracker
+
+        # Initialize circuit breaker for DB operations
+        self._db_circuit_breaker = db_circuit_breaker or CircuitBreaker(
+            failure_threshold=self._CB_FAILURE_THRESHOLD,
+            recovery_timeout=self._CB_RECOVERY_TIMEOUT,
+            success_threshold=self._CB_SUCCESS_THRESHOLD,
+        )
 
         if archive_base_path is not None:
             self._archive_base_path = archive_base_path
@@ -441,16 +464,16 @@ class HandlerMemoryArchive:
             if env_path:
                 self._archive_base_path = Path(env_path)
                 logger.debug(
-                    "Using archive path from OMNIMEMORY_ARCHIVE_PATH: %s",
-                    self._archive_base_path,
+                    "Using archive path from OMNIMEMORY_ARCHIVE_PATH",
+                    extra={"archive_path": str(self._archive_base_path)},
                 )
             else:
                 self._archive_base_path = (
                     Path(tempfile.gettempdir()) / "omnimemory" / "archives"
                 )
                 logger.info(
-                    "OMNIMEMORY_ARCHIVE_PATH not set, using default archive path: %s",
-                    self._archive_base_path,
+                    "OMNIMEMORY_ARCHIVE_PATH not set, using default archive path",
+                    extra={"archive_path": str(self._archive_base_path)},
                 )
 
     @property
@@ -478,23 +501,48 @@ class HandlerMemoryArchive:
         """
         now = datetime.now(timezone.utc)
 
+        # Check circuit breaker before any DB operations
+        if not self._db_circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker open, rejecting archive request",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "circuit_state": self._db_circuit_breaker.state.value,
+                },
+            )
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                error_message=(
+                    "Database circuit breaker is open. "
+                    "Service is protecting against cascading failures."
+                ),
+            )
+
         # Step 1: Read memory content (with optimistic lock check)
         try:
             memory = await self._read_memory(
                 command.memory_id,
                 command.expected_revision,
             )
+            # Record successful DB read (only for non-None results from actual DB query)
+            if memory is not None:
+                self._db_circuit_breaker.record_success()
         except ValueError as e:
+            # ValueError indicates memory not found - this is not a DB failure
             return ModelMemoryArchiveResult(
                 memory_id=command.memory_id,
                 success=False,
                 error_message=str(e),
             )
         except TimeoutError as e:
+            self._db_circuit_breaker.record_timeout()
             logger.error(
-                "Query timeout reading memory %s: %s",
-                command.memory_id,
-                e,
+                "Query timeout reading memory",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "error": str(e),
+                },
             )
             return ModelMemoryArchiveResult(
                 memory_id=command.memory_id,
@@ -536,8 +584,8 @@ class HandlerMemoryArchive:
             metadata=memory.metadata,
         )
 
-        # Step 4: Serialize and compress
-        compressed_bytes = self._serialize_for_archive(record)
+        # Step 4: Serialize and compress (offloaded to thread pool for large payloads)
+        compressed_bytes = await self._serialize_for_archive_async(record)
 
         # Step 5: Determine archive path
         archive_path = command.archive_path or self._get_archive_path(
@@ -553,9 +601,13 @@ class HandlerMemoryArchive:
             )
         except OSError as e:
             logger.error(
-                "Failed to write archive for memory %s: %s",
-                command.memory_id,
-                e,
+                "Failed to write archive",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "archive_path": str(archive_path),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
             )
             return ModelMemoryArchiveResult(
                 memory_id=command.memory_id,
@@ -571,16 +623,22 @@ class HandlerMemoryArchive:
                 now,
                 archive_path,
             )
+            # Record successful DB operation
+            # Note: We record success even on revision conflict because
+            # the DB query itself succeeded - conflict is application logic
+            self._db_circuit_breaker.record_success()
+
             if not updated:
                 # Revision conflict during state update
                 # Note: Archive file was written but state not updated
                 # This is a known edge case - the file exists but memory
                 # may be re-archived. Idempotent archive format handles this.
                 logger.warning(
-                    "Revision conflict during state update for memory %s. "
-                    "Archive file written to %s but state not updated.",
-                    command.memory_id,
-                    archive_path,
+                    "Revision conflict during state update",
+                    extra={
+                        "memory_id": str(command.memory_id),
+                        "archive_path": str(archive_path),
+                    },
                 )
 
                 # Track orphaned file if tracker configured
@@ -604,10 +662,14 @@ class HandlerMemoryArchive:
                     ),
                 )
         except PostgresError as e:
+            self._db_circuit_breaker.record_failure()
             logger.error(
-                "Database error updating state for memory %s: %s",
-                command.memory_id,
-                e,
+                "Database error updating state",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
             )
 
             # Track orphaned file if tracker configured
@@ -630,10 +692,14 @@ class HandlerMemoryArchive:
             # Handle asyncpg client-side errors not covered by PostgresError:
             # - InterfaceError: Pool closing, connection already acquired, etc.
             # - InternalClientError: Protocol errors, schema cache issues, etc.
+            self._db_circuit_breaker.record_failure()
             logger.error(
-                "Client error updating state for memory %s: %s",
-                command.memory_id,
-                e,
+                "Client error updating state",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
             )
 
             # Track orphaned file if tracker configured
@@ -654,10 +720,13 @@ class HandlerMemoryArchive:
             )
         except TimeoutError as e:
             # Handle pool acquisition or query timeout
+            self._db_circuit_breaker.record_timeout()
             logger.error(
-                "Timeout updating state for memory %s: %s",
-                command.memory_id,
-                e,
+                "Timeout updating state",
+                extra={
+                    "memory_id": str(command.memory_id),
+                    "error": str(e),
+                },
             )
 
             # Track orphaned file if tracker configured
@@ -678,10 +747,13 @@ class HandlerMemoryArchive:
             )
 
         logger.info(
-            "Successfully archived memory %s to %s (%d bytes)",
-            command.memory_id,
-            archive_path,
-            bytes_written,
+            "Successfully archived memory",
+            extra={
+                "memory_id": str(command.memory_id),
+                "archive_path": str(archive_path),
+                "bytes_written": bytes_written,
+                "lifecycle_revision": command.expected_revision,
+            },
         )
 
         return ModelMemoryArchiveResult(
@@ -722,8 +794,12 @@ class HandlerMemoryArchive:
             / f"{memory_id}.jsonl.gz"
         )
 
-    def _serialize_for_archive(self, record: ModelArchiveRecord) -> bytes:
-        """Serialize record to compressed JSONL bytes.
+    def _serialize_for_archive_sync(self, record: ModelArchiveRecord) -> bytes:
+        """Serialize record to compressed JSONL bytes (synchronous).
+
+        This is a synchronous CPU-bound operation that performs gzip compression.
+        For large payloads, use _serialize_for_archive_async() to avoid blocking
+        the event loop.
 
         The domain owns the format decision (gzip + JSONL).
         Infrastructure will own atomic write mechanics (OMN-1524).
@@ -743,6 +819,26 @@ class HandlerMemoryArchive:
         return gzip.compress(
             jsonl_line.encode("utf-8"),
             compresslevel=self._ARCHIVE_COMPRESSION_LEVEL,
+        )
+
+    async def _serialize_for_archive_async(
+        self,
+        record: ModelArchiveRecord,
+    ) -> bytes:
+        """Serialize record to compressed JSONL bytes (async, non-blocking).
+
+        Offloads the CPU-bound gzip compression to a thread pool to avoid
+        blocking the event loop. This is recommended for large payloads.
+
+        Args:
+            record: The archive record to serialize.
+
+        Returns:
+            Gzip-compressed JSONL bytes.
+        """
+        return await asyncio.to_thread(
+            self._serialize_for_archive_sync,
+            record,
         )
 
     def _write_archive_sync(
@@ -798,13 +894,21 @@ class HandlerMemoryArchive:
 
             return len(compressed_bytes)
 
-        except Exception:
+        except (OSError, ValueError):
             # Cleanup temp file on failure
+            # OSError: covers all filesystem errors (write, fsync, rename, unlink)
+            # ValueError: invalid file descriptor operations
             if fd >= 0:
-                os.close(fd)
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass  # Ignore close errors during cleanup
             temp_path_obj = Path(temp_path)
-            if temp_path_obj.exists():
-                temp_path_obj.unlink()
+            try:
+                if temp_path_obj.exists():
+                    temp_path_obj.unlink()
+            except OSError:
+                pass  # Ignore unlink errors during cleanup
             raise
 
     async def _write_archive_atomic(
@@ -889,10 +993,12 @@ class HandlerMemoryArchive:
             # Check revision matches
             if row["lifecycle_revision"] != expected_revision:
                 logger.debug(
-                    "Revision mismatch for memory %s: expected %d, got %d",
-                    memory_id,
-                    expected_revision,
-                    row["lifecycle_revision"],
+                    "Revision mismatch for memory",
+                    extra={
+                        "memory_id": str(memory_id),
+                        "expected_revision": expected_revision,
+                        "actual_revision": row["lifecycle_revision"],
+                    },
                 )
                 return None
 
@@ -974,9 +1080,11 @@ class HandlerMemoryArchive:
             match = re.match(r"UPDATE (\d+)", result)
             if not match:
                 logger.error(
-                    "Unexpected execute result format for memory %s: %r",
-                    memory_id,
-                    result,
+                    "Unexpected execute result format",
+                    extra={
+                        "memory_id": str(memory_id),
+                        "result": repr(result),
+                    },
                 )
                 raise RuntimeError(f"Unexpected DB result format: {result}")
             rows_affected = int(match.group(1))

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -70,7 +70,7 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -79,6 +79,9 @@ from omnimemory.enums import EnumLifecycleState
 
 if TYPE_CHECKING:
     from asyncpg import Pool
+
+# Type alias for JSON-compatible metadata values (zero Any types policy)
+JsonValue = str | int | float | bool | None
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +244,7 @@ class ModelArchiveRecord(BaseModel):  # omnimemory-model-exempt: archive record 
         default="1.0",
         description="Schema version for archive format migrations",
     )
-    metadata: dict[str, Any] | None = Field(
+    metadata: dict[str, JsonValue] | None = Field(
         default=None,
         description="Optional additional metadata from the memory",
     )
@@ -266,7 +269,7 @@ class ModelMemoryRow(BaseModel):  # omnimemory-model-exempt: handler internal
     expired_at: datetime | None
     lifecycle_state: EnumLifecycleState
     lifecycle_revision: int
-    metadata: dict[str, Any] | None = None
+    metadata: dict[str, JsonValue] | None = None
 
 
 class HandlerMemoryArchive:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -39,9 +39,14 @@ Example::
     from pathlib import Path
     from uuid import UUID
 
+    # Option 1: Use OMNIMEMORY_ARCHIVE_PATH environment variable (recommended)
+    # export OMNIMEMORY_ARCHIVE_PATH=/var/omnimemory/archives
+    handler = HandlerMemoryArchive(db_pool=pool)
+
+    # Option 2: Explicit path (useful for testing)
     handler = HandlerMemoryArchive(
         db_pool=pool,
-        archive_base_path=Path("/var/omnimemory/archives"),
+        archive_base_path=Path("/custom/archive/path"),
     )
 
     command = ModelArchiveMemoryCommand(
@@ -70,7 +75,7 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -90,7 +95,65 @@ __all__ = [
     "ModelArchiveMemoryCommand",
     "ModelArchiveRecord",
     "ModelMemoryArchiveResult",
+    "ProtocolOrphanedArchiveTracker",
 ]
+
+
+@runtime_checkable
+class ProtocolOrphanedArchiveTracker(Protocol):
+    """Protocol for tracking orphaned archive files.
+
+    An orphaned archive file occurs when the archive is successfully written
+    to disk but the database state update fails (e.g., due to revision conflict
+    or database error). These files exist on disk but are not tracked in the
+    database, requiring periodic cleanup.
+
+    Implementations of this protocol can:
+    - Log orphaned files for later cleanup
+    - Store in a dedicated cleanup queue
+    - Send alerts for immediate investigation
+    - Track metrics on orphan frequency
+
+    Example::
+
+        class FileOrphanTracker:
+            async def track_orphan(
+                self,
+                memory_id: UUID,
+                archive_path: Path,
+                reason: str,
+            ) -> None:
+                with open("/var/log/orphans.jsonl", "a") as f:
+                    f.write(json.dumps({
+                        "memory_id": str(memory_id),
+                        "archive_path": str(archive_path),
+                        "reason": reason,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }) + "\\n")
+
+    .. versionadded:: 0.1.0
+        Added for orphan tracking in OMN-1453.
+    """
+
+    async def track_orphan(
+        self,
+        memory_id: UUID,
+        archive_path: Path,
+        reason: str,
+    ) -> None:
+        """Track an orphaned archive file for later cleanup.
+
+        Called when an archive file is written but the database state
+        cannot be updated, leaving the file orphaned.
+
+        Args:
+            memory_id: UUID of the memory that was archived.
+            archive_path: Filesystem path where the orphaned archive exists.
+            reason: Description of why the file was orphaned (e.g.,
+                "revision_conflict_during_state_update" or
+                "database_error_during_state_update").
+        """
+        ...
 
 
 class ModelArchiveMemoryCommand(BaseModel):  # omnimemory-model-exempt: handler command
@@ -144,6 +207,8 @@ class ModelMemoryArchiveResult(BaseModel):  # omnimemory-model-exempt: handler r
         archive_path: Filesystem path where the archive was written.
         bytes_written: Number of compressed bytes written to the archive.
         conflict: True if a revision conflict prevented archival.
+        orphaned: True if an archive file was written but database state
+            update failed, leaving an orphaned file on disk.
         error_message: Human-readable error description if failed.
     """
 
@@ -176,6 +241,10 @@ class ModelMemoryArchiveResult(BaseModel):  # omnimemory-model-exempt: handler r
     conflict: bool = Field(
         default=False,
         description="True if revision conflict prevented archival",
+    )
+    orphaned: bool = Field(
+        default=False,
+        description="True if archive file was written but DB state update failed",
     )
     error_message: str | None = Field(
         default=None,
@@ -310,7 +379,8 @@ class HandlerMemoryArchive:
     def __init__(
         self,
         db_pool: Pool | None = None,
-        archive_base_path: Path = Path("/var/omnimemory/archives"),
+        archive_base_path: Path | None = None,
+        orphan_tracker: ProtocolOrphanedArchiveTracker | None = None,
     ) -> None:
         """Initialize the archive handler.
 
@@ -318,10 +388,35 @@ class HandlerMemoryArchive:
             db_pool: PostgreSQL connection pool for database operations.
                 If None, database operations will raise RuntimeError.
             archive_base_path: Base directory for archive storage.
+                If None, reads from OMNIMEMORY_ARCHIVE_PATH environment variable.
+                If env var not set, falls back to {tempdir}/omnimemory/archives.
                 Directories are created on-demand during archive operations.
+            orphan_tracker: Optional tracker for orphaned archive files.
+                If provided, will be called when an archive file is written
+                but the database state update fails. This enables monitoring
+                and cleanup of orphaned files.
         """
         self._db_pool = db_pool
-        self._archive_base_path = archive_base_path
+        self._orphan_tracker = orphan_tracker
+
+        if archive_base_path is not None:
+            self._archive_base_path = archive_base_path
+        else:
+            env_path = os.environ.get("OMNIMEMORY_ARCHIVE_PATH")
+            if env_path:
+                self._archive_base_path = Path(env_path)
+                logger.debug(
+                    "Using archive path from OMNIMEMORY_ARCHIVE_PATH: %s",
+                    self._archive_base_path,
+                )
+            else:
+                self._archive_base_path = (
+                    Path(tempfile.gettempdir()) / "omnimemory" / "archives"
+                )
+                logger.info(
+                    "OMNIMEMORY_ARCHIVE_PATH not set, using default archive path: %s",
+                    self._archive_base_path,
+                )
 
     @property
     def archive_base_path(self) -> Path:
@@ -441,10 +536,20 @@ class HandlerMemoryArchive:
                     command.memory_id,
                     archive_path,
                 )
+
+                # Track orphaned file if tracker configured
+                if self._orphan_tracker is not None:
+                    await self._orphan_tracker.track_orphan(
+                        memory_id=command.memory_id,
+                        archive_path=archive_path,
+                        reason="revision_conflict_during_state_update",
+                    )
+
                 return ModelMemoryArchiveResult(
                     memory_id=command.memory_id,
                     success=False,
                     conflict=True,
+                    orphaned=True,
                     archive_path=archive_path,
                     bytes_written=bytes_written,
                     error_message=(
@@ -458,9 +563,19 @@ class HandlerMemoryArchive:
                 command.memory_id,
                 e,
             )
+
+            # Track orphaned file if tracker configured
+            if self._orphan_tracker is not None:
+                await self._orphan_tracker.track_orphan(
+                    memory_id=command.memory_id,
+                    archive_path=archive_path,
+                    reason="database_error_during_state_update",
+                )
+
             return ModelMemoryArchiveResult(
                 memory_id=command.memory_id,
                 success=False,
+                orphaned=True,
                 archive_path=archive_path,
                 bytes_written=bytes_written,
                 error_message=f"State update failed: {e}",

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -1,0 +1,715 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Handler for archiving memories to cold storage.
+
+This module provides the HandlerMemoryArchive handler that moves EXPIRED
+memories to filesystem archive with atomic writes and gzip compression.
+
+Archive Format:
+    - Format: JSONL (JSON Lines) with gzip compression (.jsonl.gz)
+    - Partitioning: Date-based directory structure ({base}/{year}/{month}/{day}/)
+    - Naming: {memory_id}.jsonl.gz
+
+Atomic Write Pattern:
+    The handler uses atomic writes to prevent partial/corrupt archives:
+    1. Write compressed data to temporary file
+    2. fsync to ensure durability
+    3. Atomic rename to final path
+
+    Note: Atomic write mechanics will be provided by OMN-1524 (infra primitive).
+    Until then, this handler uses a local implementation.
+
+Optimistic Locking:
+    Uses expected_revision to prevent double-archive race conditions:
+    1. Read memory with current revision
+    2. Archive to filesystem
+    3. Update DB state only if revision unchanged
+    4. Return conflict=True if revision mismatch
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+    - OMN-1524: Atomic write primitive (pending)
+
+Example::
+
+    from omnimemory.nodes.memory_lifecycle_orchestrator.handlers import (
+        HandlerMemoryArchive,
+        ModelArchiveMemoryCommand,
+    )
+    from pathlib import Path
+    from uuid import UUID
+
+    handler = HandlerMemoryArchive(
+        db_pool=pool,
+        archive_base_path=Path("/var/omnimemory/archives"),
+    )
+
+    command = ModelArchiveMemoryCommand(
+        memory_id=UUID("abc12345-..."),
+        expected_revision=5,
+        archive_path=Path("/var/omnimemory/archives/2026/01/25/abc12345.jsonl.gz"),
+    )
+
+    result = await handler.handle(command)
+    if result.success:
+        print(f"Archived to {result.archive_path} ({result.bytes_written} bytes)")
+    elif result.conflict:
+        print("Revision conflict - memory was modified")
+    else:
+        print(f"Archive failed: {result.error_message}")
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums import EnumLifecycleState
+
+if TYPE_CHECKING:
+    from asyncpg import Pool
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HandlerMemoryArchive",
+    "ModelArchiveMemoryCommand",
+    "ModelArchiveRecord",
+    "ModelMemoryArchiveResult",
+]
+
+
+class ModelArchiveMemoryCommand(BaseModel):  # omnimemory-model-exempt: handler command
+    """Command to archive a memory to cold storage.
+
+    This command initiates the archival process for a specific memory entity.
+    The expected_revision field enables optimistic locking to prevent race
+    conditions during concurrent archive attempts.
+
+    Attributes:
+        memory_id: UUID of the memory entity to archive.
+        expected_revision: Expected lifecycle revision for optimistic lock.
+            If the actual revision differs, the archive operation fails
+            with conflict=True to prevent double-archive.
+        archive_path: Target filesystem path for the archive file.
+            If not provided, the handler generates a path using date-based
+            partitioning.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="ID of memory to archive",
+    )
+    expected_revision: int = Field(
+        ...,
+        ge=0,
+        description="Expected revision for optimistic lock",
+    )
+    archive_path: Path | None = Field(
+        default=None,
+        description="Optional target archive file path (auto-generated if not provided)",
+    )
+
+
+class ModelMemoryArchiveResult(BaseModel):  # omnimemory-model-exempt: handler result
+    """Result of an archive operation.
+
+    Contains detailed information about the archive attempt, including
+    success status, file location, and any error details.
+
+    Attributes:
+        memory_id: UUID of the archived memory.
+        success: Whether the archive operation completed successfully.
+        archived_at: Timestamp when the archive was created.
+        archive_path: Filesystem path where the archive was written.
+        bytes_written: Number of compressed bytes written to the archive.
+        conflict: True if a revision conflict prevented archival.
+        error_message: Human-readable error description if failed.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="ID of the archived memory",
+    )
+    success: bool = Field(
+        ...,
+        description="Whether the archive operation succeeded",
+    )
+    archived_at: datetime | None = Field(
+        default=None,
+        description="Timestamp of successful archive",
+    )
+    archive_path: Path | None = Field(
+        default=None,
+        description="Path to the archive file",
+    )
+    bytes_written: int = Field(
+        default=0,
+        ge=0,
+        description="Number of compressed bytes written",
+    )
+    conflict: bool = Field(
+        default=False,
+        description="True if revision conflict prevented archival",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error details if archive failed",
+    )
+
+
+class ModelArchiveRecord(BaseModel):  # omnimemory-model-exempt: archive record format
+    """Record format for archived memory.
+
+    This model defines the schema for archived memory records. Each archive
+    file contains one JSONL record (one JSON object per line), compressed
+    with gzip.
+
+    The archive_version field enables future schema migrations while
+    maintaining backwards compatibility with existing archives.
+
+    Attributes:
+        memory_id: UUID of the archived memory.
+        content: The memory content (text, structured data, etc.).
+        content_type: MIME type or content classification.
+        created_at: When the memory was originally created.
+        expired_at: When the memory transitioned to EXPIRED state.
+        archived_at: When the memory was archived to cold storage.
+        lifecycle_revision: The revision number at time of archival.
+        archive_version: Schema version for archive format migrations.
+        metadata: Optional additional metadata from the memory.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="UUID of the archived memory",
+    )
+    content: str = Field(
+        ...,
+        description="The memory content",
+    )
+    content_type: str = Field(
+        ...,
+        description="MIME type or content classification",
+    )
+    created_at: datetime = Field(
+        ...,
+        description="When the memory was originally created",
+    )
+    expired_at: datetime = Field(
+        ...,
+        description="When the memory transitioned to EXPIRED state",
+    )
+    archived_at: datetime = Field(
+        ...,
+        description="When the memory was archived to cold storage",
+    )
+    lifecycle_revision: int = Field(
+        ...,
+        ge=0,
+        description="The revision number at time of archival",
+    )
+    archive_version: str = Field(
+        default="1.0",
+        description="Schema version for archive format migrations",
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional additional metadata from the memory",
+    )
+
+
+class ModelMemoryRow(BaseModel):  # omnimemory-model-exempt: handler internal
+    """Internal model for memory row data from database.
+
+    Used internally by the handler to represent memory data fetched
+    from the database before archival.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        strict=True,
+    )
+
+    id: UUID
+    content: str
+    content_type: str
+    created_at: datetime
+    expired_at: datetime | None
+    lifecycle_state: EnumLifecycleState
+    lifecycle_revision: int
+    metadata: dict[str, Any] | None = None
+
+
+class HandlerMemoryArchive:
+    """Handler for archiving memories to cold storage.
+
+    This handler performs the complete archival workflow:
+
+    1. **Read memory content** from database with optimistic lock check
+    2. **Validate state** - only EXPIRED memories can be archived
+    3. **Serialize** to archive format (JSONL)
+    4. **Compress** with gzip (domain decision - compression format owned here)
+    5. **Write atomically** (temp file + rename) - uses infra primitive
+    6. **Update database** state: EXPIRED -> ARCHIVED
+
+    Archive Directory Structure::
+
+        {archive_base_path}/
+            2026/
+                01/
+                    25/
+                        {memory_id_1}.jsonl.gz
+                        {memory_id_2}.jsonl.gz
+                    26/
+                        {memory_id_3}.jsonl.gz
+
+    Thread Safety:
+        This handler is stateless and safe for concurrent use. Each archive
+        operation is independent and uses optimistic locking to handle races.
+
+    Attributes:
+        archive_base_path: Base directory for archive storage.
+
+    Note:
+        Atomic write mechanics will be provided by OMN-1524 (infra primitive).
+        The current implementation uses a local atomic write pattern.
+    """
+
+    def __init__(
+        self,
+        db_pool: Pool | None = None,
+        archive_base_path: Path = Path("/var/omnimemory/archives"),
+    ) -> None:
+        """Initialize the archive handler.
+
+        Args:
+            db_pool: PostgreSQL connection pool for database operations.
+                If None, database operations will raise RuntimeError.
+            archive_base_path: Base directory for archive storage.
+                Directories are created on-demand during archive operations.
+        """
+        self._db_pool = db_pool
+        self._archive_base_path = archive_base_path
+
+    @property
+    def archive_base_path(self) -> Path:
+        """Get the base path for archives."""
+        return self._archive_base_path
+
+    async def handle(
+        self,
+        command: ModelArchiveMemoryCommand,
+    ) -> ModelMemoryArchiveResult:
+        """Handle an archive command.
+
+        Performs the complete archival workflow with optimistic locking
+        to prevent race conditions.
+
+        Args:
+            command: Archive command with memory ID and expected revision.
+
+        Returns:
+            Result indicating success, conflict, or failure with details.
+
+        Raises:
+            RuntimeError: If database pool is not configured.
+        """
+        now = datetime.now(timezone.utc)
+
+        # Step 1: Read memory content (with optimistic lock check)
+        try:
+            memory = await self._read_memory(
+                command.memory_id,
+                command.expected_revision,
+            )
+        except ValueError as e:
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                error_message=str(e),
+            )
+
+        if memory is None:
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                conflict=True,
+                error_message=(
+                    f"Revision conflict: expected {command.expected_revision}, "
+                    "memory was modified or not found"
+                ),
+            )
+
+        # Step 2: Validate state - only EXPIRED memories can be archived
+        if memory.lifecycle_state != EnumLifecycleState.EXPIRED:
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                error_message=(
+                    f"Cannot archive memory in state {memory.lifecycle_state.value}. "
+                    "Only EXPIRED memories can be archived."
+                ),
+            )
+
+        # Step 3: Build archive record
+        record = ModelArchiveRecord(
+            memory_id=memory.id,
+            content=memory.content,
+            content_type=memory.content_type,
+            created_at=memory.created_at,
+            expired_at=memory.expired_at or now,  # Fallback if not set
+            archived_at=now,
+            lifecycle_revision=memory.lifecycle_revision,
+            metadata=memory.metadata,
+        )
+
+        # Step 4: Serialize and compress
+        compressed_bytes = self._serialize_for_archive(record)
+
+        # Step 5: Determine archive path
+        archive_path = command.archive_path or self._get_archive_path(
+            command.memory_id,
+            now,
+        )
+
+        # Step 6: Write atomically
+        try:
+            bytes_written = await self._write_archive_atomic(
+                archive_path,
+                compressed_bytes,
+            )
+        except OSError as e:
+            logger.error(
+                "Failed to write archive for memory %s: %s",
+                command.memory_id,
+                e,
+            )
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                error_message=f"Archive write failed: {e}",
+            )
+
+        # Step 7: Update database state
+        try:
+            updated = await self._mark_archived(
+                command.memory_id,
+                command.expected_revision,
+                now,
+                archive_path,
+            )
+            if not updated:
+                # Revision conflict during state update
+                # Note: Archive file was written but state not updated
+                # This is a known edge case - the file exists but memory
+                # may be re-archived. Idempotent archive format handles this.
+                logger.warning(
+                    "Revision conflict during state update for memory %s. "
+                    "Archive file written to %s but state not updated.",
+                    command.memory_id,
+                    archive_path,
+                )
+                return ModelMemoryArchiveResult(
+                    memory_id=command.memory_id,
+                    success=False,
+                    conflict=True,
+                    archive_path=archive_path,
+                    bytes_written=bytes_written,
+                    error_message=(
+                        "Revision conflict during state update. "
+                        "Archive file written but state not updated."
+                    ),
+                )
+        except Exception as e:
+            logger.error(
+                "Failed to update state for memory %s: %s",
+                command.memory_id,
+                e,
+            )
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                archive_path=archive_path,
+                bytes_written=bytes_written,
+                error_message=f"State update failed: {e}",
+            )
+
+        logger.info(
+            "Successfully archived memory %s to %s (%d bytes)",
+            command.memory_id,
+            archive_path,
+            bytes_written,
+        )
+
+        return ModelMemoryArchiveResult(
+            memory_id=command.memory_id,
+            success=True,
+            archived_at=now,
+            archive_path=archive_path,
+            bytes_written=bytes_written,
+        )
+
+    def _get_archive_path(self, memory_id: UUID, archived_at: datetime) -> Path:
+        """Generate archive path with date-based partitioning.
+
+        Creates a hierarchical directory structure based on the archive date
+        to enable efficient browsing and cleanup of old archives.
+
+        Pattern: {base}/{year}/{month:02d}/{day:02d}/{memory_id}.jsonl.gz
+
+        Args:
+            memory_id: UUID of the memory being archived.
+            archived_at: Timestamp of the archive operation.
+
+        Returns:
+            Path to the archive file.
+
+        Example:
+            >>> handler._get_archive_path(
+            ...     UUID("abc12345-..."),
+            ...     datetime(2026, 1, 25, 10, 30, 0),
+            ... )
+            Path("/var/omnimemory/archives/2026/01/25/abc12345-....jsonl.gz")
+        """
+        return (
+            self._archive_base_path
+            / str(archived_at.year)
+            / f"{archived_at.month:02d}"
+            / f"{archived_at.day:02d}"
+            / f"{memory_id}.jsonl.gz"
+        )
+
+    def _serialize_for_archive(self, record: ModelArchiveRecord) -> bytes:
+        """Serialize record to compressed JSONL bytes.
+
+        The domain owns the format decision (gzip + JSONL).
+        Infrastructure will own atomic write mechanics (OMN-1524).
+
+        Compression is applied here because:
+        1. Archive format is a domain decision
+        2. Compression ratio for JSON is significant (typically 5-10x)
+        3. Keeping compression in domain allows format-specific optimization
+
+        Args:
+            record: The archive record to serialize.
+
+        Returns:
+            Gzip-compressed JSONL bytes.
+        """
+        jsonl_line = record.model_dump_json() + "\n"
+        return gzip.compress(jsonl_line.encode("utf-8"), compresslevel=6)
+
+    async def _write_archive_atomic(
+        self,
+        archive_path: Path,
+        compressed_bytes: bytes,
+    ) -> int:
+        """Write archive file atomically.
+
+        Uses the temp file + rename pattern to ensure atomic writes:
+        1. Create parent directories if needed
+        2. Write to temporary file in same directory
+        3. fsync to ensure durability
+        4. Atomic rename to final path
+
+        Note: This will be replaced by omnibase_infra.write_atomic_bytes()
+        when OMN-1524 is implemented.
+
+        Args:
+            archive_path: Target path for the archive file.
+            compressed_bytes: Compressed archive data to write.
+
+        Returns:
+            Number of bytes written.
+
+        Raises:
+            OSError: If directory creation or file write fails.
+        """
+        # Ensure parent directory exists
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write to temp file, then atomic rename
+        # Using same directory ensures rename is atomic (same filesystem)
+        fd, temp_path = tempfile.mkstemp(
+            suffix=".tmp",
+            prefix=f"{archive_path.stem}.",
+            dir=archive_path.parent,
+        )
+
+        try:
+            # Write compressed data
+            os.write(fd, compressed_bytes)
+            # Ensure data is flushed to disk
+            os.fsync(fd)
+            os.close(fd)
+            fd = -1  # Mark as closed
+
+            # Atomic rename
+            Path(temp_path).rename(archive_path)
+
+            return len(compressed_bytes)
+
+        except Exception:
+            # Cleanup temp file on failure
+            if fd >= 0:
+                os.close(fd)
+            temp_path_obj = Path(temp_path)
+            if temp_path_obj.exists():
+                temp_path_obj.unlink()
+            raise
+
+    async def _read_memory(
+        self,
+        memory_id: UUID,
+        expected_revision: int,
+    ) -> ModelMemoryRow | None:
+        """Read memory from database with optimistic lock check.
+
+        Fetches the memory entity and validates that its revision matches
+        the expected revision. Returns None if the revision doesn't match,
+        indicating a concurrent modification.
+
+        Args:
+            memory_id: UUID of the memory to read.
+            expected_revision: Expected lifecycle_revision value.
+
+        Returns:
+            Memory row if found and revision matches, None otherwise.
+
+        Raises:
+            RuntimeError: If database pool is not configured.
+            ValueError: If memory is not found.
+        """
+        if self._db_pool is None:
+            raise RuntimeError(
+                "Database pool not configured. "
+                "Initialize handler with db_pool parameter."
+            )
+
+        async with self._db_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT
+                    id,
+                    content,
+                    content_type,
+                    created_at,
+                    expired_at,
+                    lifecycle_state,
+                    lifecycle_revision,
+                    metadata
+                FROM memories
+                WHERE id = $1
+                """,
+                memory_id,
+            )
+
+            if row is None:
+                raise ValueError(f"Memory {memory_id} not found")
+
+            # Check revision matches
+            if row["lifecycle_revision"] != expected_revision:
+                logger.debug(
+                    "Revision mismatch for memory %s: expected %d, got %d",
+                    memory_id,
+                    expected_revision,
+                    row["lifecycle_revision"],
+                )
+                return None
+
+            return ModelMemoryRow(
+                id=row["id"],
+                content=row["content"],
+                content_type=row["content_type"],
+                created_at=row["created_at"],
+                expired_at=row["expired_at"],
+                lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
+                lifecycle_revision=row["lifecycle_revision"],
+                metadata=row["metadata"],
+            )
+
+    async def _mark_archived(
+        self,
+        memory_id: UUID,
+        expected_revision: int,
+        archived_at: datetime,
+        archive_path: Path,
+    ) -> bool:
+        """Update memory state to ARCHIVED with optimistic locking.
+
+        Performs an atomic update that only succeeds if the current
+        revision matches the expected revision. Increments the revision
+        on successful update.
+
+        Args:
+            memory_id: UUID of the memory to update.
+            expected_revision: Expected current revision (optimistic lock).
+            archived_at: Timestamp of the archive operation.
+            archive_path: Path where the archive was written.
+
+        Returns:
+            True if update succeeded, False if revision conflict.
+
+        Raises:
+            RuntimeError: If database pool is not configured.
+        """
+        if self._db_pool is None:
+            raise RuntimeError(
+                "Database pool not configured. "
+                "Initialize handler with db_pool parameter."
+            )
+
+        async with self._db_pool.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE memories
+                SET
+                    lifecycle_state = $1,
+                    lifecycle_revision = lifecycle_revision + 1,
+                    archived_at = $2,
+                    archive_path = $3,
+                    updated_at = $2
+                WHERE id = $4
+                  AND lifecycle_revision = $5
+                  AND lifecycle_state = $6
+                """,
+                EnumLifecycleState.ARCHIVED.value,
+                archived_at,
+                str(archive_path),
+                memory_id,
+                expected_revision,
+                EnumLifecycleState.EXPIRED.value,
+            )
+
+            # Check if update affected any rows
+            rows_affected = int(result.split()[-1])
+            return rows_affected > 0

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -78,15 +78,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from uuid import UUID
 
+from omnibase_core.models.metadata.model_generic_metadata import ModelGenericMetadata
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.enums import EnumLifecycleState
 
 if TYPE_CHECKING:
     from asyncpg import Pool
-
-# Type alias for JSON-compatible metadata values (zero Any types policy)
-JsonValue = str | int | float | bool | None
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +311,7 @@ class ModelArchiveRecord(BaseModel):  # omnimemory-model-exempt: archive record 
         default="1.0",
         description="Schema version for archive format migrations",
     )
-    metadata: dict[str, JsonValue] | None = Field(
+    metadata: ModelGenericMetadata | None = Field(
         default=None,
         description="Optional additional metadata from the memory",
     )
@@ -338,7 +336,7 @@ class ModelMemoryRow(BaseModel):  # omnimemory-model-exempt: handler internal
     expired_at: datetime | None
     lifecycle_state: EnumLifecycleState
     lifecycle_revision: int
-    metadata: dict[str, JsonValue] | None = None
+    metadata: ModelGenericMetadata | None = None
 
 
 class HandlerMemoryArchive:
@@ -764,6 +762,12 @@ class HandlerMemoryArchive:
                 )
                 return None
 
+            # Convert raw metadata dict to ModelGenericMetadata if present
+            raw_metadata = row["metadata"]
+            metadata: ModelGenericMetadata | None = None
+            if raw_metadata is not None:
+                metadata = ModelGenericMetadata.model_validate(raw_metadata)
+
             return ModelMemoryRow(
                 id=row["id"],
                 content=row["content"],
@@ -772,7 +776,7 @@ class HandlerMemoryArchive:
                 expired_at=row["expired_at"],
                 lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
                 lifecycle_revision=row["lifecycle_revision"],
-                metadata=row["metadata"],
+                metadata=metadata,
             )
 
     async def _mark_archived(

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -86,14 +86,20 @@ from omnimemory.enums import EnumLifecycleState
 
 if TYPE_CHECKING:
     from asyncpg import Pool
-    from asyncpg.exceptions import PostgresError
+    from asyncpg.exceptions import InterfaceError, InternalClientError, PostgresError
 else:
     try:
-        from asyncpg.exceptions import PostgresError
+        from asyncpg.exceptions import (
+            InterfaceError,
+            InternalClientError,
+            PostgresError,
+        )
     except ImportError:
         # Fallback if asyncpg not installed - use base Exception
         # This allows the module to be imported even without asyncpg
         PostgresError = Exception  # type: ignore[misc,assignment]
+        InterfaceError = Exception  # type: ignore[misc,assignment]
+        InternalClientError = Exception  # type: ignore[misc,assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -383,6 +389,20 @@ class HandlerMemoryArchive:
         The current implementation uses a local atomic write pattern.
     """
 
+    # Gzip compression level for archive files (valid range: 1-9).
+    #
+    # Level 6 is the gzip default and provides an optimal balance between
+    # compression ratio and CPU time for archive storage workloads:
+    #   - Levels 1-3: Faster compression but lower ratio (~20-30% savings)
+    #   - Level 6: Balanced - good ratio (~60-70% savings) with moderate CPU
+    #   - Levels 7-9: Higher ratio (~70-75% savings) but significantly slower
+    #
+    # For cold storage archives where read latency is acceptable and storage
+    # cost matters, level 6 optimizes throughput while maintaining substantial
+    # space savings. Higher levels provide diminishing returns for JSON/JSONL
+    # content which already compresses well.
+    _ARCHIVE_COMPRESSION_LEVEL: int = 6
+
     def __init__(
         self,
         db_pool: Pool | None = None,
@@ -587,11 +607,12 @@ class HandlerMemoryArchive:
                 bytes_written=bytes_written,
                 error_message=f"Database error during state update: {e}",
             )
-        except (OSError, RuntimeError) as e:
-            # Handle connection-related errors that may not be PostgresError
-            # (e.g., pool exhaustion, connection timeout)
+        except (InterfaceError, InternalClientError) as e:
+            # Handle asyncpg client-side errors not covered by PostgresError:
+            # - InterfaceError: Pool closing, connection already acquired, etc.
+            # - InternalClientError: Protocol errors, schema cache issues, etc.
             logger.error(
-                "Connection error updating state for memory %s: %s",
+                "Client error updating state for memory %s: %s",
                 command.memory_id,
                 e,
             )
@@ -601,7 +622,7 @@ class HandlerMemoryArchive:
                 await self._orphan_tracker.track_orphan(
                     memory_id=command.memory_id,
                     archive_path=archive_path,
-                    reason="connection_error_during_state_update",
+                    reason="client_error_during_state_update",
                 )
 
             return ModelMemoryArchiveResult(
@@ -610,7 +631,31 @@ class HandlerMemoryArchive:
                 orphaned=True,
                 archive_path=archive_path,
                 bytes_written=bytes_written,
-                error_message=f"Connection error during state update: {e}",
+                error_message=f"Client error during state update: {e}",
+            )
+        except TimeoutError as e:
+            # Handle pool acquisition timeout (pool exhaustion)
+            logger.error(
+                "Pool timeout updating state for memory %s: %s",
+                command.memory_id,
+                e,
+            )
+
+            # Track orphaned file if tracker configured
+            if self._orphan_tracker is not None:
+                await self._orphan_tracker.track_orphan(
+                    memory_id=command.memory_id,
+                    archive_path=archive_path,
+                    reason="pool_timeout_during_state_update",
+                )
+
+            return ModelMemoryArchiveResult(
+                memory_id=command.memory_id,
+                success=False,
+                orphaned=True,
+                archive_path=archive_path,
+                bytes_written=bytes_written,
+                error_message=f"Pool timeout during state update: {e}",
             )
 
         logger.info(
@@ -676,7 +721,10 @@ class HandlerMemoryArchive:
             Gzip-compressed JSONL bytes.
         """
         jsonl_line = record.model_dump_json() + "\n"
-        return gzip.compress(jsonl_line.encode("utf-8"), compresslevel=6)
+        return gzip.compress(
+            jsonl_line.encode("utf-8"),
+            compresslevel=self._ARCHIVE_COMPRESSION_LEVEL,
+        )
 
     def _write_archive_sync(
         self,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -65,7 +65,7 @@ Example::
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -329,9 +329,6 @@ class HandlerMemoryExpire:
             will be implemented when OMN-1524 provides transaction helpers.
             The current implementation returns success for testing the interface.
         """
-        # Note: `now` will be used for database operations in OMN-1524
-        _now = command.expired_at or datetime.now(timezone.utc)
-
         # Log the operation for observability
         logger.info(
             "Expiring memory %s (expected_revision=%d, reason=%s)",

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -64,6 +64,7 @@ Example::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -85,6 +86,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from omnimemory.enums import EnumLifecycleState
 
 logger = logging.getLogger(__name__)
+
+# Query timeout for database operations (seconds)
+_QUERY_TIMEOUT_SECONDS: float = 30.0
 
 __all__ = [
     "HandlerMemoryExpire",
@@ -351,14 +355,17 @@ class HandlerMemoryExpire:
 
         try:
             async with self._db_pool.acquire() as conn:
-                row = await conn.fetchrow(
-                    self._EXPIRE_SQL,
-                    EnumLifecycleState.EXPIRED.value,  # $1: new state
-                    expired_at,  # $2: expired_at
-                    expired_at,  # $3: updated_at
-                    command.memory_id,  # $4: id
-                    command.expected_revision,  # $5: expected revision
-                    EnumLifecycleState.ACTIVE.value,  # $6: required current state
+                row = await asyncio.wait_for(
+                    conn.fetchrow(
+                        self._EXPIRE_SQL,
+                        EnumLifecycleState.EXPIRED.value,  # $1: new state
+                        expired_at,  # $2: expired_at
+                        expired_at,  # $3: updated_at
+                        command.memory_id,  # $4: id
+                        command.expected_revision,  # $5: expected revision
+                        EnumLifecycleState.ACTIVE.value,  # $6: required current state
+                    ),
+                    timeout=_QUERY_TIMEOUT_SECONDS,
                 )
 
                 if row is None:
@@ -406,6 +413,17 @@ class HandlerMemoryExpire:
                     previous_state=EnumLifecycleState.ACTIVE,
                 )
 
+        except TimeoutError:
+            logger.error(
+                "Database query timeout for memory %s",
+                command.memory_id,
+            )
+            return ModelMemoryExpireResult(
+                memory_id=command.memory_id,
+                success=False,
+                conflict=False,
+                error_message="Database query timeout",
+            )
         except PostgresError as e:
             logger.error(
                 "Database error during expiration of memory %s: %s",
@@ -544,15 +562,25 @@ class HandlerMemoryExpire:
                 "Initialize handler with db_pool parameter."
             )
 
-        async with self._db_pool.acquire() as conn:
-            row = await conn.fetchrow(self._READ_STATE_SQL, memory_id)
+        try:
+            async with self._db_pool.acquire() as conn:
+                row = await asyncio.wait_for(
+                    conn.fetchrow(self._READ_STATE_SQL, memory_id),
+                    timeout=_QUERY_TIMEOUT_SECONDS,
+                )
 
-            if row is None:
-                return None
+                if row is None:
+                    return None
 
-            return ModelMemoryCurrentState(
-                memory_id=row["id"],
-                lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
-                lifecycle_revision=row["lifecycle_revision"],
-                updated_at=row["updated_at"],
+                return ModelMemoryCurrentState(
+                    memory_id=row["id"],
+                    lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
+                    lifecycle_revision=row["lifecycle_revision"],
+                    updated_at=row["updated_at"],
+                )
+        except TimeoutError:
+            logger.error(
+                "Database query timeout reading state for memory %s",
+                memory_id,
             )
+            return None

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -65,7 +65,7 @@ Example::
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -244,11 +244,6 @@ class HandlerMemoryExpire:
 
     Attributes:
         max_retries: Maximum retry attempts for handle_with_retry().
-
-    Note:
-        Database operations are placeholders until OMN-1524 provides the
-        infra transaction helper primitives. The SQL patterns and logic
-        are fully documented for future implementation.
     """
 
     # SQL for atomic state transition with optimistic locking
@@ -285,9 +280,9 @@ class HandlerMemoryExpire:
         """Initialize the expiration handler.
 
         Args:
-            db_pool: Database connection pool. When None, the handler operates
-                in stub mode (returns success without DB access). This allows
-                testing the interface before OMN-1524 primitives are available.
+            db_pool: Database connection pool. Required for database operations.
+                If None, calling handle() or _read_current_state() will raise
+                RuntimeError.
             max_retries: Maximum retry attempts for handle_with_retry().
                 Defaults to 3, which balances retry opportunity against
                 excessive contention scenarios.
@@ -326,11 +321,6 @@ class HandlerMemoryExpire:
             - success=True: Transition completed, new_revision populated
             - success=False, conflict=True: Revision mismatch, retry eligible
             - success=False, conflict=False: Invalid state or not found
-
-        Note:
-            This implementation is a placeholder. The actual database operations
-            will be implemented when OMN-1524 provides transaction helpers.
-            The current implementation returns success for testing the interface.
         """
         # Log the operation for observability
         logger.info(
@@ -347,14 +337,78 @@ class HandlerMemoryExpire:
                 "Initialize handler with db_pool parameter."
             )
 
-        # Actual implementation will be added with OMN-1524
-        # For now, return a placeholder result
-        return ModelMemoryExpireResult(
-            memory_id=command.memory_id,
-            success=True,
-            new_revision=command.expected_revision + 1,
-            previous_state=EnumLifecycleState.ACTIVE,
-        )
+        # Determine expiration timestamp
+        expired_at = command.expired_at or datetime.now(timezone.utc)
+
+        try:
+            async with self._db_pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    self._EXPIRE_SQL,
+                    EnumLifecycleState.EXPIRED.value,  # $1: new state
+                    expired_at,  # $2: expired_at
+                    expired_at,  # $3: updated_at
+                    command.memory_id,  # $4: id
+                    command.expected_revision,  # $5: expected revision
+                    EnumLifecycleState.ACTIVE.value,  # $6: required current state
+                )
+
+                if row is None:
+                    # No rows updated - either revision mismatch or invalid state
+                    # Try to read current state for better error message
+                    current_state = await self._read_current_state(command.memory_id)
+
+                    if current_state is None:
+                        return ModelMemoryExpireResult(
+                            memory_id=command.memory_id,
+                            success=False,
+                            conflict=False,
+                            error_message="Memory not found",
+                        )
+
+                    if current_state.lifecycle_revision != command.expected_revision:
+                        return ModelMemoryExpireResult(
+                            memory_id=command.memory_id,
+                            success=False,
+                            conflict=True,
+                            previous_state=current_state.lifecycle_state,
+                            error_message=(
+                                f"Revision conflict: expected {command.expected_revision}, "
+                                f"found {current_state.lifecycle_revision}"
+                            ),
+                        )
+
+                    # Revision matched but state was wrong
+                    return ModelMemoryExpireResult(
+                        memory_id=command.memory_id,
+                        success=False,
+                        conflict=False,
+                        previous_state=current_state.lifecycle_state,
+                        error_message=(
+                            f"Cannot expire memory in state {current_state.lifecycle_state.value}. "
+                            "Only ACTIVE memories can be expired."
+                        ),
+                    )
+
+                # Success - row contains the new revision
+                return ModelMemoryExpireResult(
+                    memory_id=command.memory_id,
+                    success=True,
+                    new_revision=row["lifecycle_revision"],
+                    previous_state=EnumLifecycleState.ACTIVE,
+                )
+
+        except Exception as e:
+            logger.error(
+                "Database error during expiration of memory %s: %s",
+                command.memory_id,
+                e,
+            )
+            return ModelMemoryExpireResult(
+                memory_id=command.memory_id,
+                success=False,
+                conflict=False,
+                error_message=f"Database error: {e}",
+            )
 
     async def handle_with_retry(
         self,
@@ -471,22 +525,8 @@ class HandlerMemoryExpire:
         Returns:
             ModelMemoryCurrentState if found, None if not found.
 
-        Note:
-            This is a placeholder. Actual implementation will use the
-            database pool when OMN-1524 primitives are available.
-
-            Production pattern:
-
-            async with self._db_pool.acquire() as conn:
-                row = await conn.fetchrow(self._READ_STATE_SQL, memory_id)
-                if row is None:
-                    return None
-                return ModelMemoryCurrentState(
-                    memory_id=row["id"],
-                    lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
-                    lifecycle_revision=row["lifecycle_revision"],
-                    updated_at=row["updated_at"],
-                )
+        Raises:
+            RuntimeError: If database pool is not configured.
         """
         # Require database pool for all operations
         if self._db_pool is None:
@@ -495,5 +535,15 @@ class HandlerMemoryExpire:
                 "Initialize handler with db_pool parameter."
             )
 
-        # Actual implementation will be added with OMN-1524
-        return None
+        async with self._db_pool.acquire() as conn:
+            row = await conn.fetchrow(self._READ_STATE_SQL, memory_id)
+
+            if row is None:
+                return None
+
+            return ModelMemoryCurrentState(
+                memory_id=row["id"],
+                lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
+                lifecycle_revision=row["lifecycle_revision"],
+                updated_at=row["updated_at"],
+            )

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -66,8 +66,11 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING
 from uuid import UUID
+
+if TYPE_CHECKING:
+    from asyncpg import Pool
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -276,7 +279,7 @@ class HandlerMemoryExpire:
 
     def __init__(
         self,
-        db_pool: Any | None = None,
+        db_pool: Pool | None = None,
         max_retries: int = 3,
     ) -> None:
         """Initialize the expiration handler.
@@ -337,19 +340,11 @@ class HandlerMemoryExpire:
             command.reason,
         )
 
-        # Database operation placeholder - see OMN-1524 for implementation
-
-        # Stub implementation for interface testing
+        # Require database pool for all operations
         if self._db_pool is None:
-            logger.warning(
-                "HandlerMemoryExpire operating in stub mode (no db_pool). "
-                "Returning success for interface testing."
-            )
-            return ModelMemoryExpireResult(
-                memory_id=command.memory_id,
-                success=True,
-                new_revision=command.expected_revision + 1,
-                previous_state=EnumLifecycleState.ACTIVE,
+            raise RuntimeError(
+                "Database pool not configured. "
+                "Initialize handler with db_pool parameter."
             )
 
         # Actual implementation will be added with OMN-1524
@@ -493,13 +488,12 @@ class HandlerMemoryExpire:
                     updated_at=row["updated_at"],
                 )
         """
-        # Placeholder for actual implementation
+        # Require database pool for all operations
         if self._db_pool is None:
-            logger.debug(
-                "Stub mode: _read_current_state returning None for memory %s",
-                memory_id,
+            raise RuntimeError(
+                "Database pool not configured. "
+                "Initialize handler with db_pool parameter."
             )
-            return None
 
         # Actual implementation will be added with OMN-1524
         return None

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -71,6 +71,14 @@ from uuid import UUID
 
 if TYPE_CHECKING:
     from asyncpg import Pool
+    from asyncpg.exceptions import PostgresError
+else:
+    try:
+        from asyncpg.exceptions import PostgresError
+    except ImportError:
+        # Fallback if asyncpg not installed - use base Exception
+        # This allows the module to be imported even without asyncpg
+        PostgresError = Exception  # type: ignore[misc,assignment]
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -267,10 +275,11 @@ class HandlerMemoryExpire:
         WHERE id = $1
     """
 
-    # Valid source states for expiration transition
-    _VALID_FROM_STATES = frozenset(
-        {EnumLifecycleState.ACTIVE, EnumLifecycleState.EXPIRED}
-    )
+    # Valid source states for expiration transition.
+    # Only ACTIVE memories can be expired - the SQL WHERE clause requires
+    # lifecycle_state = 'active'. Including EXPIRED here would cause
+    # handle_with_retry() to keep retrying on already-expired memories.
+    _VALID_FROM_STATES = frozenset({EnumLifecycleState.ACTIVE})
 
     def __init__(
         self,
@@ -397,7 +406,7 @@ class HandlerMemoryExpire:
                     previous_state=EnumLifecycleState.ACTIVE,
                 )
 
-        except Exception as e:
+        except PostgresError as e:
             logger.error(
                 "Database error during expiration of memory %s: %s",
                 command.memory_id,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Handler for memory expiration with optimistic locking.
+
+This module implements the core expiration logic for the memory lifecycle
+orchestrator. It performs state transitions from ACTIVE to EXPIRED using
+optimistic concurrency control to handle concurrent access safely.
+
+Optimistic Locking Pattern:
+    The handler uses a revision-based optimistic locking strategy where each
+    memory entity has a `lifecycle_revision` counter. State transitions only
+    succeed when the expected revision matches the current database revision.
+    On conflict (another process updated the entity), the caller can retry
+    with the updated revision.
+
+    This pattern is preferred over pessimistic locking (SELECT FOR UPDATE)
+    because:
+    - It allows higher read concurrency
+    - It avoids deadlocks in distributed systems
+    - It scales better with multiple orchestrator instances
+
+SQL Pattern:
+    UPDATE memories
+    SET lifecycle_state = 'expired',
+        expired_at = :now,
+        lifecycle_revision = lifecycle_revision + 1,
+        updated_at = :now
+    WHERE id = :memory_id
+      AND lifecycle_revision = :expected_revision
+      AND lifecycle_state = 'active'
+
+    If rows_affected == 0 -> conflict (another process updated first)
+
+Related:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+    - OMN-1524: Infra transaction helper primitives (pending)
+
+Example::
+
+    from omnimemory.nodes.memory_lifecycle_orchestrator.handlers import (
+        HandlerMemoryExpire,
+        ModelExpireMemoryCommand,
+    )
+
+    handler = HandlerMemoryExpire(db_pool=pool)
+    result = await handler.handle(
+        ModelExpireMemoryCommand(
+            memory_id=uuid4(),
+            expected_revision=5,
+            reason="ttl_expired",
+        )
+    )
+
+    if result.success:
+        print(f"Memory expired, new revision: {result.new_revision}")
+    elif result.conflict:
+        print("Conflict detected, retry with updated revision")
+    else:
+        print(f"Error: {result.error_message}")
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums import EnumLifecycleState
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HandlerMemoryExpire",
+    "ModelExpireMemoryCommand",
+    "ModelMemoryExpireResult",
+    "ModelMemoryCurrentState",
+]
+
+
+# =============================================================================
+# Models
+# =============================================================================
+
+
+class ModelExpireMemoryCommand(BaseModel):  # omnimemory-model-exempt: handler command
+    """Command to expire a memory entity.
+
+    This command initiates a state transition from ACTIVE to EXPIRED using
+    optimistic concurrency control. The expected_revision must match the
+    current revision in the database for the transition to succeed.
+
+    Attributes:
+        memory_id: UUID of the memory entity to expire.
+        expected_revision: Expected lifecycle revision for optimistic lock.
+            Must match current revision in database.
+        reason: Reason for expiration (for audit trail).
+        expired_at: Timestamp for expiration (defaults to current time).
+            Allows injecting test timestamps for deterministic testing.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="UUID of the memory entity to expire",
+    )
+    expected_revision: int = Field(
+        ...,
+        ge=0,
+        description="Expected lifecycle revision for optimistic lock",
+    )
+    reason: str = Field(
+        default="ttl_expired",
+        min_length=1,
+        max_length=256,
+        description="Reason for expiration (for audit trail)",
+    )
+    expired_at: datetime | None = Field(
+        default=None,
+        description="Optional explicit expiration timestamp (defaults to now)",
+    )
+
+
+class ModelMemoryExpireResult(BaseModel):  # omnimemory-model-exempt: handler result
+    """Result of memory expiration attempt.
+
+    Contains the outcome of the expiration operation, including success/failure
+    status, conflict detection, and any error details.
+
+    State Interpretations:
+        - success=True, conflict=False: Expiration succeeded
+        - success=False, conflict=True: Concurrent modification detected, retry eligible
+        - success=False, conflict=False: Hard failure (invalid state, not found, etc.)
+
+    Attributes:
+        memory_id: UUID of the memory entity.
+        success: Whether the expiration succeeded.
+        new_revision: New revision after successful transition (None on failure).
+        conflict: Whether a concurrent modification was detected.
+        error_message: Detailed error message on failure.
+        previous_state: The state before transition (if known).
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="UUID of the memory entity",
+    )
+    success: bool = Field(
+        ...,
+        description="Whether the expiration succeeded",
+    )
+    new_revision: int | None = Field(
+        default=None,
+        description="New revision after successful transition",
+    )
+    conflict: bool = Field(
+        default=False,
+        description="Whether a concurrent modification was detected",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Detailed error message on failure",
+    )
+    previous_state: EnumLifecycleState | None = Field(
+        default=None,
+        description="The state before transition attempt (if known)",
+    )
+
+
+class ModelMemoryCurrentState(BaseModel):  # omnimemory-model-exempt: handler state
+    """Current state of a memory entity for retry operations.
+
+    Used by handle_with_retry() to re-read current state after conflict.
+
+    Attributes:
+        memory_id: UUID of the memory entity.
+        lifecycle_state: Current lifecycle state.
+        lifecycle_revision: Current revision number.
+        updated_at: Timestamp of last update.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+    )
+
+    memory_id: UUID = Field(
+        ...,
+        description="UUID of the memory entity",
+    )
+    lifecycle_state: EnumLifecycleState = Field(
+        ...,
+        description="Current lifecycle state",
+    )
+    lifecycle_revision: int = Field(
+        ...,
+        ge=0,
+        description="Current revision number",
+    )
+    updated_at: datetime = Field(
+        ...,
+        description="Timestamp of last update",
+    )
+
+
+# =============================================================================
+# Handler
+# =============================================================================
+
+
+class HandlerMemoryExpire:
+    """Handler for expiring memories with optimistic locking.
+
+    Performs state transition: ACTIVE -> EXPIRED
+
+    Uses optimistic concurrency control to safely handle concurrent access:
+    1. Check current revision matches expected revision
+    2. If match: update state, increment revision, commit
+    3. If mismatch: return conflict result (caller can retry with updated revision)
+
+    The handler is designed to be stateless and idempotent - the same command
+    with the same expected_revision will always produce the same result (either
+    success or conflict, never partial state).
+
+    Attributes:
+        max_retries: Maximum retry attempts for handle_with_retry().
+
+    Note:
+        Database operations are placeholders until OMN-1524 provides the
+        infra transaction helper primitives. The SQL patterns and logic
+        are fully documented for future implementation.
+    """
+
+    # SQL for atomic state transition with optimistic locking
+    # The WHERE clause ensures both revision AND state match expected values
+    _EXPIRE_SQL = """
+        UPDATE memories
+        SET lifecycle_state = $1,
+            expired_at = $2,
+            lifecycle_revision = lifecycle_revision + 1,
+            updated_at = $3
+        WHERE id = $4
+          AND lifecycle_revision = $5
+          AND lifecycle_state = $6
+        RETURNING lifecycle_revision
+    """
+
+    # SQL to read current state for retry operations
+    _READ_STATE_SQL = """
+        SELECT id, lifecycle_state, lifecycle_revision, updated_at
+        FROM memories
+        WHERE id = $1
+    """
+
+    # Valid source states for expiration transition
+    _VALID_FROM_STATES = frozenset(
+        {EnumLifecycleState.ACTIVE, EnumLifecycleState.EXPIRED}
+    )
+
+    def __init__(
+        self,
+        db_pool: Any | None = None,
+        max_retries: int = 3,
+    ) -> None:
+        """Initialize the expiration handler.
+
+        Args:
+            db_pool: Database connection pool. When None, the handler operates
+                in stub mode (returns success without DB access). This allows
+                testing the interface before OMN-1524 primitives are available.
+            max_retries: Maximum retry attempts for handle_with_retry().
+                Defaults to 3, which balances retry opportunity against
+                excessive contention scenarios.
+
+        Raises:
+            ValueError: If max_retries is less than 1.
+        """
+        if max_retries < 1:
+            raise ValueError(f"max_retries must be >= 1, got {max_retries}")
+
+        self._db_pool = db_pool
+        self._max_retries = max_retries
+
+    @property
+    def max_retries(self) -> int:
+        """Maximum retry attempts for handle_with_retry()."""
+        return self._max_retries
+
+    async def handle(
+        self,
+        command: ModelExpireMemoryCommand,
+    ) -> ModelMemoryExpireResult:
+        """Handle expire command with optimistic locking.
+
+        Performs the ACTIVE -> EXPIRED state transition atomically using
+        optimistic concurrency control. The transition only succeeds if:
+        - The memory entity exists
+        - The current revision matches expected_revision
+        - The current state is ACTIVE (or other valid source state)
+
+        Args:
+            command: Expiration command with memory ID and expected revision.
+
+        Returns:
+            ModelMemoryExpireResult indicating:
+            - success=True: Transition completed, new_revision populated
+            - success=False, conflict=True: Revision mismatch, retry eligible
+            - success=False, conflict=False: Invalid state or not found
+
+        Note:
+            This implementation is a placeholder. The actual database operations
+            will be implemented when OMN-1524 provides transaction helpers.
+            The current implementation returns success for testing the interface.
+        """
+        # Note: `now` will be used for database operations in OMN-1524
+        _now = command.expired_at or datetime.now(timezone.utc)
+
+        # Log the operation for observability
+        logger.info(
+            "Expiring memory %s (expected_revision=%d, reason=%s)",
+            command.memory_id,
+            command.expected_revision,
+            command.reason,
+        )
+
+        # Database operation placeholder - see OMN-1524 for implementation
+
+        # Stub implementation for interface testing
+        if self._db_pool is None:
+            logger.warning(
+                "HandlerMemoryExpire operating in stub mode (no db_pool). "
+                "Returning success for interface testing."
+            )
+            return ModelMemoryExpireResult(
+                memory_id=command.memory_id,
+                success=True,
+                new_revision=command.expected_revision + 1,
+                previous_state=EnumLifecycleState.ACTIVE,
+            )
+
+        # Actual implementation will be added with OMN-1524
+        # For now, return a placeholder result
+        return ModelMemoryExpireResult(
+            memory_id=command.memory_id,
+            success=True,
+            new_revision=command.expected_revision + 1,
+            previous_state=EnumLifecycleState.ACTIVE,
+        )
+
+    async def handle_with_retry(
+        self,
+        memory_id: UUID,
+        initial_revision: int,
+        reason: str = "ttl_expired",
+        expired_at: datetime | None = None,
+    ) -> ModelMemoryExpireResult:
+        """Handle expiration with automatic retry on conflict.
+
+        Provides a higher-level API that automatically retries on revision
+        conflicts by re-reading the current revision and retrying. This is
+        useful when the caller doesn't need fine-grained control over retry
+        behavior.
+
+        Retry Strategy:
+            - On conflict: re-read current state, retry with updated revision
+            - On success or hard failure: return immediately
+            - Bounded by max_retries to prevent infinite loops in high-contention scenarios
+
+        Args:
+            memory_id: UUID of the memory entity to expire.
+            initial_revision: Starting revision for first attempt.
+            reason: Reason for expiration (for audit trail).
+            expired_at: Optional explicit expiration timestamp.
+
+        Returns:
+            ModelMemoryExpireResult with final outcome:
+            - success=True: Expiration eventually succeeded
+            - success=False, conflict=True: Max retries exceeded due to contention
+            - success=False, conflict=False: Hard failure (invalid state, not found)
+
+        Note:
+            The retry logic is a domain policy decision that belongs in this
+            handler. The underlying transaction helper (OMN-1524) will provide
+            the connection and transaction primitives.
+        """
+        revision = initial_revision
+
+        for attempt in range(self._max_retries):
+            logger.debug(
+                "Expiration attempt %d/%d for memory %s (revision=%d)",
+                attempt + 1,
+                self._max_retries,
+                memory_id,
+                revision,
+            )
+
+            result = await self.handle(
+                ModelExpireMemoryCommand(
+                    memory_id=memory_id,
+                    expected_revision=revision,
+                    reason=reason,
+                    expired_at=expired_at,
+                )
+            )
+
+            # Success or hard failure - return immediately
+            if result.success or not result.conflict:
+                return result
+
+            # Conflict - re-read current revision for next attempt
+            logger.info(
+                "Conflict on attempt %d for memory %s, re-reading state",
+                attempt + 1,
+                memory_id,
+            )
+
+            current_state = await self._read_current_state(memory_id)
+            if current_state is None:
+                return ModelMemoryExpireResult(
+                    memory_id=memory_id,
+                    success=False,
+                    conflict=False,
+                    error_message="Memory not found during retry",
+                )
+
+            # Check if memory is still in a valid state for expiration
+            if current_state.lifecycle_state not in self._VALID_FROM_STATES:
+                return ModelMemoryExpireResult(
+                    memory_id=memory_id,
+                    success=False,
+                    conflict=False,
+                    previous_state=current_state.lifecycle_state,
+                    error_message=(
+                        f"Memory transitioned to invalid state during retry: "
+                        f"{current_state.lifecycle_state.value}"
+                    ),
+                )
+
+            # Update revision for next attempt
+            revision = current_state.lifecycle_revision
+
+        # Max retries exceeded
+        return ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=True,
+            error_message=f"Max retries ({self._max_retries}) exceeded due to contention",
+        )
+
+    async def _read_current_state(
+        self,
+        memory_id: UUID,
+    ) -> ModelMemoryCurrentState | None:
+        """Read current state of a memory entity.
+
+        Used by handle_with_retry() to get the updated revision after a
+        conflict, and by handle() to provide detailed error information.
+
+        Args:
+            memory_id: UUID of the memory entity.
+
+        Returns:
+            ModelMemoryCurrentState if found, None if not found.
+
+        Note:
+            This is a placeholder. Actual implementation will use the
+            database pool when OMN-1524 primitives are available.
+
+            Production pattern:
+
+            async with self._db_pool.acquire() as conn:
+                row = await conn.fetchrow(self._READ_STATE_SQL, memory_id)
+                if row is None:
+                    return None
+                return ModelMemoryCurrentState(
+                    memory_id=row["id"],
+                    lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
+                    lifecycle_revision=row["lifecycle_revision"],
+                    updated_at=row["updated_at"],
+                )
+        """
+        # Placeholder for actual implementation
+        if self._db_pool is None:
+            logger.debug(
+                "Stub mode: _read_current_state returning None for memory %s",
+                memory_id,
+            )
+            return None
+
+        # Actual implementation will be added with OMN-1524
+        return None

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_expire.py
@@ -72,29 +72,46 @@ from uuid import UUID
 
 if TYPE_CHECKING:
     from asyncpg import Pool
-    from asyncpg.exceptions import PostgresError
+    from asyncpg.exceptions import InterfaceError, InternalClientError, PostgresError
 else:
     try:
-        from asyncpg.exceptions import PostgresError
+        from asyncpg.exceptions import (
+            InterfaceError,
+            InternalClientError,
+            PostgresError,
+        )
     except ImportError:
         # Fallback if asyncpg not installed - use base Exception
         # This allows the module to be imported even without asyncpg
         PostgresError = Exception  # type: ignore[misc,assignment]
+        InterfaceError = Exception  # type: ignore[misc,assignment]
+        InternalClientError = Exception  # type: ignore[misc,assignment]
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.enums import EnumLifecycleState
+from omnimemory.utils.concurrency import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitBreakerState,
+)
 
 logger = logging.getLogger(__name__)
 
 # Query timeout for database operations (seconds)
 _QUERY_TIMEOUT_SECONDS: float = 30.0
 
+# Circuit breaker configuration for database operations
+_CIRCUIT_BREAKER_FAILURE_THRESHOLD: int = 5
+_CIRCUIT_BREAKER_RECOVERY_TIMEOUT: float = 60.0
+_CIRCUIT_BREAKER_SUCCESS_THRESHOLD: int = 2
+
 __all__ = [
     "HandlerMemoryExpire",
     "ModelExpireMemoryCommand",
     "ModelMemoryExpireResult",
     "ModelMemoryCurrentState",
+    "CircuitBreakerOpenError",
 ]
 
 
@@ -289,16 +306,22 @@ class HandlerMemoryExpire:
         self,
         db_pool: Pool | None = None,
         max_retries: int = 3,
+        circuit_breaker: CircuitBreaker | None = None,
     ) -> None:
         """Initialize the expiration handler.
 
         Args:
             db_pool: Database connection pool. Required for database operations.
                 If None, calling handle() or _read_current_state() will raise
-                RuntimeError.
+                RuntimeError. The handler requires a database pool for all
+                operations - there is no in-memory fallback mode.
             max_retries: Maximum retry attempts for handle_with_retry().
                 Defaults to 3, which balances retry opportunity against
                 excessive contention scenarios.
+            circuit_breaker: Optional circuit breaker for database operations.
+                If None, a default circuit breaker is created with standard
+                settings (5 failures to open, 60s recovery, 2 successes to close).
+                Protects against cascading failures during database outages.
 
         Raises:
             ValueError: If max_retries is less than 1.
@@ -308,11 +331,36 @@ class HandlerMemoryExpire:
 
         self._db_pool = db_pool
         self._max_retries = max_retries
+        self._circuit_breaker = circuit_breaker or CircuitBreaker(
+            failure_threshold=_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+            recovery_timeout=_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
+            success_threshold=_CIRCUIT_BREAKER_SUCCESS_THRESHOLD,
+        )
 
     @property
     def max_retries(self) -> int:
         """Maximum retry attempts for handle_with_retry()."""
         return self._max_retries
+
+    @property
+    def circuit_breaker(self) -> CircuitBreaker:
+        """Circuit breaker protecting database operations.
+
+        Exposed for monitoring and testing purposes. The circuit breaker
+        tracks database failures and opens to prevent cascading failures.
+        """
+        return self._circuit_breaker
+
+    @property
+    def circuit_breaker_state(self) -> CircuitBreakerState:
+        """Current state of the circuit breaker.
+
+        Returns:
+            CircuitBreakerState.CLOSED: Normal operation
+            CircuitBreakerState.OPEN: Failing fast, DB assumed unavailable
+            CircuitBreakerState.HALF_OPEN: Testing if DB has recovered
+        """
+        return self._circuit_breaker.state
 
     async def handle(
         self,
@@ -350,6 +398,22 @@ class HandlerMemoryExpire:
                 "Initialize handler with db_pool parameter."
             )
 
+        # Check circuit breaker before attempting database operation
+        if not self._circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker open, failing fast for memory %s",
+                command.memory_id,
+            )
+            return ModelMemoryExpireResult(
+                memory_id=command.memory_id,
+                success=False,
+                conflict=False,
+                error_message=(
+                    "Database circuit breaker is open. "
+                    "Service is temporarily unavailable."
+                ),
+            )
+
         # Determine expiration timestamp
         expired_at = command.expired_at or datetime.now(timezone.utc)
 
@@ -371,9 +435,45 @@ class HandlerMemoryExpire:
                 if row is None:
                     # No rows updated - either revision mismatch or invalid state
                     # Try to read current state for better error message
-                    current_state = await self._read_current_state(command.memory_id)
+                    try:
+                        current_state = await self._read_current_state(
+                            command.memory_id
+                        )
+                    except CircuitBreakerOpenError:
+                        # Circuit breaker opened during state read
+                        return ModelMemoryExpireResult(
+                            memory_id=command.memory_id,
+                            success=False,
+                            conflict=False,
+                            error_message=(
+                                "Database circuit breaker is open. "
+                                "Unable to read current state for diagnostics."
+                            ),
+                        )
+                    except (
+                        PostgresError,
+                        InterfaceError,
+                        InternalClientError,
+                        TimeoutError,
+                    ) as e:
+                        # Database error during state read - log and return generic error
+                        logger.warning(
+                            "Error reading current state for memory %s: %s",
+                            command.memory_id,
+                            e,
+                        )
+                        return ModelMemoryExpireResult(
+                            memory_id=command.memory_id,
+                            success=False,
+                            conflict=False,
+                            error_message=(
+                                "Expiration failed and unable to determine cause. "
+                                f"State read error: {e}"
+                            ),
+                        )
 
                     if current_state is None:
+                        self._circuit_breaker.record_success()
                         return ModelMemoryExpireResult(
                             memory_id=command.memory_id,
                             success=False,
@@ -382,6 +482,7 @@ class HandlerMemoryExpire:
                         )
 
                     if current_state.lifecycle_revision != command.expected_revision:
+                        self._circuit_breaker.record_success()
                         return ModelMemoryExpireResult(
                             memory_id=command.memory_id,
                             success=False,
@@ -394,6 +495,7 @@ class HandlerMemoryExpire:
                         )
 
                     # Revision matched but state was wrong
+                    self._circuit_breaker.record_success()
                     return ModelMemoryExpireResult(
                         memory_id=command.memory_id,
                         success=False,
@@ -406,6 +508,7 @@ class HandlerMemoryExpire:
                     )
 
                 # Success - row contains the new revision
+                self._circuit_breaker.record_success()
                 return ModelMemoryExpireResult(
                     memory_id=command.memory_id,
                     success=True,
@@ -414,6 +517,7 @@ class HandlerMemoryExpire:
                 )
 
         except TimeoutError:
+            self._circuit_breaker.record_timeout()
             logger.error(
                 "Database query timeout for memory %s",
                 command.memory_id,
@@ -425,6 +529,7 @@ class HandlerMemoryExpire:
                 error_message="Database query timeout",
             )
         except PostgresError as e:
+            self._circuit_breaker.record_failure()
             logger.error(
                 "Database error during expiration of memory %s: %s",
                 command.memory_id,
@@ -435,6 +540,22 @@ class HandlerMemoryExpire:
                 success=False,
                 conflict=False,
                 error_message=f"Database error: {e}",
+            )
+        except (InterfaceError, InternalClientError) as e:
+            # Handle asyncpg client-side errors:
+            # - InterfaceError: Pool closing, connection already acquired, etc.
+            # - InternalClientError: Protocol errors, schema cache issues, etc.
+            self._circuit_breaker.record_failure()
+            logger.error(
+                "Client error during expiration of memory %s: %s",
+                command.memory_id,
+                e,
+            )
+            return ModelMemoryExpireResult(
+                memory_id=command.memory_id,
+                success=False,
+                conflict=False,
+                error_message=f"Client error: {e}",
             )
 
     async def handle_with_retry(
@@ -504,7 +625,46 @@ class HandlerMemoryExpire:
                 memory_id,
             )
 
-            current_state = await self._read_current_state(memory_id)
+            try:
+                current_state = await self._read_current_state(memory_id)
+            except CircuitBreakerOpenError:
+                logger.warning(
+                    "Circuit breaker open during retry state read for memory %s",
+                    memory_id,
+                )
+                return ModelMemoryExpireResult(
+                    memory_id=memory_id,
+                    success=False,
+                    conflict=False,
+                    error_message=(
+                        "Database circuit breaker is open. "
+                        "Unable to retry - service temporarily unavailable."
+                    ),
+                )
+            except (PostgresError, InterfaceError, InternalClientError) as e:
+                logger.error(
+                    "Database error reading state during retry for memory %s: %s",
+                    memory_id,
+                    e,
+                )
+                return ModelMemoryExpireResult(
+                    memory_id=memory_id,
+                    success=False,
+                    conflict=False,
+                    error_message=f"Database error during retry state read: {e}",
+                )
+            except TimeoutError:
+                logger.error(
+                    "Timeout reading state during retry for memory %s",
+                    memory_id,
+                )
+                return ModelMemoryExpireResult(
+                    memory_id=memory_id,
+                    success=False,
+                    conflict=False,
+                    error_message="Timeout during retry state read",
+                )
+
             if current_state is None:
                 return ModelMemoryExpireResult(
                     memory_id=memory_id,
@@ -554,12 +714,26 @@ class HandlerMemoryExpire:
 
         Raises:
             RuntimeError: If database pool is not configured.
+            PostgresError: If a database error occurs during the query.
+            InterfaceError: If a client-side asyncpg error occurs.
+            InternalClientError: If a protocol-level asyncpg error occurs.
+            TimeoutError: If the database query exceeds the timeout.
         """
         # Require database pool for all operations
         if self._db_pool is None:
             raise RuntimeError(
                 "Database pool not configured. "
                 "Initialize handler with db_pool parameter."
+            )
+
+        # Check circuit breaker before attempting database operation
+        if not self._circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker open, failing fast for state read of memory %s",
+                memory_id,
+            )
+            raise CircuitBreakerOpenError(
+                f"Circuit breaker is {self._circuit_breaker.state.value}"
             )
 
         try:
@@ -570,8 +744,10 @@ class HandlerMemoryExpire:
                 )
 
                 if row is None:
+                    self._circuit_breaker.record_success()
                     return None
 
+                self._circuit_breaker.record_success()
                 return ModelMemoryCurrentState(
                     memory_id=row["id"],
                     lifecycle_state=EnumLifecycleState(row["lifecycle_state"]),
@@ -579,8 +755,25 @@ class HandlerMemoryExpire:
                     updated_at=row["updated_at"],
                 )
         except TimeoutError:
+            self._circuit_breaker.record_timeout()
             logger.error(
                 "Database query timeout reading state for memory %s",
                 memory_id,
             )
-            return None
+            raise
+        except PostgresError as e:
+            self._circuit_breaker.record_failure()
+            logger.error(
+                "Database error reading state for memory %s: %s",
+                memory_id,
+                e,
+            )
+            raise
+        except (InterfaceError, InternalClientError) as e:
+            self._circuit_breaker.record_failure()
+            logger.error(
+                "Client error reading state for memory %s: %s",
+                memory_id,
+                e,
+            )
+            raise

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
@@ -34,6 +34,7 @@ Related Tickets:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime
@@ -44,11 +45,17 @@ from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnimemory.enums import EnumLifecycleState
+from omnimemory.utils.concurrency import CircuitBreaker, CircuitBreakerOpenError
+
 if TYPE_CHECKING:
     from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
     from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
 
 logger = logging.getLogger(__name__)
+
+# Timeout for projection reader calls (seconds)
+_PROJECTION_READER_TIMEOUT_SECONDS: float = 10.0
 
 
 # =============================================================================
@@ -235,7 +242,7 @@ class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection mod
 
     Attributes:
         entity_id: The memory entity UUID.
-        lifecycle_state: Current state (active, expired, archived, deleted).
+        lifecycle_state: Current state (active, stale, expired, archived, deleted).
         expires_at: TTL deadline (None = no expiration).
         expired_at: When memory transitioned to EXPIRED.
         archived_at: When memory was archived (None = not archived).
@@ -272,7 +279,7 @@ class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection mod
         """Check if this memory needs an expiration event emitted.
 
         Returns True if:
-            - lifecycle_state == 'active'
+            - lifecycle_state == ACTIVE (using EnumLifecycleState)
             - expires_at is not None AND expires_at <= now
             - expiration_emitted_at is None (not already emitted)
 
@@ -283,7 +290,7 @@ class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection mod
             True if expiration event should be emitted.
         """
         return (
-            self.lifecycle_state == "active"
+            self.lifecycle_state == EnumLifecycleState.ACTIVE.value
             and self.expires_at is not None
             and self.expires_at <= now
             and self.expiration_emitted_at is None
@@ -293,7 +300,7 @@ class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection mod
         """Check if this memory needs an archive initiation event.
 
         Returns True if:
-            - lifecycle_state == 'expired'
+            - lifecycle_state == EXPIRED (using EnumLifecycleState)
             - archived_at is None (not yet archived)
             - archive_initiated_at is None (not already initiated)
 
@@ -304,7 +311,7 @@ class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection mod
             True if archive initiation event should be emitted.
         """
         return (
-            self.lifecycle_state == "expired"
+            self.lifecycle_state == EnumLifecycleState.EXPIRED.value
             and self.archived_at is None
             and self.archive_initiated_at is None
         )
@@ -365,6 +372,7 @@ class HandlerMemoryTick:
         self,
         projection_reader: ProtocolMemoryLifecycleProjectionReader | None = None,
         batch_size: int = 100,
+        circuit_breaker: CircuitBreaker | None = None,
     ) -> None:
         """Initialize the handler with a projection reader.
 
@@ -373,9 +381,18 @@ class HandlerMemoryTick:
                 If None, handler will return empty results (useful for testing).
             batch_size: Maximum number of memories to process per tick.
                 Prevents tick processing from blocking too long.
+            circuit_breaker: Optional circuit breaker for projection reader resilience.
+                If None, a default circuit breaker is created with conservative settings.
         """
         self._projection_reader = projection_reader
         self._batch_size = batch_size
+        # Circuit breaker for projection reader calls - protects against
+        # cascading failures when the projection reader is unavailable
+        self._circuit_breaker = circuit_breaker or CircuitBreaker(
+            failure_threshold=5,
+            recovery_timeout=30.0,
+            success_threshold=2,
+        )
 
     @property
     def handler_id(self) -> str:
@@ -425,7 +442,9 @@ class HandlerMemoryTick:
 
         # Extract from envelope
         tick = envelope.payload
-        now = envelope.envelope_timestamp
+        # Use tick.now (injected time) for consistent evaluation across distributed
+        # deployments and deterministic testing - NOT envelope_timestamp
+        now = tick.now
         correlation_id = envelope.correlation_id or uuid4()
 
         events: list[BaseModel] = []
@@ -514,14 +533,57 @@ class HandlerMemoryTick:
             )
             return []
 
+        # Check circuit breaker before attempting external call
+        if not self._circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker OPEN for projection reader, skipping expiration check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "circuit_breaker_state": self._circuit_breaker.state.value,
+                },
+            )
+            return []
+
         # TODO(OMN-1524): Use infra projection reader primitives
-        # Query projection for expired candidates
-        expired_projections = await self._projection_reader.get_expired_candidates(
-            now=now,
-            domain="memory",
-            correlation_id=correlation_id,
-            limit=self._batch_size,
-        )
+        # Query projection for expired candidates with timeout and circuit breaker
+        try:
+            expired_projections = await asyncio.wait_for(
+                self._projection_reader.get_expired_candidates(
+                    now=now,
+                    domain="memory",
+                    correlation_id=correlation_id,
+                    limit=self._batch_size,
+                ),
+                timeout=_PROJECTION_READER_TIMEOUT_SECONDS,
+            )
+            self._circuit_breaker.record_success()
+        except TimeoutError:
+            self._circuit_breaker.record_timeout()
+            logger.error(
+                "Projection reader timeout during expiration check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "timeout_seconds": _PROJECTION_READER_TIMEOUT_SECONDS,
+                },
+            )
+            return []
+        except CircuitBreakerOpenError:
+            logger.warning(
+                "Circuit breaker rejected expiration check request",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return []
+        except Exception as exc:
+            self._circuit_breaker.record_failure()
+            logger.error(
+                "Projection reader error during expiration check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+            )
+            return []
 
         events: list[ModelMemoryExpiredEvent] = []
 
@@ -597,14 +659,57 @@ class HandlerMemoryTick:
             )
             return []
 
+        # Check circuit breaker before attempting external call
+        if not self._circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker OPEN for projection reader, skipping archive check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "circuit_breaker_state": self._circuit_breaker.state.value,
+                },
+            )
+            return []
+
         # TODO(OMN-1524): Use infra projection reader primitives
-        # Query projection for archive candidates
-        archive_projections = await self._projection_reader.get_archive_candidates(
-            now=now,
-            domain="memory",
-            correlation_id=correlation_id,
-            limit=self._batch_size,
-        )
+        # Query projection for archive candidates with timeout and circuit breaker
+        try:
+            archive_projections = await asyncio.wait_for(
+                self._projection_reader.get_archive_candidates(
+                    now=now,
+                    domain="memory",
+                    correlation_id=correlation_id,
+                    limit=self._batch_size,
+                ),
+                timeout=_PROJECTION_READER_TIMEOUT_SECONDS,
+            )
+            self._circuit_breaker.record_success()
+        except TimeoutError:
+            self._circuit_breaker.record_timeout()
+            logger.error(
+                "Projection reader timeout during archive check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "timeout_seconds": _PROJECTION_READER_TIMEOUT_SECONDS,
+                },
+            )
+            return []
+        except CircuitBreakerOpenError:
+            logger.warning(
+                "Circuit breaker rejected archive check request",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return []
+        except Exception as exc:
+            self._circuit_breaker.record_failure()
+            logger.error(
+                "Projection reader error during archive check",
+                extra={
+                    "correlation_id": str(correlation_id),
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+            )
+            return []
 
         events: list[ModelMemoryArchiveInitiated] = []
 

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
@@ -1,0 +1,651 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Handler for RuntimeTick - memory lifecycle TTL evaluation.
+
+This handler processes RuntimeTick events from the runtime scheduler
+and evaluates memory entities for TTL expiration and archive eligibility.
+It queries the memory lifecycle projection for entities that need lifecycle
+transition events emitted.
+
+Detection Logic:
+    For Memory Expiration:
+        - Query projection for ACTIVE memories with expires_at <= now
+        - Use projection.needs_expiration_event() for deduplication
+        - Emit ModelMemoryExpiredEvent for each expired memory
+
+    For Archive Initiation:
+        - Query projection for EXPIRED memories with archived_at IS NULL
+        - Use projection.needs_archive_event() for deduplication
+        - Emit ModelMemoryArchiveInitiated for each archive candidate
+
+Deduplication:
+    The projection stores emission markers (expiration_emitted_at,
+    archive_initiated_at) to prevent duplicate lifecycle events.
+    The projection reader filters out already-emitted transitions.
+
+Coroutine Safety:
+    This handler is stateless and coroutine-safe for concurrent calls
+    with different tick instances.
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+    - OMN-1524: Infra projection reader primitives (future dependency)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Protocol
+from uuid import UUID, uuid4
+
+from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+    from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# EVENT MODELS (Placeholder - will be extracted to separate module)
+# =============================================================================
+# TODO(OMN-1453): Extract to omnimemory/models/events/model_memory_expired_event.py
+#                 These are inline placeholders for handler structure validation.
+
+
+class ModelMemoryExpiredEvent(BaseModel):  # omnimemory-model-exempt: handler event
+    """Event emitted when a memory entity's TTL has expired.
+
+    This event signals that a memory has transitioned from ACTIVE to EXPIRED
+    state due to its TTL being reached. Downstream handlers should update
+    projections and potentially initiate archival.
+
+    Attributes:
+        entity_id: The memory entity that expired.
+        memory_id: Alias for entity_id (memory-specific semantic).
+        correlation_id: Correlation ID for distributed tracing.
+        causation_id: The tick_id that triggered this expiration.
+        emitted_at: Timestamp when this event was emitted (from tick.now).
+        expires_at: The original expiration deadline that was exceeded.
+        lifecycle_revision: Current revision for optimistic locking.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entity_id: UUID = Field(..., description="The memory entity that expired.")
+    memory_id: UUID = Field(..., description="The memory ID (alias for entity_id).")
+    correlation_id: UUID = Field(..., description="Correlation ID for tracing.")
+    causation_id: UUID = Field(..., description="The tick_id that triggered this.")
+    emitted_at: datetime = Field(..., description="When this event was emitted.")
+    expires_at: datetime = Field(..., description="The original expiration deadline.")
+    lifecycle_revision: int = Field(
+        default=1, ge=1, description="Revision for optimistic locking."
+    )
+
+
+class ModelMemoryArchiveInitiated(BaseModel):  # omnimemory-model-exempt: handler event
+    """Event emitted when archival is initiated for an expired memory.
+
+    This event signals that a memory in EXPIRED state should be moved to
+    archive storage. The actual archival is performed by the archive effect
+    handler which subscribes to this event.
+
+    Attributes:
+        entity_id: The memory entity to archive.
+        memory_id: Alias for entity_id (memory-specific semantic).
+        correlation_id: Correlation ID for distributed tracing.
+        causation_id: The tick_id that triggered this archival.
+        emitted_at: Timestamp when this event was emitted (from tick.now).
+        expired_at: When the memory transitioned to EXPIRED state.
+        lifecycle_revision: Current revision for optimistic locking.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entity_id: UUID = Field(..., description="The memory entity to archive.")
+    memory_id: UUID = Field(..., description="The memory ID (alias for entity_id).")
+    correlation_id: UUID = Field(..., description="Correlation ID for tracing.")
+    causation_id: UUID = Field(..., description="The tick_id that triggered this.")
+    emitted_at: datetime = Field(..., description="When this event was emitted.")
+    expired_at: datetime | None = Field(
+        default=None, description="When the memory transitioned to EXPIRED."
+    )
+    lifecycle_revision: int = Field(
+        default=1, ge=1, description="Revision for optimistic locking."
+    )
+
+
+# =============================================================================
+# RESULT MODEL
+# =============================================================================
+
+
+class ModelMemoryTickResult(BaseModel):  # omnimemory-model-exempt: handler result
+    """Result of memory lifecycle tick evaluation.
+
+    Captures metrics and identifiers from a single tick evaluation cycle.
+    Used for observability and debugging of lifecycle processing.
+
+    Attributes:
+        expired_count: Number of memories transitioned to EXPIRED state.
+        archive_initiated_count: Number of archive jobs initiated.
+        tick_id: The tick that triggered this evaluation.
+        sequence_number: The tick's sequence number for ordering.
+        evaluated_at: Timestamp of evaluation (from tick.now).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    expired_count: int = Field(
+        default=0, ge=0, description="Number of memories expired this tick."
+    )
+    archive_initiated_count: int = Field(
+        default=0, ge=0, description="Number of archive jobs started this tick."
+    )
+    tick_id: UUID = Field(..., description="The tick that triggered this evaluation.")
+    sequence_number: int = Field(
+        ..., ge=0, description="Tick sequence for ordering and restart detection."
+    )
+    evaluated_at: datetime = Field(
+        ..., description="Timestamp of evaluation (from injected now)."
+    )
+
+
+# =============================================================================
+# PROJECTION READER PROTOCOL (Placeholder for OMN-1524)
+# =============================================================================
+
+
+class ProtocolMemoryLifecycleProjectionReader(Protocol):
+    """Protocol for reading memory lifecycle projection state.
+
+    This protocol defines the interface for querying memory entities
+    that are candidates for lifecycle transitions. Implementations
+    will be provided by OMN-1524 (Infra Projection Reader Primitives).
+
+    Note:
+        This is a placeholder protocol. The actual implementation will
+        use omnibase_infra projection reader primitives when available.
+    """
+
+    async def get_expired_candidates(
+        self,
+        now: datetime,
+        domain: str,
+        correlation_id: UUID,
+        limit: int = 100,
+    ) -> list[ModelMemoryLifecycleProjection]:
+        """Get ACTIVE memories that have passed their TTL.
+
+        Query: lifecycle_state = 'active' AND expires_at IS NOT NULL AND expires_at <= :now
+               AND expiration_emitted_at IS NULL
+
+        Args:
+            now: Current time for deadline comparison.
+            domain: Domain scope for the query.
+            correlation_id: Correlation ID for tracing.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of projections for memories eligible for expiration.
+        """
+        ...
+
+    async def get_archive_candidates(
+        self,
+        now: datetime,
+        domain: str,
+        correlation_id: UUID,
+        limit: int = 100,
+    ) -> list[ModelMemoryLifecycleProjection]:
+        """Get EXPIRED memories that are ready for archival.
+
+        Query: lifecycle_state = 'expired' AND archived_at IS NULL
+               AND archive_initiated_at IS NULL
+
+        Args:
+            now: Current time (for consistent evaluation).
+            domain: Domain scope for the query.
+            correlation_id: Correlation ID for tracing.
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of projections for memories eligible for archival.
+        """
+        ...
+
+
+class ModelMemoryLifecycleProjection(  # omnimemory-model-exempt: projection model
+    BaseModel
+):
+    """Projection of memory lifecycle state for tick evaluation.
+
+    This is a read-optimized view of memory state specifically for
+    lifecycle orchestration decisions. It contains only the fields
+    needed for expiration and archival evaluation.
+
+    Note:
+        This is a placeholder model. The actual projection will be
+        managed by the memory lifecycle reducer (OMN-1453 P4c).
+
+    Attributes:
+        entity_id: The memory entity UUID.
+        lifecycle_state: Current state (active, expired, archived, deleted).
+        expires_at: TTL deadline (None = no expiration).
+        expired_at: When memory transitioned to EXPIRED.
+        archived_at: When memory was archived (None = not archived).
+        lifecycle_revision: Revision for optimistic locking.
+        expiration_emitted_at: When expiration event was emitted (dedup marker).
+        archive_initiated_at: When archive initiation was emitted (dedup marker).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entity_id: UUID = Field(..., description="The memory entity UUID.")
+    lifecycle_state: str = Field(..., description="Current lifecycle state.")
+    expires_at: datetime | None = Field(
+        default=None, description="TTL deadline (None = no expiration)."
+    )
+    expired_at: datetime | None = Field(
+        default=None, description="When memory transitioned to EXPIRED."
+    )
+    archived_at: datetime | None = Field(
+        default=None, description="When memory was archived."
+    )
+    lifecycle_revision: int = Field(
+        default=1, ge=1, description="Revision for optimistic locking."
+    )
+    # Deduplication markers
+    expiration_emitted_at: datetime | None = Field(
+        default=None, description="When expiration event was emitted."
+    )
+    archive_initiated_at: datetime | None = Field(
+        default=None, description="When archive initiation was emitted."
+    )
+
+    def needs_expiration_event(self, now: datetime) -> bool:
+        """Check if this memory needs an expiration event emitted.
+
+        Returns True if:
+            - lifecycle_state == 'active'
+            - expires_at is not None AND expires_at <= now
+            - expiration_emitted_at is None (not already emitted)
+
+        Args:
+            now: Current time for deadline comparison.
+
+        Returns:
+            True if expiration event should be emitted.
+        """
+        return (
+            self.lifecycle_state == "active"
+            and self.expires_at is not None
+            and self.expires_at <= now
+            and self.expiration_emitted_at is None
+        )
+
+    def needs_archive_event(self, now: datetime) -> bool:
+        """Check if this memory needs an archive initiation event.
+
+        Returns True if:
+            - lifecycle_state == 'expired'
+            - archived_at is None (not yet archived)
+            - archive_initiated_at is None (not already initiated)
+
+        Args:
+            now: Current time (unused, for consistent interface).
+
+        Returns:
+            True if archive initiation event should be emitted.
+        """
+        return (
+            self.lifecycle_state == "expired"
+            and self.archived_at is None
+            and self.archive_initiated_at is None
+        )
+
+
+# =============================================================================
+# HANDLER
+# =============================================================================
+
+
+class HandlerMemoryTick:
+    """Handler for RuntimeTick - memory lifecycle TTL evaluation.
+
+    This handler processes runtime tick events and scans the memory
+    lifecycle projection for entities with expired TTLs or pending
+    archival. It emits lifecycle transition events for entities that
+    need them, using projection emission markers for deduplication.
+
+    Lifecycle Evaluation:
+        The handler performs two scans on each tick:
+        1. Expiration: Find ACTIVE memories with expires_at <= now
+        2. Archive initiation: Find EXPIRED memories pending archive
+
+    Projection Queries:
+        Uses dedicated projection reader methods that filter by:
+        - Deadline < now (TTL has passed)
+        - Emission marker IS NULL (not yet emitted)
+        - Appropriate lifecycle state (ACTIVE for expiration, EXPIRED for archive)
+
+    Time Injection:
+        Uses the `now` timestamp from RuntimeTick for deterministic
+        evaluation, enabling reproducible tests and consistent behavior
+        across distributed deployments.
+
+    Attributes:
+        _projection_reader: Reader for memory lifecycle projection state.
+        _batch_size: Maximum memories to process per tick (default: 100).
+
+    Example:
+        >>> from datetime import datetime, timezone
+        >>> from uuid import uuid4
+        >>> tick_time = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        >>> runtime_tick = ModelRuntimeTick(
+        ...     now=tick_time,
+        ...     tick_id=uuid4(),
+        ...     sequence_number=1,
+        ...     scheduled_at=tick_time,
+        ...     correlation_id=uuid4(),
+        ...     scheduler_id="runtime-001",
+        ...     tick_interval_ms=1000,
+        ... )
+        >>> handler = HandlerMemoryTick(projection_reader)
+        >>> output = await handler.handle(envelope)
+        >>> # Output events: ModelMemoryExpiredEvent, ModelMemoryArchiveInitiated
+    """
+
+    def __init__(
+        self,
+        projection_reader: ProtocolMemoryLifecycleProjectionReader | None = None,
+        batch_size: int = 100,
+    ) -> None:
+        """Initialize the handler with a projection reader.
+
+        Args:
+            projection_reader: Reader for querying memory lifecycle projection state.
+                If None, handler will return empty results (useful for testing).
+            batch_size: Maximum number of memories to process per tick.
+                Prevents tick processing from blocking too long.
+        """
+        self._projection_reader = projection_reader
+        self._batch_size = batch_size
+
+    @property
+    def handler_id(self) -> str:
+        """Return unique identifier for this handler."""
+        return "handler-memory-tick"
+
+    @property
+    def category(self) -> EnumMessageCategory:
+        """Return the message category this handler processes."""
+        return EnumMessageCategory.EVENT
+
+    @property
+    def message_types(self) -> set[str]:
+        """Return the set of message types this handler processes."""
+        return {"ModelRuntimeTick"}
+
+    @property
+    def node_kind(self) -> EnumNodeKind:
+        """Return the node kind this handler belongs to."""
+        return EnumNodeKind.ORCHESTRATOR
+
+    async def handle(
+        self,
+        envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> ModelHandlerOutput[None]:
+        """Process runtime tick and emit lifecycle transition events.
+
+        Scans the memory lifecycle projection for:
+        1. ACTIVE memories with expired TTL -> emit ModelMemoryExpiredEvent
+        2. EXPIRED memories pending archive -> emit ModelMemoryArchiveInitiated
+
+        Uses projection emission markers to prevent duplicate events.
+
+        Args:
+            envelope: The event envelope containing the runtime tick event.
+
+        Returns:
+            ModelHandlerOutput containing lifecycle events (ModelMemoryExpiredEvent,
+            ModelMemoryArchiveInitiated). Events tuple may be empty if no
+            transitions detected.
+
+        Note:
+            The actual projection queries are placeholders (return empty lists)
+            until OMN-1524 (Infra Projection Reader Primitives) is implemented.
+        """
+        start_time = time.perf_counter()
+
+        # Extract from envelope
+        tick = envelope.payload
+        now = envelope.envelope_timestamp
+        correlation_id = envelope.correlation_id or uuid4()
+
+        events: list[BaseModel] = []
+
+        # 1. Check for expired memories (ACTIVE -> EXPIRED)
+        expired_events = await self._check_memory_expirations(
+            tick=tick,
+            now=now,
+            correlation_id=correlation_id,
+        )
+        events.extend(expired_events)
+
+        # 2. Check for archive candidates (EXPIRED -> ARCHIVED)
+        archive_events = await self._check_archive_candidates(
+            tick=tick,
+            now=now,
+            correlation_id=correlation_id,
+        )
+        events.extend(archive_events)
+
+        if events:
+            logger.info(
+                "MemoryTick processed, emitting lifecycle events",
+                extra={
+                    "tick_id": str(tick.tick_id),
+                    "sequence_number": tick.sequence_number,
+                    "expired_count": len(expired_events),
+                    "archive_initiated_count": len(archive_events),
+                    "correlation_id": str(correlation_id),
+                },
+            )
+
+        # Build result for metrics/observability
+        result = ModelMemoryTickResult(
+            expired_count=len(expired_events),
+            archive_initiated_count=len(archive_events),
+            tick_id=tick.tick_id,
+            sequence_number=tick.sequence_number,
+            evaluated_at=now,
+        )
+
+        # Calculate processing time
+        processing_time_ms = (time.perf_counter() - start_time) * 1000
+
+        # Return handler output (ORCHESTRATOR: events only, no result)
+        return ModelHandlerOutput.for_orchestrator(
+            input_envelope_id=envelope.envelope_id,
+            correlation_id=correlation_id,
+            handler_id=self.handler_id,
+            events=tuple(events),
+            metrics={
+                "expired_count": float(result.expired_count),
+                "archive_initiated_count": float(result.archive_initiated_count),
+                "batch_size": float(self._batch_size),
+            },
+            processing_time_ms=processing_time_ms,
+        )
+
+    async def _check_memory_expirations(
+        self,
+        tick: ModelRuntimeTick,
+        now: datetime,
+        correlation_id: UUID,
+    ) -> list[ModelMemoryExpiredEvent]:
+        """Check for ACTIVE memories with expired TTL.
+
+        Queries the projection for memories that:
+        - Have lifecycle_state = 'active'
+        - Have expires_at IS NOT NULL AND expires_at <= now
+        - Have NOT already had expiration event emitted
+
+        Args:
+            tick: The runtime tick event (used for causation_id).
+            now: Current time for deadline comparison.
+            correlation_id: Correlation ID for tracing.
+
+        Returns:
+            List of ModelMemoryExpiredEvent events to emit.
+        """
+        if self._projection_reader is None:
+            # No projection reader configured - return empty
+            # This is expected during initial development and testing
+            logger.debug(
+                "No projection reader configured, skipping expiration check",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return []
+
+        # TODO(OMN-1524): Use infra projection reader primitives
+        # Query projection for expired candidates
+        expired_projections = await self._projection_reader.get_expired_candidates(
+            now=now,
+            domain="memory",
+            correlation_id=correlation_id,
+            limit=self._batch_size,
+        )
+
+        events: list[ModelMemoryExpiredEvent] = []
+
+        for projection in expired_projections:
+            # Double-check with projection helper (defensive)
+            if not projection.needs_expiration_event(now):
+                continue
+
+            # Type narrowing: needs_expiration_event() guarantees expires_at is not None
+            expires_at = projection.expires_at
+            if expires_at is None:
+                # This should never happen - needs_expiration_event() ensures expires_at
+                # is not None. Log and skip as defensive measure.
+                logger.warning(
+                    "Skipping projection with None expires_at despite passing "
+                    "needs_expiration_event() check - this indicates a bug",
+                    extra={
+                        "entity_id": str(projection.entity_id),
+                        "correlation_id": str(correlation_id),
+                    },
+                )
+                continue
+
+            event = ModelMemoryExpiredEvent(
+                entity_id=projection.entity_id,
+                memory_id=projection.entity_id,
+                correlation_id=correlation_id,
+                causation_id=tick.tick_id,
+                emitted_at=now,
+                expires_at=expires_at,
+                lifecycle_revision=projection.lifecycle_revision,
+            )
+            events.append(event)
+
+            logger.info(
+                "Detected memory expiration",
+                extra={
+                    "memory_id": str(projection.entity_id),
+                    "expires_at": expires_at.isoformat(),
+                    "lifecycle_revision": projection.lifecycle_revision,
+                    "correlation_id": str(correlation_id),
+                },
+            )
+
+        return events
+
+    async def _check_archive_candidates(
+        self,
+        tick: ModelRuntimeTick,
+        now: datetime,
+        correlation_id: UUID,
+    ) -> list[ModelMemoryArchiveInitiated]:
+        """Check for EXPIRED memories ready for archival.
+
+        Queries the projection for memories that:
+        - Have lifecycle_state = 'expired'
+        - Have archived_at IS NULL (not yet archived)
+        - Have NOT already had archive initiation emitted
+
+        Args:
+            tick: The runtime tick event (used for causation_id).
+            now: Current time for consistent evaluation.
+            correlation_id: Correlation ID for tracing.
+
+        Returns:
+            List of ModelMemoryArchiveInitiated events to emit.
+        """
+        if self._projection_reader is None:
+            # No projection reader configured - return empty
+            logger.debug(
+                "No projection reader configured, skipping archive check",
+                extra={"correlation_id": str(correlation_id)},
+            )
+            return []
+
+        # TODO(OMN-1524): Use infra projection reader primitives
+        # Query projection for archive candidates
+        archive_projections = await self._projection_reader.get_archive_candidates(
+            now=now,
+            domain="memory",
+            correlation_id=correlation_id,
+            limit=self._batch_size,
+        )
+
+        events: list[ModelMemoryArchiveInitiated] = []
+
+        for projection in archive_projections:
+            # Double-check with projection helper (defensive)
+            if not projection.needs_archive_event(now):
+                continue
+
+            event = ModelMemoryArchiveInitiated(
+                entity_id=projection.entity_id,
+                memory_id=projection.entity_id,
+                correlation_id=correlation_id,
+                causation_id=tick.tick_id,
+                emitted_at=now,
+                expired_at=projection.expired_at,
+                lifecycle_revision=projection.lifecycle_revision,
+            )
+            events.append(event)
+
+            logger.info(
+                "Initiating memory archival",
+                extra={
+                    "memory_id": str(projection.entity_id),
+                    "expired_at": (
+                        projection.expired_at.isoformat()
+                        if projection.expired_at
+                        else None
+                    ),
+                    "lifecycle_revision": projection.lifecycle_revision,
+                    "correlation_id": str(correlation_id),
+                },
+            )
+
+        return events
+
+
+__all__: list[str] = [
+    "HandlerMemoryTick",
+    "ModelMemoryTickResult",
+    "ModelMemoryExpiredEvent",
+    "ModelMemoryArchiveInitiated",
+    "ModelMemoryLifecycleProjection",
+    "ProtocolMemoryLifecycleProjectionReader",
+]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/models/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/models/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Memory Lifecycle Orchestrator Models.
+
+Input, output, command, and event models for memory lifecycle orchestration.
+
+Model Categories:
+    - Input/Output: Orchestrator node I/O models
+    - Commands: Explicit lifecycle transition commands
+    - Events: Lifecycle transition event models
+
+Models (to be implemented):
+    - ModelLifecycleOrchestratorInput: Orchestrator input configuration
+    - ModelLifecycleOrchestratorOutput: Orchestrator execution results
+    - ModelArchiveMemoryCommand: Command to archive memory to cold storage
+    - ModelExpireMemoryCommand: Command to explicitly expire memory
+    - ModelRestoreMemoryCommand: Command to restore archived memory
+    - ModelMemoryExpiredEvent: Event emitted when memory expires
+    - ModelMemoryArchivedEvent: Event emitted when memory is archived
+    - ModelMemoryRestoredEvent: Event emitted when memory is restored
+    - ModelLifecycleTransitionFailedEvent: Event emitted on transition failure
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+
+Ticket: OMN-1453
+"""
+
+# TODO(OMN-1453): Add model imports as implemented:
+#   Input/Output: ModelLifecycleOrchestratorInput, ModelLifecycleOrchestratorOutput
+#   Commands: ModelArchiveMemoryCommand, ModelExpireMemoryCommand, ModelRestoreMemoryCommand
+#   Events: ModelMemoryExpiredEvent, ModelMemoryArchivedEvent, ModelMemoryRestoredEvent,
+#           ModelLifecycleTransitionFailedEvent
+
+__all__: list[str] = []

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
@@ -9,18 +9,16 @@ Validators (to be implemented):
 
 Validation Rules:
     State transitions must follow the lifecycle state machine:
-    - ACTIVE -> STALE (access timeout)
-    - ACTIVE -> EXPIRED (explicit expiration)
+    - ACTIVE -> EXPIRED (TTL expiration)
     - ACTIVE -> ARCHIVED (explicit archival)
-    - STALE -> EXPIRED (TTL expiration)
-    - STALE -> ARCHIVED (explicit archival)
     - EXPIRED -> ARCHIVED (post-expiration archival)
     - ARCHIVED -> ACTIVE (restore command)
+    - Any -> DELETED (terminal state)
 
 Invalid Transitions:
-    - DELETED -> any state (terminal)
+    - DELETED -> any state (terminal, no recovery)
     - ARCHIVED -> EXPIRED (must restore first)
-    - any state -> ACTIVE (except restore from ARCHIVED)
+    - EXPIRED -> ACTIVE (must archive then restore)
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1453.

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Memory Lifecycle Orchestrator Validators.
+
+Validation logic for lifecycle state transitions.
+
+Validators (to be implemented):
+    - ValidatorLifecycleTransition: Validates state transition rules
+
+Validation Rules:
+    State transitions must follow the lifecycle state machine:
+    - ACTIVE -> STALE (access timeout)
+    - ACTIVE -> EXPIRED (explicit expiration)
+    - ACTIVE -> ARCHIVED (explicit archival)
+    - STALE -> EXPIRED (TTL expiration)
+    - STALE -> ARCHIVED (explicit archival)
+    - EXPIRED -> ARCHIVED (post-expiration archival)
+    - ARCHIVED -> ACTIVE (restore command)
+
+Invalid Transitions:
+    - DELETED -> any state (terminal)
+    - ARCHIVED -> EXPIRED (must restore first)
+    - any state -> ACTIVE (except restore from ARCHIVED)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+
+Ticket: OMN-1453
+"""
+
+# TODO(OMN-1453): Add validator imports as implemented:
+#   ValidatorLifecycleTransition
+
+__all__: list[str] = []

--- a/src/omnimemory/protocols/data_models.py
+++ b/src/omnimemory/protocols/data_models.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ..enums import EnumLifecycleState
 from ..models.foundation import (
     ModelConfiguration,
     ModelMetadata,
@@ -369,6 +370,17 @@ class MemoryRecord(BaseMemoryModel):
     )
     expires_at: datetime | None = Field(
         None, description="Expiration timestamp (for temporal memory)"
+    )
+    lifecycle_state: EnumLifecycleState = Field(
+        EnumLifecycleState.ACTIVE, description="Current lifecycle state of the memory"
+    )
+    archived_at: datetime | None = Field(
+        None, description="Timestamp when memory was archived to cold storage"
+    )
+    lifecycle_revision: int = Field(
+        1,
+        ge=1,
+        description="Revision number for optimistic locking (incremented on each state change)",
     )
     provenance: ModelStringList = Field(
         default_factory=ModelStringList, description="Memory provenance chain"

--- a/src/omnimemory/protocols/data_models.py
+++ b/src/omnimemory/protocols/data_models.py
@@ -379,7 +379,7 @@ class MemoryRecord(BaseMemoryModel):
     )
     lifecycle_revision: int = Field(
         1,
-        ge=1,
+        ge=0,
         description="Revision number for optimistic locking (incremented on each state change)",
     )
     provenance: ModelStringList = Field(

--- a/tests/integration/nodes/__init__.py
+++ b/tests/integration/nodes/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for ONEX nodes.
+
+This package contains integration tests that verify node behavior with
+real PostgreSQL, Valkey, and other external services.
+
+Test Categories:
+    - memory_lifecycle_orchestrator: Concurrency and atomicity tests
+
+Prerequisites:
+    - PostgreSQL running (for projection queries)
+    - Valkey running (for distributed locks)
+    - omnibase_infra installed (dev dependency)
+    - OMN-1524 infra primitives implemented
+
+Usage:
+    # Run all node integration tests
+    pytest tests/integration/nodes/ -v
+
+    # Run with specific markers
+    pytest -m "integration and concurrency" -v
+
+Environment Variables:
+    TEST_DB_DSN: PostgreSQL connection string
+    TEST_VALKEY_HOST: Valkey hostname (default: localhost)
+    TEST_VALKEY_PORT: Valkey port (default: 6379)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+"""

--- a/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
+++ b/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import pytest
 
@@ -647,11 +646,17 @@ async def insert_test_memory(
     Returns:
         UUID of inserted memory.
 
+    Raises:
+        NotImplementedError: Always raised until OMN-1524 is implemented.
+
     Note:
-        Implementation pending OMN-1524.
+        Implementation pending OMN-1524. This stub raises NotImplementedError
+        to fail fast and prevent tests from silently passing with invalid data.
     """
-    # Placeholder - will be implemented with OMN-1524
-    return memory_id or uuid4()
+    raise NotImplementedError(
+        "insert_test_memory() requires OMN-1524 infra primitives (db.with_transaction). "
+        "See: https://linear.app/omninode/issue/OMN-1524"
+    )
 
 
 async def get_memory_state(memory_id: UUID) -> dict:
@@ -663,11 +668,17 @@ async def get_memory_state(memory_id: UUID) -> dict:
     Returns:
         Dict with lifecycle_state, lifecycle_revision, etc.
 
+    Raises:
+        NotImplementedError: Always raised until OMN-1524 is implemented.
+
     Note:
-        Implementation pending OMN-1524.
+        Implementation pending OMN-1524. This stub raises NotImplementedError
+        to fail fast and prevent tests from silently passing with invalid data.
     """
-    # Placeholder - will be implemented with OMN-1524
-    return {}
+    raise NotImplementedError(
+        "get_memory_state() requires OMN-1524 infra primitives (db.with_transaction). "
+        "See: https://linear.app/omninode/issue/OMN-1524"
+    )
 
 
 async def count_expired_events(correlation_id: UUID) -> int:
@@ -679,11 +690,17 @@ async def count_expired_events(correlation_id: UUID) -> int:
     Returns:
         Number of events emitted.
 
+    Raises:
+        NotImplementedError: Always raised until OMN-1524 is implemented.
+
     Note:
-        Implementation pending OMN-1524.
+        Implementation pending OMN-1524. This stub raises NotImplementedError
+        to fail fast and prevent tests from silently passing with invalid data.
     """
-    # Placeholder - will be implemented with OMN-1524
-    return 0
+    raise NotImplementedError(
+        "count_expired_events() requires OMN-1524 infra primitives (event tracking). "
+        "See: https://linear.app/omninode/issue/OMN-1524"
+    )
 
 
 # =============================================================================

--- a/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
+++ b/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
@@ -1,0 +1,701 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for memory_lifecycle_orchestrator.
+
+These tests verify concurrent behavior with real PostgreSQL database connections.
+Requires OMN-1524 infra primitives for proper transaction support.
+
+Test Scenarios:
+    - SKIP LOCKED concurrent processing (prevents double processing)
+    - Optimistic locking conflict detection (revision-based concurrency)
+    - Archive atomicity (no partial files on crash)
+    - Tick handler idempotency (same tick processed safely)
+    - Projection reader query isolation (consistent snapshot reads)
+
+Prerequisites:
+    - PostgreSQL running at TEST_DB_DSN
+    - OMN-1524 primitives: db.with_transaction(), write_atomic_bytes()
+    - Test database with memory_lifecycle_projection table
+
+Run with:
+    pytest tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py -v
+
+Environment Variables:
+    TEST_DB_DSN: PostgreSQL connection string
+    TEST_ISOLATION_LEVEL: Transaction isolation level (default: READ COMMITTED)
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+    - OMN-1524: Infra projection reader primitives (blocking dependency)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1453.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+# =============================================================================
+# Module-Level Markers
+# =============================================================================
+# Mark all tests in this module as integration tests
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.asyncio,
+]
+
+
+# =============================================================================
+# Test Constants
+# =============================================================================
+
+# Isolation test timeouts
+CONCURRENT_HANDLER_TIMEOUT_SECONDS = 5.0
+
+# Test entity configuration
+TEST_DOMAIN = "memory"
+TEST_BATCH_SIZE = 100
+
+
+# =============================================================================
+# Concurrency Tests - SKIP LOCKED Behavior
+# =============================================================================
+
+
+class TestSkipLockedConcurrency:
+    """Tests for FOR UPDATE SKIP LOCKED concurrent processing behavior.
+
+    These tests verify that the projection reader properly uses PostgreSQL's
+    SKIP LOCKED clause to prevent multiple concurrent tick handlers from
+    processing the same memory entity simultaneously.
+
+    The SKIP LOCKED pattern is essential for:
+        - Preventing duplicate lifecycle events
+        - Enabling horizontal scaling of tick handlers
+        - Maintaining consistency under concurrent load
+
+    Database Requirements:
+        - PostgreSQL 9.5+ (SKIP LOCKED support)
+        - memory_lifecycle_projection table with row-level locking
+        - Multiple concurrent database connections
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_skip_locked_prevents_double_processing(self) -> None:
+        """Verify FOR UPDATE SKIP LOCKED prevents concurrent handlers
+        from processing same memory.
+
+        Scenario:
+            1. Insert memory with lifecycle_state='active', expires_at=past
+            2. Start two concurrent tick handlers
+            3. Both query for candidates with SKIP LOCKED
+            4. Only ONE should process the memory (other skips it)
+            5. Verify memory was expired exactly once
+
+        Expected Behavior:
+            - Handler A acquires lock on memory row
+            - Handler B's SKIP LOCKED query returns empty (row is locked)
+            - Handler A emits ModelMemoryExpiredEvent
+            - Handler B emits no events
+            - Total events emitted: exactly 1
+
+        Implementation Notes:
+            When implementing, use asyncio.gather() to run two handlers
+            concurrently. Insert barrier synchronization to ensure both
+            handlers reach the query point before either commits.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_skip_locked_allows_different_memory_processing(self) -> None:
+        """Verify concurrent handlers can process different memories.
+
+        Scenario:
+            1. Insert memory_A and memory_B, both expired
+            2. Start two concurrent tick handlers
+            3. Handler A locks memory_A, Handler B locks memory_B
+            4. Both should successfully process their respective memory
+            5. Verify both memories were expired
+
+        Expected Behavior:
+            - Handler A processes memory_A
+            - Handler B processes memory_B (not blocked)
+            - Total events emitted: exactly 2
+            - No deadlock or contention
+
+        This tests that SKIP LOCKED allows parallelism for non-overlapping
+        workloads while preventing double-processing of individual entities.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_skip_locked_batch_processing_isolation(self) -> None:
+        """Verify batch processing with SKIP LOCKED isolates work correctly.
+
+        Scenario:
+            1. Insert 10 expired memories
+            2. Start three concurrent tick handlers with batch_size=4
+            3. Each handler should acquire different subset of memories
+            4. Verify all 10 memories processed exactly once
+
+        Expected Behavior:
+            - Handler A: processes memories [0-3] (or subset)
+            - Handler B: processes memories [4-7] (or subset)
+            - Handler C: processes remaining (or subset)
+            - No memory processed more than once
+            - All memories eventually processed
+
+        Implementation Notes:
+            Use explicit locking hints and verify row-level isolation.
+            Track which handler processed which memory_id.
+        """
+
+
+# =============================================================================
+# Optimistic Locking Tests - Revision-Based Concurrency
+# =============================================================================
+
+
+class TestOptimisticLocking:
+    """Tests for revision-based optimistic concurrency control.
+
+    These tests verify that the lifecycle handlers properly detect
+    revision conflicts when attempting to update memory state that
+    has been modified by another concurrent operation.
+
+    The optimistic locking pattern is essential for:
+        - Detecting concurrent modifications
+        - Preventing lost updates
+        - Enabling eventual consistency recovery
+
+    Database Requirements:
+        - lifecycle_revision column in memory_lifecycle_projection
+        - UPDATE ... WHERE lifecycle_revision = :expected_revision
+        - Row count validation after UPDATE
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_optimistic_lock_conflict_detected(self) -> None:
+        """Verify revision mismatch is detected and handled.
+
+        Scenario:
+            1. Insert memory with lifecycle_revision=1
+            2. Handler A reads memory (revision=1)
+            3. Handler B reads memory (revision=1)
+            4. Handler A expires memory (revision becomes 2)
+            5. Handler B attempts expire with revision=1
+            6. Handler B should get conflict (rows_affected=0)
+
+        Expected Behavior:
+            - Handler A: UPDATE succeeds, revision -> 2
+            - Handler B: UPDATE WHERE revision=1 returns 0 rows
+            - Handler B detects conflict, does NOT emit duplicate event
+            - Memory in EXPIRED state with revision=2
+
+        Implementation Notes:
+            The conflict detection relies on rows_affected count from UPDATE.
+            When rows_affected=0, handler must recognize this as conflict.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_optimistic_lock_revision_increment(self) -> None:
+        """Verify lifecycle_revision increments on each state change.
+
+        Scenario:
+            1. Insert memory with lifecycle_revision=1, state='active'
+            2. Expire memory -> revision becomes 2, state='expired'
+            3. Archive memory -> revision becomes 3, state='archived'
+            4. Verify final revision=3
+
+        Expected Behavior:
+            - Each state transition increments revision by 1
+            - Revision is atomically incremented in same transaction
+            - Final state reflects all transitions
+
+        This test validates the revision increment mechanism works
+        correctly across the full lifecycle state machine.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_optimistic_lock_conflict_recovery(self) -> None:
+        """Verify handler gracefully recovers from optimistic lock conflict.
+
+        Scenario:
+            1. Insert memory with lifecycle_revision=1
+            2. Simulate conflict by pre-incrementing revision
+            3. Handler attempts operation with stale revision
+            4. Handler detects conflict
+            5. Handler logs warning but does NOT crash
+            6. Handler continues processing other memories
+
+        Expected Behavior:
+            - Conflict detected via rows_affected=0
+            - Warning logged with memory_id and expected/actual revision
+            - No exception raised to caller
+            - Other memories in batch processed normally
+
+        Implementation Notes:
+            This tests the error handling path, not the happy path.
+            Handler must be resilient to individual entity conflicts.
+        """
+
+
+# =============================================================================
+# Archive Atomicity Tests - Crash Safety
+# =============================================================================
+
+
+class TestArchiveAtomicity:
+    """Tests for atomic archive writes.
+
+    These tests verify that archive operations are atomic - either
+    the archive file is fully written and database updated, or
+    neither occurs. This prevents partial files and orphaned state.
+
+    The atomicity pattern is essential for:
+        - Preventing partial archive files
+        - Maintaining database/filesystem consistency
+        - Enabling safe crash recovery
+
+    Storage Requirements:
+        - Atomic write support (write_atomic_bytes from OMN-1524)
+        - Transaction coordination with database updates
+        - Temp file + rename pattern for atomicity
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    async def test_archive_atomic_write_crash_safety(self) -> None:
+        """Verify archive write is atomic (no partial files).
+
+        Scenario:
+            1. Mock filesystem to fail mid-write
+            2. Attempt archive operation
+            3. Verify no partial file exists
+            4. Verify original DB state unchanged
+
+        Expected Behavior:
+            - Archive writes to temp file first
+            - On failure, temp file cleaned up
+            - No file at final destination path
+            - Database still shows archived_at=NULL
+            - Memory still in 'expired' state
+
+        Implementation Notes:
+            Uses write_atomic_bytes() which implements:
+                1. Write to .tmp file
+                2. fsync() the file
+                3. rename() to final path (atomic on POSIX)
+            On failure at any step, .tmp file is deleted.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    async def test_archive_database_filesystem_consistency(self) -> None:
+        """Verify database and filesystem stay consistent on archive.
+
+        Scenario:
+            1. Insert expired memory ready for archive
+            2. Begin archive transaction
+            3. Write archive file successfully
+            4. Update database archived_at
+            5. Commit transaction
+            6. Verify both file exists AND database updated
+
+        Expected Behavior:
+            - File written atomically to storage
+            - Database update in same logical transaction
+            - Both succeed or both fail
+            - On rollback, file should not exist
+
+        Implementation Notes:
+            True cross-resource atomicity requires 2PC or saga pattern.
+            For now, we use compensating transactions - if DB update
+            fails, delete the archive file.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    async def test_archive_rollback_on_db_failure(self) -> None:
+        """Verify archive file deleted if database update fails.
+
+        Scenario:
+            1. Insert expired memory
+            2. Write archive file successfully
+            3. Simulate database update failure (e.g., connection lost)
+            4. Verify archive file is deleted (compensating action)
+            5. Verify memory state unchanged
+
+        Expected Behavior:
+            - Archive file written to storage
+            - Database update fails (simulated)
+            - Compensating transaction deletes archive file
+            - Memory remains in 'expired' state
+            - archived_at remains NULL
+
+        This tests the compensation pattern for cross-resource consistency.
+        """
+
+
+# =============================================================================
+# Idempotency Tests - Safe Retry Behavior
+# =============================================================================
+
+
+class TestTickIdempotency:
+    """Tests for tick handler idempotency.
+
+    These tests verify that processing the same tick multiple times
+    (e.g., due to retry or duplicate delivery) produces the same
+    result without duplicate events or state corruption.
+
+    The idempotency pattern is essential for:
+        - Safe message retry in Kafka
+        - Crash recovery without duplicate events
+        - At-least-once delivery semantics
+
+    Database Requirements:
+        - Emission markers: expiration_emitted_at, archive_initiated_at
+        - Idempotency checks in projection queries
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_tick_reprocessing_idempotent(self) -> None:
+        """Verify processing same tick twice produces same result.
+
+        Scenario:
+            1. Insert expired memory (no emission marker)
+            2. Process tick -> emits ModelMemoryExpiredEvent
+            3. Emission marker set: expiration_emitted_at = now
+            4. Process same tick again
+            5. No additional events emitted (marker check)
+
+        Expected Behavior:
+            - First tick: 1 event emitted, marker set
+            - Second tick: 0 events emitted (already marked)
+            - Database state unchanged after second tick
+            - No duplicate events in output
+
+        Implementation Notes:
+            The projection query filters: AND expiration_emitted_at IS NULL
+            This ensures already-emitted transitions are not re-emitted.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_emission_marker_atomicity(self) -> None:
+        """Verify emission marker set atomically with event emission.
+
+        Scenario:
+            1. Insert expired memory
+            2. Handler detects expiration
+            3. Handler sets emission marker AND emits event atomically
+            4. Verify both happened in same transaction
+
+        Expected Behavior:
+            - Emission marker set in same transaction as event emit
+            - If transaction rolls back, neither happens
+            - Marker timestamps matches event timestamp
+
+        Implementation Notes:
+            This requires careful transaction boundary management.
+            The emission marker must be set BEFORE the event is
+            published to Kafka to prevent duplicate events on retry.
+        """
+
+
+# =============================================================================
+# Projection Query Isolation Tests
+# =============================================================================
+
+
+class TestProjectionQueryIsolation:
+    """Tests for projection reader query isolation.
+
+    These tests verify that projection queries return consistent
+    snapshots and handle concurrent modifications correctly.
+
+    The query isolation pattern is essential for:
+        - Consistent batch processing
+        - Preventing phantom reads
+        - Correct lifecycle state evaluation
+
+    Database Requirements:
+        - READ COMMITTED or higher isolation level
+        - Consistent snapshot within transaction
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_projection_query_snapshot_consistency(self) -> None:
+        """Verify projection query returns consistent snapshot.
+
+        Scenario:
+            1. Insert 5 expired memories
+            2. Begin transaction, query expired candidates
+            3. Another transaction inserts 2 more expired memories
+            4. First transaction should see original 5 (not 7)
+
+        Expected Behavior:
+            - Query returns consistent snapshot at query time
+            - Concurrent inserts not visible until next query
+            - No phantom reads within transaction
+
+        Implementation Notes:
+            Uses READ COMMITTED isolation by default.
+            For stricter isolation, can use REPEATABLE READ.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_projection_query_deadline_evaluation(self) -> None:
+        """Verify projection query uses injected 'now' for deadline.
+
+        Scenario:
+            1. Insert memory with expires_at = T+10 seconds
+            2. Query with now=T -> memory NOT returned (not expired)
+            3. Query with now=T+15 -> memory returned (expired)
+
+        Expected Behavior:
+            - Query uses injected 'now' parameter, not database NOW()
+            - Deterministic results regardless of clock drift
+            - Enables reproducible testing
+
+        Implementation Notes:
+            The projection reader must accept 'now' as parameter
+            and use it in WHERE expires_at <= :now clause.
+        """
+
+
+# =============================================================================
+# Transaction Boundary Tests
+# =============================================================================
+
+
+class TestTransactionBoundaries:
+    """Tests for correct transaction boundary management.
+
+    These tests verify that handlers properly manage transaction
+    boundaries to ensure atomicity and consistency of operations.
+
+    Transaction requirements:
+        - Single transaction per tick processing
+        - Projection read + emission marker update atomic
+        - Rollback on any failure
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_tick_processing_single_transaction(self) -> None:
+        """Verify tick processing uses single transaction.
+
+        Scenario:
+            1. Insert 3 expired memories
+            2. Process tick
+            3. Simulate failure after processing 2 memories
+            4. Verify rollback: all 3 memories unmarked
+
+        Expected Behavior:
+            - All emission marker updates in same transaction
+            - Failure causes full rollback
+            - Partial state not persisted
+
+        Implementation Notes:
+            Uses db.with_transaction() context manager from OMN-1524.
+            All database operations within handler are in same transaction.
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    async def test_transaction_rollback_on_exception(self) -> None:
+        """Verify transaction rolls back on unhandled exception.
+
+        Scenario:
+            1. Insert expired memory
+            2. Begin processing, update emission marker
+            3. Raise exception before commit
+            4. Verify rollback: emission marker NOT set
+
+        Expected Behavior:
+            - Exception propagates to caller
+            - Transaction automatically rolled back
+            - Database state unchanged
+            - Memory still eligible for reprocessing
+
+        This tests the error handling path ensures no partial state.
+        """
+
+
+# =============================================================================
+# Performance and Scale Tests
+# =============================================================================
+
+
+class TestConcurrentScalePerformance:
+    """Performance tests for concurrent processing at scale.
+
+    These tests verify that the system performs acceptably under
+    concurrent load with realistic batch sizes.
+
+    Note: These are benchmarks, not correctness tests.
+    They validate performance characteristics, not functionality.
+    """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.benchmark
+    async def test_skip_locked_throughput_under_contention(self) -> None:
+        """Benchmark SKIP LOCKED throughput with high contention.
+
+        Scenario:
+            1. Insert 1000 expired memories
+            2. Start 10 concurrent tick handlers
+            3. Measure total processing time
+            4. Verify all memories processed exactly once
+
+        Metrics:
+            - Total processing time (should be < 10 seconds)
+            - Memories processed per second per handler
+            - Lock contention rate (queries returning 0 rows)
+
+        Acceptance Criteria:
+            - 1000 memories processed in < 10 seconds
+            - No duplicate processing
+            - Contention rate < 50%
+        """
+
+    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.benchmark
+    async def test_optimistic_lock_retry_overhead(self) -> None:
+        """Benchmark overhead of optimistic lock conflict resolution.
+
+        Scenario:
+            1. Create scenario with 50% conflict rate
+            2. Measure time to process batch with conflicts
+            3. Compare to conflict-free baseline
+
+        Metrics:
+            - Conflict detection time
+            - Retry overhead per conflict
+            - Total batch processing time
+
+        Acceptance Criteria:
+            - Conflict detection < 1ms
+            - Retry overhead < 5ms per conflict
+            - Total time < 2x baseline
+        """
+
+
+# =============================================================================
+# Fixture Definitions (To Be Implemented with OMN-1524)
+# =============================================================================
+
+# Note: The following fixtures will be implemented when OMN-1524 lands.
+# They are documented here to show the expected test infrastructure.
+
+# @pytest.fixture
+# async def test_db_connection():
+#     """Provide a test database connection.
+#
+#     Yields:
+#         AsyncConnection: PostgreSQL connection for test.
+#
+#     Cleanup:
+#         Rolls back any uncommitted changes after test.
+#     """
+#     pass
+
+# @pytest.fixture
+# async def memory_lifecycle_projection_table(test_db_connection):
+#     """Create and populate memory_lifecycle_projection table.
+#
+#     Creates:
+#         - memory_lifecycle_projection table
+#         - Required indexes for SKIP LOCKED queries
+#
+#     Cleanup:
+#         Drops table after test.
+#     """
+#     pass
+
+# @pytest.fixture
+# async def projection_reader(test_db_connection):
+#     """Provide configured projection reader.
+#
+#     Returns:
+#         ProtocolMemoryLifecycleProjectionReader: Configured reader.
+#     """
+#     pass
+
+
+# =============================================================================
+# Helper Functions (To Be Implemented)
+# =============================================================================
+
+
+async def insert_test_memory(
+    memory_id: UUID | None = None,
+    lifecycle_state: str = "active",
+    expires_at: datetime | None = None,
+    lifecycle_revision: int = 1,
+) -> UUID:
+    """Insert a test memory entity into projection table.
+
+    Args:
+        memory_id: UUID for memory (generated if None).
+        lifecycle_state: Initial lifecycle state.
+        expires_at: Expiration deadline.
+        lifecycle_revision: Initial revision number.
+
+    Returns:
+        UUID of inserted memory.
+
+    Note:
+        Implementation pending OMN-1524.
+    """
+    # Placeholder - will be implemented with OMN-1524
+    return memory_id or uuid4()
+
+
+async def get_memory_state(memory_id: UUID) -> dict:
+    """Get current state of memory from projection table.
+
+    Args:
+        memory_id: UUID of memory to query.
+
+    Returns:
+        Dict with lifecycle_state, lifecycle_revision, etc.
+
+    Note:
+        Implementation pending OMN-1524.
+    """
+    # Placeholder - will be implemented with OMN-1524
+    return {}
+
+
+async def count_expired_events(correlation_id: UUID) -> int:
+    """Count ModelMemoryExpiredEvent events for correlation.
+
+    Args:
+        correlation_id: Correlation ID to filter by.
+
+    Returns:
+        Number of events emitted.
+
+    Note:
+        Implementation pending OMN-1524.
+    """
+    # Placeholder - will be implemented with OMN-1524
+    return 0
+
+
+# =============================================================================
+# Exports
+# =============================================================================
+
+__all__: list[str] = [
+    "TestSkipLockedConcurrency",
+    "TestOptimisticLocking",
+    "TestArchiveAtomicity",
+    "TestTickIdempotency",
+    "TestProjectionQueryIsolation",
+    "TestTransactionBoundaries",
+    "TestConcurrentScalePerformance",
+]

--- a/tests/test_contract_validation.py
+++ b/tests/test_contract_validation.py
@@ -67,7 +67,13 @@ class TestContractValidation:
 
     @pytest.mark.parametrize("node_name", CORE_8_NODES)
     def test_contract_validates_with_pydantic(self, node_name: str) -> None:
-        """Verify contract validates against appropriate Pydantic model."""
+        """Verify contract validates against appropriate Pydantic model.
+
+        Note: Uses constructor (**data) instead of model_validate() due to a bug
+        in omnibase_core 0.9.x where model_validate() passes an unsupported 'extra'
+        parameter to Pydantic's BaseModel.model_validate(). The constructor performs
+        identical validation.
+        """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
             pytest.skip(f"File not yet implemented: {contract_path}")
@@ -84,23 +90,25 @@ class TestContractValidation:
         node_type = node_type.upper()
 
         # Import appropriate contract model based on node type
+        # Note: Using constructor (**data) instead of model_validate() to work around
+        # omnibase_core bug where model_validate() passes unsupported 'extra' kwarg
         try:
             if "EFFECT" in node_type:
                 from omnibase_core.models.contracts import ModelContractEffect
 
-                ModelContractEffect.model_validate(data)
+                ModelContractEffect(**data)
             elif "COMPUTE" in node_type:
                 from omnibase_core.models.contracts import ModelContractCompute
 
-                ModelContractCompute.model_validate(data)
+                ModelContractCompute(**data)
             elif "REDUCER" in node_type:
                 from omnibase_core.models.contracts import ModelContractReducer
 
-                ModelContractReducer.model_validate(data)
+                ModelContractReducer(**data)
             elif "ORCHESTRATOR" in node_type:
                 from omnibase_core.models.contracts import ModelContractOrchestrator
 
-                ModelContractOrchestrator.model_validate(data)
+                ModelContractOrchestrator(**data)
             else:
                 pytest.fail(f"Unknown node_type: {node_type}")
         except ImportError:

--- a/tests/test_node_enforcement.py
+++ b/tests/test_node_enforcement.py
@@ -33,9 +33,22 @@ import yaml
 
 from tests.conftest import CORE_8_NODES, NODES_DIR
 
-# Valid ONEX node types
+# Valid ONEX node types (includes both simple and _GENERIC forms)
+# The _GENERIC suffix is used by EnumNodeType in omnibase_core
+# The validation lowercases the input, so these must be lowercase
 VALID_NODE_TYPES: frozenset[str] = frozenset(
-    {"effect", "compute", "reducer", "orchestrator"}
+    {
+        "effect",
+        "compute",
+        "reducer",
+        "orchestrator",
+        # _GENERIC suffix variants (from EnumNodeType)
+        "effect_generic",
+        "compute_generic",
+        "reducer_generic",
+        "orchestrator_generic",
+        "runtime_host_generic",
+    }
 )
 
 

--- a/tests/test_node_enforcement.py
+++ b/tests/test_node_enforcement.py
@@ -10,6 +10,18 @@ Ensures all ONEX nodes follow the FULLY DECLARATIVE pattern:
 This module validates that node directories contain proper contracts
 and handler registrations, catching violations at test time.
 
+Valid Node Types:
+    The following node_type values are accepted in contract.yaml files:
+    - effect: External I/O operations (APIs, DB, files)
+    - compute: Pure transforms and algorithms
+    - reducer: Aggregation and persistence operations
+    - orchestrator: Workflow coordination
+    - effect_generic: Generic effect node (EnumNodeType suffix variant)
+    - compute_generic: Generic compute node (EnumNodeType suffix variant)
+    - reducer_generic: Generic reducer node (EnumNodeType suffix variant)
+    - orchestrator_generic: Generic orchestrator node (EnumNodeType suffix variant)
+    - runtime_host_generic: Runtime host infrastructure node
+
 AST Enforcement:
     If node.py files exist (legacy pattern), validates they properly
     call super().__init__(container) to ensure proper initialization.
@@ -331,12 +343,32 @@ onex:
         assert result.valid, f"Should be valid: {result.error}"
 
     @pytest.mark.parametrize(
-        "node_type", ["effect", "compute", "reducer", "orchestrator"]
+        "node_type",
+        [
+            # Core 4-node architecture types
+            "effect",
+            "compute",
+            "reducer",
+            "orchestrator",
+            # _GENERIC suffix variants (from EnumNodeType)
+            "effect_generic",
+            "compute_generic",
+            "reducer_generic",
+            "orchestrator_generic",
+            # Runtime host type
+            "runtime_host_generic",
+        ],
     )
     def test_validate_contract_accepts_all_node_types(
         self, tmp_path: Path, node_type: str
     ) -> None:
-        """Test that validator accepts all valid node types."""
+        """Test that validator accepts all valid node types.
+
+        Validates all 9 valid node types defined in VALID_NODE_TYPES:
+        - Core types: effect, compute, reducer, orchestrator
+        - Generic variants: effect_generic, compute_generic, reducer_generic, orchestrator_generic
+        - Runtime host: runtime_host_generic
+        """
         contract: Path = tmp_path / f"{node_type}_contract.yaml"
         contract.write_text(
             f"""
@@ -347,6 +379,53 @@ onex:
         )
         result: ContractValidationResult = validate_contract(contract)
         assert result.valid, f"node_type '{node_type}' should be valid: {result.error}"
+
+    def test_runtime_host_generic_is_valid_node_type(self, tmp_path: Path) -> None:
+        """Explicitly verify runtime_host_generic is accepted as valid node type.
+
+        This test ensures the runtime_host_generic type (used for runtime host
+        infrastructure nodes) is properly included in VALID_NODE_TYPES and
+        passes contract validation.
+        """
+        contract: Path = tmp_path / "runtime_host_contract.yaml"
+        contract.write_text(
+            """
+onex:
+  name: runtime_host_node
+  node_type: runtime_host_generic
+  description: Runtime host infrastructure node for ONEX
+"""
+        )
+        result: ContractValidationResult = validate_contract(contract)
+        assert result.valid, f"runtime_host_generic should be valid: {result.error}"
+
+    def test_valid_node_types_frozenset_completeness(self) -> None:
+        """Verify VALID_NODE_TYPES contains all expected node types.
+
+        This test documents and enforces the complete set of valid node types
+        that should be accepted by the contract validator.
+        """
+        expected_types = {
+            # Core 4-node architecture
+            "effect",
+            "compute",
+            "reducer",
+            "orchestrator",
+            # Generic variants
+            "effect_generic",
+            "compute_generic",
+            "reducer_generic",
+            "orchestrator_generic",
+            # Runtime host
+            "runtime_host_generic",
+        }
+        assert expected_types == VALID_NODE_TYPES, (
+            f"VALID_NODE_TYPES mismatch.\n"
+            f"Expected: {sorted(expected_types)}\n"
+            f"Actual: {sorted(VALID_NODE_TYPES)}\n"
+            f"Missing: {sorted(expected_types - VALID_NODE_TYPES)}\n"
+            f"Extra: {sorted(VALID_NODE_TYPES - expected_types)}"
+        )
 
     def test_validate_contract_rejects_invalid_yaml(self, tmp_path: Path) -> None:
         """Test that validator rejects malformed YAML."""

--- a/tests/test_node_imports.py
+++ b/tests/test_node_imports.py
@@ -86,6 +86,8 @@ class TestNodeStructure:
     #   which are fundamentally different from infrastructure handlers
     # - Nodes with mock handlers: Temporary development/testing implementations
     #   until omnibase_infra handlers are available
+    # - ORCHESTRATOR nodes with domain-specific handlers: Memory lifecycle handlers
+    #   contain domain logic that doesn't belong in omnibase_infra
     NODES_WITH_ALLOWED_HANDLERS: set[str] = {
         # COMPUTE node: Pure math computation handler for vector similarity.
         # Not an infrastructure handler - performs no I/O operations.
@@ -94,6 +96,12 @@ class TestNodeStructure:
         # development/testing. Will be removed when omnibase_infra is integrated.
         # TODO: Remove from exclusion list when migrating to real handlers.
         "memory_retrieval_effect",
+        # ORCHESTRATOR node with domain-specific lifecycle handlers:
+        # - handler_memory_tick: TTL evaluation and event emission
+        # - handler_memory_expire: ACTIVE->EXPIRED with optimistic locking
+        # - handler_memory_archive: Archive to cold storage with gzip compression
+        # These contain memory-domain logic (not generic infrastructure).
+        "memory_lifecycle_orchestrator",
     }
 
     @pytest.mark.parametrize("node_name", CORE_8_NODES)

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/__init__.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for memory_lifecycle_orchestrator handlers.
+
+This package contains unit tests for the lifecycle orchestrator handlers:
+- HandlerMemoryTick: RuntimeTick evaluation for TTL and archive candidates
+- HandlerMemoryExpire: ACTIVE -> EXPIRED state transition with optimistic locking
+- HandlerMemoryArchive: EXPIRED -> ARCHIVED with cold storage archival
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+"""

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -165,15 +166,52 @@ class TestHandlerMemoryArchiveInitialization:
         assert handler is not None
         assert handler._db_pool is None
 
-    def test_handler_default_archive_path(self) -> None:
-        """Test handler uses default archive path.
+    def test_handler_default_archive_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test handler uses temp directory-based default path.
 
-        Given: No archive_base_path provided
+        Given: No archive_base_path provided and no env var set
         When: Creating HandlerMemoryArchive
-        Then: Handler uses default path /var/omnimemory/archives
+        Then: Handler uses temp directory-based path
         """
+        # Ensure env var is not set
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_PATH", raising=False)
+
         handler = HandlerMemoryArchive()
-        assert handler.archive_base_path == Path("/var/omnimemory/archives")
+        expected_path = Path(tempfile.gettempdir()) / "omnimemory" / "archives"
+        assert handler.archive_base_path == expected_path
+
+    def test_handler_archive_path_from_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test handler reads archive path from environment variable.
+
+        Given: OMNIMEMORY_ARCHIVE_PATH environment variable is set
+        When: Creating HandlerMemoryArchive without explicit path
+        Then: Handler uses path from environment variable
+        """
+        env_path = "/custom/env/archive/path"
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_PATH", env_path)
+
+        handler = HandlerMemoryArchive()
+        assert handler.archive_base_path == Path(env_path)
+
+    def test_handler_explicit_path_overrides_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        archive_base_path: Path,
+    ) -> None:
+        """Test explicit path parameter overrides environment variable.
+
+        Given: Both env var and explicit path provided
+        When: Creating HandlerMemoryArchive
+        Then: Explicit path takes precedence over env var
+        """
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_PATH", "/ignored/env/path")
+
+        handler = HandlerMemoryArchive(archive_base_path=archive_base_path)
+        assert handler.archive_base_path == archive_base_path
 
     def test_handler_custom_archive_path(
         self,

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
@@ -1,0 +1,1059 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerMemoryArchive.
+
+Tests the memory archive handler that performs EXPIRED -> ARCHIVED state
+transitions with filesystem archival. Tests cover archive format, path
+generation, conflict detection, and state validation.
+
+Test Categories:
+    - Initialization: Handler setup and configuration
+    - Archive Path Generation: Date-based directory structure
+    - Archive Format: JSONL gzip compression
+    - Conflict Detection: Revision mismatch handling
+    - State Validation: Only EXPIRED memories can be archived
+    - Atomic Write: File write mechanics (via _write_archive_atomic)
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py -v
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers import (
+    HandlerMemoryArchive,
+    ModelArchiveMemoryCommand,
+    ModelArchiveRecord,
+    ModelMemoryArchiveResult,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """Provide a fixed timestamp for deterministic testing.
+
+    Returns:
+        A fixed datetime in UTC timezone.
+    """
+    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def memory_id() -> UUID:
+    """Provide a fixed memory ID for testing.
+
+    Returns:
+        A deterministic UUID for the memory.
+    """
+    return UUID("12345678-abcd-1234-abcd-567812345678")
+
+
+@pytest.fixture
+def archive_base_path(tmp_path: Path) -> Path:
+    """Provide a temporary archive base path.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+
+    Returns:
+        Path to temporary archive directory.
+    """
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    return archive_dir
+
+
+@pytest.fixture
+def handler(archive_base_path: Path) -> HandlerMemoryArchive:
+    """Create handler without database pool for testing.
+
+    Args:
+        archive_base_path: Base path for archive storage.
+
+    Returns:
+        HandlerMemoryArchive instance for testing.
+    """
+    return HandlerMemoryArchive(
+        db_pool=None,
+        archive_base_path=archive_base_path,
+    )
+
+
+@pytest.fixture
+def archive_command(memory_id: UUID) -> ModelArchiveMemoryCommand:
+    """Create an archive command for testing.
+
+    Args:
+        memory_id: The memory entity ID.
+
+    Returns:
+        Configured ModelArchiveMemoryCommand instance.
+    """
+    return ModelArchiveMemoryCommand(
+        memory_id=memory_id,
+        expected_revision=5,
+    )
+
+
+@pytest.fixture
+def sample_archive_record(
+    memory_id: UUID,
+    fixed_now: datetime,
+) -> ModelArchiveRecord:
+    """Create a sample archive record for testing.
+
+    Args:
+        memory_id: The memory entity ID.
+        fixed_now: Fixed timestamp.
+
+    Returns:
+        Configured ModelArchiveRecord instance.
+    """
+    from datetime import timedelta
+
+    return ModelArchiveRecord(
+        memory_id=memory_id,
+        content="Test memory content for archival",
+        content_type="text/plain",
+        created_at=fixed_now - timedelta(days=30),  # Created 30 days ago
+        expired_at=fixed_now - timedelta(days=1),  # Expired 1 day ago
+        archived_at=fixed_now,
+        lifecycle_revision=5,
+        metadata={"source": "test", "tags": ["important", "archive"]},
+    )
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+class TestHandlerMemoryArchiveInitialization:
+    """Tests for HandlerMemoryArchive initialization."""
+
+    def test_handler_creates_without_db_pool(
+        self,
+        archive_base_path: Path,
+    ) -> None:
+        """Test handler can be created without database pool.
+
+        Given: No db_pool provided
+        When: Creating HandlerMemoryArchive
+        Then: Handler is created successfully
+        """
+        handler = HandlerMemoryArchive(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+        )
+        assert handler is not None
+        assert handler._db_pool is None
+
+    def test_handler_default_archive_path(self) -> None:
+        """Test handler uses default archive path.
+
+        Given: No archive_base_path provided
+        When: Creating HandlerMemoryArchive
+        Then: Handler uses default path /var/omnimemory/archives
+        """
+        handler = HandlerMemoryArchive()
+        assert handler.archive_base_path == Path("/var/omnimemory/archives")
+
+    def test_handler_custom_archive_path(
+        self,
+        archive_base_path: Path,
+    ) -> None:
+        """Test handler uses custom archive path.
+
+        Given: Custom archive_base_path
+        When: Creating HandlerMemoryArchive
+        Then: Handler uses the custom path
+        """
+        handler = HandlerMemoryArchive(archive_base_path=archive_base_path)
+        assert handler.archive_base_path == archive_base_path
+
+    def test_archive_base_path_property(
+        self,
+        archive_base_path: Path,
+    ) -> None:
+        """Test archive_base_path property returns correct path.
+
+        Given: Handler with custom archive path
+        When: Accessing archive_base_path property
+        Then: Returns the configured path
+        """
+        handler = HandlerMemoryArchive(archive_base_path=archive_base_path)
+        assert handler.archive_base_path == archive_base_path
+
+
+# =============================================================================
+# Archive Path Generation Tests
+# =============================================================================
+
+
+class TestArchivePathGeneration:
+    """Tests for date-based archive path generation."""
+
+    def test_get_archive_path_format(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+        archive_base_path: Path,
+    ) -> None:
+        """Test archive path follows date-based directory structure.
+
+        Given: Memory ID and archive timestamp
+        When: Generating archive path
+        Then: Path follows {base}/{year}/{month}/{day}/{id}.jsonl.gz pattern
+        """
+        path = handler._get_archive_path(memory_id, fixed_now)
+
+        expected = archive_base_path / "2026" / "01" / "25" / f"{memory_id}.jsonl.gz"
+        assert path == expected
+
+    def test_archive_path_month_padding(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        archive_base_path: Path,
+    ) -> None:
+        """Test month is zero-padded in path.
+
+        Given: Archive date with single-digit month
+        When: Generating archive path
+        Then: Month is zero-padded (e.g., '01' not '1')
+        """
+        jan_date = datetime(2026, 1, 15, tzinfo=timezone.utc)
+        path = handler._get_archive_path(memory_id, jan_date)
+
+        assert "/01/" in str(path)
+
+    def test_archive_path_day_padding(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        archive_base_path: Path,
+    ) -> None:
+        """Test day is zero-padded in path.
+
+        Given: Archive date with single-digit day
+        When: Generating archive path
+        Then: Day is zero-padded (e.g., '05' not '5')
+        """
+        fifth_date = datetime(2026, 3, 5, tzinfo=timezone.utc)
+        path = handler._get_archive_path(memory_id, fifth_date)
+
+        assert "/05/" in str(path)
+
+    def test_archive_path_file_extension(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test archive path has .jsonl.gz extension.
+
+        Given: Memory ID
+        When: Generating archive path
+        Then: Path ends with .jsonl.gz
+        """
+        path = handler._get_archive_path(memory_id, fixed_now)
+
+        assert path.suffix == ".gz"
+        assert path.stem.endswith(".jsonl")
+
+    def test_archive_path_different_dates(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        archive_base_path: Path,
+    ) -> None:
+        """Test archive paths differ for different dates.
+
+        Given: Same memory ID with different dates
+        When: Generating archive paths
+        Then: Paths are different
+        """
+        date1 = datetime(2026, 1, 25, tzinfo=timezone.utc)
+        date2 = datetime(2026, 6, 15, tzinfo=timezone.utc)
+
+        path1 = handler._get_archive_path(memory_id, date1)
+        path2 = handler._get_archive_path(memory_id, date2)
+
+        assert path1 != path2
+        assert "2026/01/25" in str(path1)
+        assert "2026/06/15" in str(path2)
+
+
+# =============================================================================
+# Archive Format Tests
+# =============================================================================
+
+
+class TestArchiveFormat:
+    """Tests for archive serialization and compression format."""
+
+    def test_serialize_produces_gzip_bytes(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization produces gzip-compressed bytes.
+
+        Given: An archive record
+        When: Serializing for archive
+        Then: Output is valid gzip-compressed data
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test content",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+
+        # Verify it's valid gzip by decompressing
+        decompressed = gzip.decompress(compressed)
+        assert isinstance(decompressed, bytes)
+
+    def test_serialize_produces_jsonl_format(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization produces JSONL format (JSON + newline).
+
+        Given: An archive record
+        When: Serializing for archive
+        Then: Decompressed output is valid JSON followed by newline
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test content",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+        decompressed = gzip.decompress(compressed).decode("utf-8")
+
+        # JSONL format: JSON followed by newline
+        assert decompressed.endswith("\n")
+
+        # Remove trailing newline and parse JSON
+        json_str = decompressed.rstrip("\n")
+        parsed = json.loads(json_str)
+
+        assert parsed["memory_id"] == str(memory_id)
+        assert parsed["content"] == "Test content"
+        assert parsed["content_type"] == "text/plain"
+
+    def test_serialize_preserves_metadata(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization preserves metadata in archive.
+
+        Given: An archive record with metadata
+        When: Serializing and deserializing
+        Then: Metadata is preserved correctly
+        """
+        metadata = {"source": "test", "priority": 1, "tags": ["a", "b"]}
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Content with metadata",
+            content_type="application/json",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=3,
+            metadata=metadata,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+        decompressed = gzip.decompress(compressed).decode("utf-8")
+        parsed = json.loads(decompressed.rstrip("\n"))
+
+        assert parsed["metadata"] == metadata
+
+    def test_serialize_includes_archive_version(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization includes archive_version field.
+
+        Given: An archive record
+        When: Serializing
+        Then: Output includes archive_version for future migrations
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+        decompressed = gzip.decompress(compressed).decode("utf-8")
+        parsed = json.loads(decompressed.rstrip("\n"))
+
+        assert "archive_version" in parsed
+        assert parsed["archive_version"] == "1.0"
+
+
+# =============================================================================
+# Atomic Write Tests
+# =============================================================================
+
+
+class TestAtomicWrite:
+    """Tests for atomic file write functionality."""
+
+    @pytest.mark.asyncio
+    async def test_write_creates_file(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test atomic write creates file at specified path.
+
+        Given: Compressed data and target path
+        When: Calling _write_archive_atomic
+        Then: File is created at target path
+        """
+        target_path = archive_base_path / "2026" / "01" / "25" / "test.jsonl.gz"
+        test_data = b"compressed test data"
+
+        bytes_written = await handler._write_archive_atomic(target_path, test_data)
+
+        assert target_path.exists()
+        assert bytes_written == len(test_data)
+
+    @pytest.mark.asyncio
+    async def test_write_creates_parent_directories(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test atomic write creates parent directories if needed.
+
+        Given: Target path with non-existent parent directories
+        When: Calling _write_archive_atomic
+        Then: Parent directories are created
+        """
+        deep_path = archive_base_path / "2030" / "12" / "31" / "deep.jsonl.gz"
+        test_data = b"test"
+
+        await handler._write_archive_atomic(deep_path, test_data)
+
+        assert deep_path.parent.exists()
+        assert deep_path.parent.is_dir()
+
+    @pytest.mark.asyncio
+    async def test_write_file_contents_correct(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test atomic write produces file with correct contents.
+
+        Given: Specific data to write
+        When: Writing and reading back
+        Then: Contents match original data
+        """
+        target_path = archive_base_path / "content_test.jsonl.gz"
+        test_data = b"exact content to verify"
+
+        await handler._write_archive_atomic(target_path, test_data)
+
+        with open(target_path, "rb") as f:
+            written_content = f.read()
+
+        assert written_content == test_data
+
+    @pytest.mark.asyncio
+    async def test_write_returns_bytes_count(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test atomic write returns correct byte count.
+
+        Given: Data of known size
+        When: Calling _write_archive_atomic
+        Then: Returns correct number of bytes written
+        """
+        target_path = archive_base_path / "size_test.jsonl.gz"
+        test_data = b"x" * 1024  # 1KB
+
+        bytes_written = await handler._write_archive_atomic(target_path, test_data)
+
+        assert bytes_written == 1024
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites_existing(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test atomic write overwrites existing file.
+
+        Given: Existing file at target path
+        When: Writing new data
+        Then: File contains new data, not old
+        """
+        target_path = archive_base_path / "overwrite_test.jsonl.gz"
+
+        # Write initial file
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(target_path, "wb") as f:
+            f.write(b"old content")
+
+        # Overwrite with atomic write
+        new_data = b"new content"
+        await handler._write_archive_atomic(target_path, new_data)
+
+        with open(target_path, "rb") as f:
+            content = f.read()
+
+        assert content == new_data
+
+
+# =============================================================================
+# Command Model Tests
+# =============================================================================
+
+
+class TestArchiveCommandModel:
+    """Tests for ModelArchiveMemoryCommand validation."""
+
+    def test_command_requires_memory_id(self) -> None:
+        """Test command requires memory_id field.
+
+        Given: No memory_id provided
+        When: Creating ModelArchiveMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelArchiveMemoryCommand(
+                expected_revision=1,
+            )  # type: ignore[call-arg]
+
+    def test_command_requires_expected_revision(self, memory_id: UUID) -> None:
+        """Test command requires expected_revision field.
+
+        Given: No expected_revision provided
+        When: Creating ModelArchiveMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelArchiveMemoryCommand(
+                memory_id=memory_id,
+            )  # type: ignore[call-arg]
+
+    def test_command_rejects_negative_revision(self, memory_id: UUID) -> None:
+        """Test command rejects negative expected_revision.
+
+        Given: negative expected_revision
+        When: Creating ModelArchiveMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelArchiveMemoryCommand(
+                memory_id=memory_id,
+                expected_revision=-1,
+            )
+
+    def test_command_archive_path_optional(self, memory_id: UUID) -> None:
+        """Test archive_path is optional.
+
+        Given: No archive_path provided
+        When: Creating ModelArchiveMemoryCommand
+        Then: Command is created with archive_path=None
+        """
+        command = ModelArchiveMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+        )
+        assert command.archive_path is None
+
+    def test_command_with_archive_path(
+        self,
+        memory_id: UUID,
+        archive_base_path: Path,
+    ) -> None:
+        """Test command accepts custom archive_path.
+
+        Given: Custom archive_path
+        When: Creating ModelArchiveMemoryCommand
+        Then: Command uses the custom path
+        """
+        custom_path = archive_base_path / "custom" / "path.jsonl.gz"
+        command = ModelArchiveMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+            archive_path=custom_path,
+        )
+        assert command.archive_path == custom_path
+
+    def test_command_is_frozen(self, memory_id: UUID) -> None:
+        """Test command model is immutable.
+
+        Given: A ModelArchiveMemoryCommand instance
+        When: Attempting to modify a field
+        Then: Error is raised
+        """
+        command = ModelArchiveMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+        )
+
+        with pytest.raises(ValidationError):
+            command.expected_revision = 5  # type: ignore[misc]
+
+
+# =============================================================================
+# Result Model Tests
+# =============================================================================
+
+
+class TestArchiveResultModel:
+    """Tests for ModelMemoryArchiveResult validation."""
+
+    def test_result_success_state(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+        archive_base_path: Path,
+    ) -> None:
+        """Test result model for successful archive.
+
+        Given: Successful archive data
+        When: Creating ModelMemoryArchiveResult
+        Then: Model represents success correctly
+        """
+        archive_path = archive_base_path / "test.jsonl.gz"
+        result = ModelMemoryArchiveResult(
+            memory_id=memory_id,
+            success=True,
+            archived_at=fixed_now,
+            archive_path=archive_path,
+            bytes_written=1024,
+            conflict=False,
+        )
+
+        assert result.success is True
+        assert result.archived_at == fixed_now
+        assert result.archive_path == archive_path
+        assert result.bytes_written == 1024
+        assert result.conflict is False
+        assert result.error_message is None
+
+    def test_result_conflict_state(self, memory_id: UUID) -> None:
+        """Test result model for conflict scenario.
+
+        Given: Conflict archive data
+        When: Creating ModelMemoryArchiveResult
+        Then: Model represents conflict correctly
+        """
+        result = ModelMemoryArchiveResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=True,
+            error_message="Revision conflict: expected 5, memory was modified",
+        )
+
+        assert result.success is False
+        assert result.conflict is True
+        assert "Revision conflict" in result.error_message
+        assert result.archived_at is None
+        assert result.archive_path is None
+        assert result.bytes_written == 0
+
+    def test_result_failure_state(self, memory_id: UUID) -> None:
+        """Test result model for failure (invalid state).
+
+        Given: Invalid state failure data
+        When: Creating ModelMemoryArchiveResult
+        Then: Model represents failure correctly
+        """
+        result = ModelMemoryArchiveResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=False,
+            error_message="Cannot archive memory in state active",
+        )
+
+        assert result.success is False
+        assert result.conflict is False
+        assert "Cannot archive" in result.error_message
+
+    def test_result_bytes_written_default(self, memory_id: UUID) -> None:
+        """Test bytes_written defaults to 0.
+
+        Given: No bytes_written provided
+        When: Creating ModelMemoryArchiveResult
+        Then: bytes_written defaults to 0
+        """
+        result = ModelMemoryArchiveResult(
+            memory_id=memory_id,
+            success=False,
+            error_message="Error",
+        )
+
+        assert result.bytes_written == 0
+
+    def test_result_bytes_written_non_negative(self, memory_id: UUID) -> None:
+        """Test bytes_written rejects negative values.
+
+        Given: Negative bytes_written
+        When: Creating ModelMemoryArchiveResult
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelMemoryArchiveResult(
+                memory_id=memory_id,
+                success=True,
+                bytes_written=-100,
+            )
+
+
+# =============================================================================
+# Archive Record Model Tests
+# =============================================================================
+
+
+class TestArchiveRecordModel:
+    """Tests for ModelArchiveRecord validation."""
+
+    def test_record_creation(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test archive record can be created with valid data.
+
+        Given: Valid archive record data
+        When: Creating ModelArchiveRecord
+        Then: Record is created successfully
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test memory content",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=5,
+        )
+
+        assert record.memory_id == memory_id
+        assert record.content == "Test memory content"
+        assert record.content_type == "text/plain"
+        assert record.lifecycle_revision == 5
+        assert record.archive_version == "1.0"
+
+    def test_record_default_archive_version(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test archive_version defaults to '1.0'.
+
+        Given: No archive_version provided
+        When: Creating ModelArchiveRecord
+        Then: archive_version defaults to '1.0'
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        assert record.archive_version == "1.0"
+
+    def test_record_metadata_optional(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test metadata field is optional.
+
+        Given: No metadata provided
+        When: Creating ModelArchiveRecord
+        Then: metadata is None
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        assert record.metadata is None
+
+    def test_record_with_metadata(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test record accepts metadata dict.
+
+        Given: Metadata dictionary
+        When: Creating ModelArchiveRecord
+        Then: metadata is stored correctly
+        """
+        metadata: dict[str, Any] = {
+            "source": "agent",
+            "priority": 1,
+            "tags": ["important"],
+        }
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+            metadata=metadata,
+        )
+
+        assert record.metadata == metadata
+
+    def test_record_is_frozen(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test archive record model is immutable.
+
+        Given: A ModelArchiveRecord instance
+        When: Attempting to modify a field
+        Then: Error is raised
+        """
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="Test",
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        with pytest.raises(ValidationError):
+            record.content = "Modified"  # type: ignore[misc]
+
+    def test_record_revision_non_negative(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test lifecycle_revision rejects negative values.
+
+        Given: Negative lifecycle_revision
+        When: Creating ModelArchiveRecord
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelArchiveRecord(
+                memory_id=memory_id,
+                content="Test",
+                content_type="text/plain",
+                created_at=fixed_now,
+                expired_at=fixed_now,
+                archived_at=fixed_now,
+                lifecycle_revision=-1,
+            )
+
+
+# =============================================================================
+# Handler Error Handling Tests
+# =============================================================================
+
+
+class TestHandlerErrorHandling:
+    """Tests for handler error handling behavior."""
+
+    @pytest.mark.asyncio
+    async def test_handle_without_db_pool_raises_error(
+        self,
+        archive_base_path: Path,
+        archive_command: ModelArchiveMemoryCommand,
+    ) -> None:
+        """Test handler raises RuntimeError without db_pool.
+
+        Given: Handler without db_pool configured
+        When: Calling handle()
+        Then: RuntimeError is raised
+        """
+        handler = HandlerMemoryArchive(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+        )
+
+        # The handler raises RuntimeError when trying to read memory
+        with pytest.raises(RuntimeError, match="Database pool not configured"):
+            await handler.handle(archive_command)
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_archive_path_with_uuid_hyphens(
+        self,
+        handler: HandlerMemoryArchive,
+        fixed_now: datetime,
+    ) -> None:
+        """Test archive path preserves UUID format with hyphens.
+
+        Given: Standard UUID with hyphens
+        When: Generating archive path
+        Then: Path contains UUID with hyphens
+        """
+        memory_id = UUID("12345678-1234-5678-1234-567812345678")
+        path = handler._get_archive_path(memory_id, fixed_now)
+
+        assert "12345678-1234-5678-1234-567812345678" in str(path)
+
+    def test_large_content_serialization(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization handles large content.
+
+        Given: Archive record with large content (1MB)
+        When: Serializing
+        Then: Compression produces smaller output
+        """
+        large_content = "x" * (1024 * 1024)  # 1MB of text
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content=large_content,
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+
+        # Compression should reduce size significantly
+        original_size = len(large_content.encode("utf-8"))
+        assert len(compressed) < original_size / 5  # At least 5x compression
+
+    def test_unicode_content_serialization(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test serialization handles unicode content correctly.
+
+        Given: Archive record with unicode content
+        When: Serializing and deserializing
+        Then: Unicode is preserved correctly
+        """
+        unicode_content = "Hello World! Emojis allowed in content for test purposes."
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content=unicode_content,
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        compressed = handler._serialize_for_archive(record)
+        decompressed = gzip.decompress(compressed).decode("utf-8")
+        parsed = json.loads(decompressed.rstrip("\n"))
+
+        assert parsed["content"] == unicode_content
+
+    @pytest.mark.asyncio
+    async def test_write_empty_data(
+        self,
+        handler: HandlerMemoryArchive,
+        archive_base_path: Path,
+    ) -> None:
+        """Test writing empty data creates empty file.
+
+        Given: Empty bytes data
+        When: Writing to archive
+        Then: File is created with 0 bytes
+        """
+        target_path = archive_base_path / "empty.jsonl.gz"
+        empty_data = b""
+
+        bytes_written = await handler._write_archive_atomic(target_path, empty_data)
+
+        assert target_path.exists()
+        assert bytes_written == 0
+        assert target_path.stat().st_size == 0
+
+    def test_archive_path_year_2099(
+        self,
+        handler: HandlerMemoryArchive,
+        memory_id: UUID,
+        archive_base_path: Path,
+    ) -> None:
+        """Test archive path handles far future dates.
+
+        Given: Date in year 2099
+        When: Generating archive path
+        Then: Path is generated correctly
+        """
+        future_date = datetime(2099, 12, 31, tzinfo=timezone.utc)
+        path = handler._get_archive_path(memory_id, future_date)
+
+        assert "2099/12/31" in str(path)

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
@@ -374,7 +374,7 @@ class TestArchiveFormat:
             lifecycle_revision=1,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
 
         # Verify it's valid gzip by decompressing
         decompressed = gzip.decompress(compressed)
@@ -402,7 +402,7 @@ class TestArchiveFormat:
             lifecycle_revision=1,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
         decompressed = gzip.decompress(compressed).decode("utf-8")
 
         # JSONL format: JSON followed by newline
@@ -446,7 +446,7 @@ class TestArchiveFormat:
             metadata=metadata,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
         decompressed = gzip.decompress(compressed).decode("utf-8")
         parsed = json.loads(decompressed.rstrip("\n"))
 
@@ -478,7 +478,7 @@ class TestArchiveFormat:
             lifecycle_revision=1,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
         decompressed = gzip.decompress(compressed).decode("utf-8")
         parsed = json.loads(decompressed.rstrip("\n"))
 
@@ -1046,7 +1046,7 @@ class TestEdgeCases:
             lifecycle_revision=1,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
 
         # Compression should reduce size significantly
         original_size = len(large_content.encode("utf-8"))
@@ -1075,7 +1075,7 @@ class TestEdgeCases:
             lifecycle_revision=1,
         )
 
-        compressed = handler._serialize_for_archive(record)
+        compressed = handler._serialize_for_archive_sync(record)
         decompressed = gzip.decompress(compressed).decode("utf-8")
         parsed = json.loads(decompressed.rstrip("\n"))
 

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
@@ -28,10 +28,11 @@ import json
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 from uuid import UUID
 
 import pytest
+from omnibase_core.models.infrastructure.model_value import ModelValue
+from omnibase_core.models.metadata.model_generic_metadata import ModelGenericMetadata
 from pydantic import ValidationError
 
 from omnimemory.nodes.memory_lifecycle_orchestrator.handlers import (
@@ -137,7 +138,10 @@ def sample_archive_record(
         expired_at=fixed_now - timedelta(days=1),  # Expired 1 day ago
         archived_at=fixed_now,
         lifecycle_revision=5,
-        metadata={"source": "test", "tags": ["important", "archive"]},
+        metadata=ModelGenericMetadata(
+            tags=["important", "archive"],
+            custom_fields={"source": ModelValue.from_string("test")},
+        ),
     )
 
 
@@ -420,11 +424,17 @@ class TestArchiveFormat:
     ) -> None:
         """Test serialization preserves metadata in archive.
 
-        Given: An archive record with metadata
+        Given: An archive record with ModelGenericMetadata
         When: Serializing and deserializing
-        Then: Metadata is preserved correctly
+        Then: Metadata structure is preserved correctly
         """
-        metadata = {"source": "test", "priority": 1, "tags": ["a", "b"]}
+        metadata = ModelGenericMetadata(
+            tags=["a", "b"],
+            custom_fields={
+                "source": ModelValue.from_string("test"),
+                "priority": ModelValue.from_integer(1),
+            },
+        )
         record = ModelArchiveRecord(
             memory_id=memory_id,
             content="Content with metadata",
@@ -440,7 +450,11 @@ class TestArchiveFormat:
         decompressed = gzip.decompress(compressed).decode("utf-8")
         parsed = json.loads(decompressed.rstrip("\n"))
 
-        assert parsed["metadata"] == metadata
+        # Verify metadata structure is preserved after serialization
+        assert parsed["metadata"] is not None
+        assert parsed["metadata"]["tags"] == ["a", "b"]
+        assert parsed["metadata"]["custom_fields"]["source"]["raw_value"] == "test"
+        assert parsed["metadata"]["custom_fields"]["priority"]["raw_value"] == 1
 
     def test_serialize_includes_archive_version(
         self,
@@ -736,6 +750,7 @@ class TestArchiveResultModel:
 
         assert result.success is False
         assert result.conflict is True
+        assert result.error_message is not None
         assert "Revision conflict" in result.error_message
         assert result.archived_at is None
         assert result.archive_path is None
@@ -757,6 +772,7 @@ class TestArchiveResultModel:
 
         assert result.success is False
         assert result.conflict is False
+        assert result.error_message is not None
         assert "Cannot archive" in result.error_message
 
     def test_result_bytes_written_default(self, memory_id: UUID) -> None:
@@ -875,17 +891,19 @@ class TestArchiveRecordModel:
         memory_id: UUID,
         fixed_now: datetime,
     ) -> None:
-        """Test record accepts metadata dict.
+        """Test record accepts ModelGenericMetadata.
 
-        Given: Metadata dictionary
+        Given: ModelGenericMetadata instance
         When: Creating ModelArchiveRecord
         Then: metadata is stored correctly
         """
-        metadata: dict[str, Any] = {
-            "source": "agent",
-            "priority": 1,
-            "tags": ["important"],
-        }
+        metadata = ModelGenericMetadata(
+            tags=["important"],
+            custom_fields={
+                "source": ModelValue.from_string("agent"),
+                "priority": ModelValue.from_integer(1),
+            },
+        )
         record = ModelArchiveRecord(
             memory_id=memory_id,
             content="Test",
@@ -898,6 +916,11 @@ class TestArchiveRecordModel:
         )
 
         assert record.metadata == metadata
+        assert record.metadata is not None
+        assert record.metadata.tags == ["important"]
+        assert record.metadata.custom_fields is not None
+        assert record.metadata.custom_fields["source"].to_python_value() == "agent"
+        assert record.metadata.custom_fields["priority"].to_python_value() == 1
 
     def test_record_is_frozen(
         self,

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
@@ -3,16 +3,18 @@
 """Unit tests for HandlerMemoryExpire.
 
 Tests the memory expiration handler that performs ACTIVE -> EXPIRED state
-transitions using optimistic locking. Tests cover stub mode behavior,
-conflict detection, retry logic, and state validation.
+transitions using optimistic locking. Tests cover error handling when db_pool
+is not configured, model validation, and SQL pattern documentation.
 
 Test Categories:
     - Initialization: Handler setup with max_retries validation
-    - Stub Mode: Success behavior when no database pool configured
-    - Conflict Detection: Revision mismatch handling
-    - Retry Logic: handle_with_retry() behavior
-    - State Validation: Only ACTIVE memories can be expired
-    - Revision Increment: New revision on success
+    - No Database Pool: RuntimeError behavior when db_pool not configured
+    - Command Validation: ModelExpireMemoryCommand field validation
+    - Result Model: ModelMemoryExpireResult representation
+    - Current State Model: ModelMemoryCurrentState validation
+    - Retry Logic: handle_with_retry() error behavior without db_pool
+    - Edge Cases: Command boundary condition validation
+    - SQL Pattern Documentation: SQL constant verification
 
 Related Tickets:
     - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
@@ -60,16 +62,6 @@ def memory_id() -> UUID:
         A deterministic UUID for the memory.
     """
     return UUID("12345678-abcd-1234-abcd-567812345678")
-
-
-@pytest.fixture
-def handler_stub() -> HandlerMemoryExpire:
-    """Create handler in stub mode (no db_pool).
-
-    Returns:
-        HandlerMemoryExpire instance without database connection.
-    """
-    return HandlerMemoryExpire(db_pool=None)
 
 
 @pytest.fixture
@@ -152,69 +144,67 @@ class TestHandlerMemoryExpireInitialization:
 
 
 # =============================================================================
-# Stub Mode Tests
+# No Database Pool Tests
 # =============================================================================
 
 
-class TestStubMode:
-    """Tests for handler behavior in stub mode (no database)."""
+class TestNoDatabasePool:
+    """Tests for handler behavior when db_pool is not configured."""
 
     @pytest.mark.asyncio
-    async def test_expire_success_in_stub_mode(
+    async def test_handle_without_db_pool_raises_error(
         self,
-        handler_stub: HandlerMemoryExpire,
-        expire_command: ModelExpireMemoryCommand,
+        memory_id: UUID,
     ) -> None:
-        """Test handler returns success in stub mode.
+        """Test that handle() raises RuntimeError when db_pool is not configured.
 
-        Given: Handler without db_pool (stub mode)
-        When: Handling an expire command
-        Then: Returns success with incremented revision
+        Given: Handler without db_pool
+        When: Calling handle()
+        Then: RuntimeError is raised with appropriate message
         """
-        result = await handler_stub.handle(expire_command)
+        handler = HandlerMemoryExpire()
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+        )
 
-        assert result.success is True
-        assert result.new_revision == expire_command.expected_revision + 1
-        assert result.conflict is False
-        assert result.error_message is None
-        assert result.previous_state == EnumLifecycleState.ACTIVE
+        with pytest.raises(RuntimeError, match="Database pool not configured"):
+            await handler.handle(command)
 
     @pytest.mark.asyncio
-    async def test_stub_mode_returns_correct_memory_id(
+    async def test_handle_without_db_pool_raises_error_with_custom_params(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
         fixed_now: datetime,
     ) -> None:
-        """Test stub mode returns correct memory_id in result.
+        """Test that handle() raises RuntimeError regardless of command parameters.
 
-        Given: Handler in stub mode
-        When: Handling an expire command
-        Then: Result contains correct memory_id
+        Given: Handler without db_pool and command with custom parameters
+        When: Calling handle()
+        Then: RuntimeError is raised
         """
+        handler = HandlerMemoryExpire()
         command = ModelExpireMemoryCommand(
             memory_id=memory_id,
             expected_revision=5,
             expired_at=fixed_now,
         )
 
-        result = await handler_stub.handle(command)
-
-        assert result.memory_id == memory_id
-        assert result.new_revision == 6
+        with pytest.raises(RuntimeError, match="Database pool not configured"):
+            await handler.handle(command)
 
     @pytest.mark.asyncio
-    async def test_stub_mode_increments_revision_correctly(
+    async def test_handle_without_db_pool_raises_error_for_various_revisions(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test stub mode increments revision by 1.
+        """Test that handle() raises RuntimeError for any expected_revision.
 
-        Given: Various expected_revision values
-        When: Handling expire commands
-        Then: new_revision = expected_revision + 1
+        Given: Handler without db_pool and various revision values
+        When: Calling handle()
+        Then: RuntimeError is raised for all cases
         """
+        handler = HandlerMemoryExpire()
         test_cases = [0, 1, 5, 100, 999]
 
         for expected_revision in test_cases:
@@ -222,9 +212,9 @@ class TestStubMode:
                 memory_id=memory_id,
                 expected_revision=expected_revision,
             )
-            result = await handler_stub.handle(command)
 
-            assert result.new_revision == expected_revision + 1
+            with pytest.raises(RuntimeError, match="Database pool not configured"):
+                await handler.handle(command)
 
 
 # =============================================================================
@@ -498,122 +488,107 @@ class TestCurrentStateModel:
 
 
 # =============================================================================
-# Retry Logic Tests (Stub Mode)
+# Retry Logic Tests (No Database Pool)
 # =============================================================================
 
 
 class TestRetryLogic:
-    """Tests for handle_with_retry() behavior in stub mode."""
+    """Tests for handle_with_retry() behavior when db_pool is not configured."""
 
     @pytest.mark.asyncio
-    async def test_retry_succeeds_first_attempt_in_stub_mode(
+    async def test_handle_with_retry_without_db_pool_raises_error(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
         fixed_now: datetime,
     ) -> None:
-        """Test handle_with_retry succeeds on first attempt in stub mode.
+        """Test handle_with_retry raises RuntimeError when db_pool is not configured.
 
-        Given: Handler in stub mode
+        Given: Handler without db_pool
         When: Calling handle_with_retry
-        Then: Returns success on first attempt
+        Then: RuntimeError is raised
         """
-        result = await handler_stub.handle_with_retry(
-            memory_id=memory_id,
-            initial_revision=1,
-            reason="test_retry",
-            expired_at=fixed_now,
-        )
+        handler = HandlerMemoryExpire()
 
-        assert result.success is True
-        assert result.new_revision == 2
-        assert result.conflict is False
+        with pytest.raises(RuntimeError, match="Database pool not configured"):
+            await handler.handle_with_retry(
+                memory_id=memory_id,
+                initial_revision=1,
+                reason="test_retry",
+                expired_at=fixed_now,
+            )
 
     @pytest.mark.asyncio
-    async def test_retry_uses_correct_parameters(
+    async def test_handle_with_retry_without_db_pool_raises_error_with_params(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test handle_with_retry passes correct parameters to handle().
+        """Test handle_with_retry raises RuntimeError regardless of parameters.
 
-        Given: Specific parameters for retry
+        Given: Handler without db_pool and specific parameters
         When: Calling handle_with_retry
-        Then: Parameters are correctly used
+        Then: RuntimeError is raised
         """
-        result = await handler_stub.handle_with_retry(
-            memory_id=memory_id,
-            initial_revision=10,
-            reason="custom_reason",
-        )
+        handler = HandlerMemoryExpire()
 
-        assert result.memory_id == memory_id
-        assert result.new_revision == 11
+        with pytest.raises(RuntimeError, match="Database pool not configured"):
+            await handler.handle_with_retry(
+                memory_id=memory_id,
+                initial_revision=10,
+                reason="custom_reason",
+            )
 
 
 # =============================================================================
-# Edge Cases
+# Edge Cases - Command Validation
 # =============================================================================
 
 
 class TestEdgeCases:
-    """Tests for edge cases and boundary conditions."""
+    """Tests for edge cases and boundary conditions in command creation."""
 
-    @pytest.mark.asyncio
-    async def test_large_revision_number(
+    def test_large_revision_number_accepted(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test handler handles large revision numbers correctly.
+        """Test command accepts large revision numbers.
 
         Given: Very large expected_revision
-        When: Handling expire command
-        Then: Returns success with incremented revision
+        When: Creating expire command
+        Then: Command is created successfully
         """
         command = ModelExpireMemoryCommand(
             memory_id=memory_id,
             expected_revision=999999999,
         )
 
-        result = await handler_stub.handle(command)
+        assert command.expected_revision == 999999999
 
-        assert result.success is True
-        assert result.new_revision == 1000000000
-
-    @pytest.mark.asyncio
-    async def test_zero_revision(
+    def test_zero_revision_accepted(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test handler handles revision 0 correctly.
+        """Test command accepts revision 0.
 
         Given: expected_revision = 0 (first revision)
-        When: Handling expire command
-        Then: Returns success with new_revision = 1
+        When: Creating expire command
+        Then: Command is created successfully
         """
         command = ModelExpireMemoryCommand(
             memory_id=memory_id,
             expected_revision=0,
         )
 
-        result = await handler_stub.handle(command)
+        assert command.expected_revision == 0
 
-        assert result.success is True
-        assert result.new_revision == 1
-
-    @pytest.mark.asyncio
-    async def test_custom_expired_at_timestamp(
+    def test_custom_expired_at_timestamp_accepted(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test handler accepts custom expired_at timestamp.
+        """Test command accepts custom expired_at timestamp.
 
         Given: Custom expired_at timestamp
-        When: Handling expire command
-        Then: Command is processed successfully
+        When: Creating expire command
+        Then: Command is created with the custom timestamp
         """
         custom_time = datetime(2020, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
         command = ModelExpireMemoryCommand(
@@ -622,21 +597,17 @@ class TestEdgeCases:
             expired_at=custom_time,
         )
 
-        result = await handler_stub.handle(command)
+        assert command.expired_at == custom_time
 
-        assert result.success is True
-
-    @pytest.mark.asyncio
-    async def test_none_expired_at_uses_current_time(
+    def test_none_expired_at_accepted(
         self,
-        handler_stub: HandlerMemoryExpire,
         memory_id: UUID,
     ) -> None:
-        """Test handler uses current time when expired_at is None.
+        """Test command accepts None for expired_at.
 
         Given: No expired_at provided
-        When: Handling expire command
-        Then: Command is processed using current time
+        When: Creating expire command
+        Then: Command is created with expired_at=None
         """
         command = ModelExpireMemoryCommand(
             memory_id=memory_id,
@@ -644,9 +615,7 @@ class TestEdgeCases:
             expired_at=None,
         )
 
-        result = await handler_stub.handle(command)
-
-        assert result.success is True
+        assert command.expired_at is None
 
 
 # =============================================================================

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
@@ -669,13 +669,17 @@ class TestSQLPatternDocumentation:
 
         Given: HandlerMemoryExpire class
         When: Checking for _VALID_FROM_STATES attribute
-        Then: Attribute exists and contains expected states
+        Then: Attribute exists and contains only ACTIVE state
+
+        Note: Only ACTIVE memories can be expired. You cannot expire an
+        already EXPIRED memory - that would be a no-op or error condition.
         """
         assert hasattr(HandlerMemoryExpire, "_VALID_FROM_STATES")
         valid_states = HandlerMemoryExpire._VALID_FROM_STATES
 
-        # Verify contains expected states
+        # Only ACTIVE memories can be expired
         assert EnumLifecycleState.ACTIVE in valid_states
-        assert EnumLifecycleState.EXPIRED in valid_states
+        # EXPIRED is NOT a valid source state - can't expire already expired
+        assert EnumLifecycleState.EXPIRED not in valid_states
         assert EnumLifecycleState.ARCHIVED not in valid_states
         assert EnumLifecycleState.DELETED not in valid_states

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py
@@ -1,0 +1,712 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerMemoryExpire.
+
+Tests the memory expiration handler that performs ACTIVE -> EXPIRED state
+transitions using optimistic locking. Tests cover stub mode behavior,
+conflict detection, retry logic, and state validation.
+
+Test Categories:
+    - Initialization: Handler setup with max_retries validation
+    - Stub Mode: Success behavior when no database pool configured
+    - Conflict Detection: Revision mismatch handling
+    - Retry Logic: handle_with_retry() behavior
+    - State Validation: Only ACTIVE memories can be expired
+    - Revision Increment: New revision on success
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_expire.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from omnimemory.enums import EnumLifecycleState
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers import (
+    HandlerMemoryExpire,
+    ModelExpireMemoryCommand,
+    ModelMemoryCurrentState,
+    ModelMemoryExpireResult,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """Provide a fixed timestamp for deterministic testing.
+
+    Returns:
+        A fixed datetime in UTC timezone.
+    """
+    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def memory_id() -> UUID:
+    """Provide a fixed memory ID for testing.
+
+    Returns:
+        A deterministic UUID for the memory.
+    """
+    return UUID("12345678-abcd-1234-abcd-567812345678")
+
+
+@pytest.fixture
+def handler_stub() -> HandlerMemoryExpire:
+    """Create handler in stub mode (no db_pool).
+
+    Returns:
+        HandlerMemoryExpire instance without database connection.
+    """
+    return HandlerMemoryExpire(db_pool=None)
+
+
+@pytest.fixture
+def expire_command(memory_id: UUID, fixed_now: datetime) -> ModelExpireMemoryCommand:
+    """Create an expiration command for testing.
+
+    Args:
+        memory_id: The memory entity ID.
+        fixed_now: Fixed timestamp for expiration.
+
+    Returns:
+        Configured ModelExpireMemoryCommand instance.
+    """
+    return ModelExpireMemoryCommand(
+        memory_id=memory_id,
+        expected_revision=1,
+        reason="ttl_expired",
+        expired_at=fixed_now,
+    )
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+class TestHandlerMemoryExpireInitialization:
+    """Tests for HandlerMemoryExpire initialization."""
+
+    def test_handler_creates_without_db_pool(self) -> None:
+        """Test handler can be created without database pool.
+
+        Given: No db_pool provided
+        When: Creating HandlerMemoryExpire
+        Then: Handler is created in stub mode
+        """
+        handler = HandlerMemoryExpire(db_pool=None)
+        assert handler is not None
+        assert handler._db_pool is None
+
+    def test_handler_default_max_retries(self) -> None:
+        """Test handler uses default max_retries of 3.
+
+        Given: No max_retries provided
+        When: Creating HandlerMemoryExpire
+        Then: Handler uses default max_retries of 3
+        """
+        handler = HandlerMemoryExpire()
+        assert handler.max_retries == 3
+
+    def test_handler_custom_max_retries(self) -> None:
+        """Test handler can be created with custom max_retries.
+
+        Given: Custom max_retries value
+        When: Creating HandlerMemoryExpire
+        Then: Handler uses the custom value
+        """
+        handler = HandlerMemoryExpire(max_retries=5)
+        assert handler.max_retries == 5
+
+    def test_handler_rejects_invalid_max_retries(self) -> None:
+        """Test handler rejects max_retries < 1.
+
+        Given: max_retries = 0
+        When: Creating HandlerMemoryExpire
+        Then: ValueError is raised
+        """
+        with pytest.raises(ValueError, match="max_retries must be >= 1"):
+            HandlerMemoryExpire(max_retries=0)
+
+    def test_handler_rejects_negative_max_retries(self) -> None:
+        """Test handler rejects negative max_retries.
+
+        Given: max_retries = -1
+        When: Creating HandlerMemoryExpire
+        Then: ValueError is raised
+        """
+        with pytest.raises(ValueError, match="max_retries must be >= 1"):
+            HandlerMemoryExpire(max_retries=-1)
+
+
+# =============================================================================
+# Stub Mode Tests
+# =============================================================================
+
+
+class TestStubMode:
+    """Tests for handler behavior in stub mode (no database)."""
+
+    @pytest.mark.asyncio
+    async def test_expire_success_in_stub_mode(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        expire_command: ModelExpireMemoryCommand,
+    ) -> None:
+        """Test handler returns success in stub mode.
+
+        Given: Handler without db_pool (stub mode)
+        When: Handling an expire command
+        Then: Returns success with incremented revision
+        """
+        result = await handler_stub.handle(expire_command)
+
+        assert result.success is True
+        assert result.new_revision == expire_command.expected_revision + 1
+        assert result.conflict is False
+        assert result.error_message is None
+        assert result.previous_state == EnumLifecycleState.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_stub_mode_returns_correct_memory_id(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test stub mode returns correct memory_id in result.
+
+        Given: Handler in stub mode
+        When: Handling an expire command
+        Then: Result contains correct memory_id
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=5,
+            expired_at=fixed_now,
+        )
+
+        result = await handler_stub.handle(command)
+
+        assert result.memory_id == memory_id
+        assert result.new_revision == 6
+
+    @pytest.mark.asyncio
+    async def test_stub_mode_increments_revision_correctly(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test stub mode increments revision by 1.
+
+        Given: Various expected_revision values
+        When: Handling expire commands
+        Then: new_revision = expected_revision + 1
+        """
+        test_cases = [0, 1, 5, 100, 999]
+
+        for expected_revision in test_cases:
+            command = ModelExpireMemoryCommand(
+                memory_id=memory_id,
+                expected_revision=expected_revision,
+            )
+            result = await handler_stub.handle(command)
+
+            assert result.new_revision == expected_revision + 1
+
+
+# =============================================================================
+# Model Validation Tests
+# =============================================================================
+
+
+class TestCommandValidation:
+    """Tests for ModelExpireMemoryCommand validation."""
+
+    def test_command_requires_memory_id(self) -> None:
+        """Test command requires memory_id field.
+
+        Given: No memory_id provided
+        When: Creating ModelExpireMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelExpireMemoryCommand(
+                expected_revision=1,
+            )  # type: ignore[call-arg]
+
+    def test_command_requires_expected_revision(self, memory_id: UUID) -> None:
+        """Test command requires expected_revision field.
+
+        Given: No expected_revision provided
+        When: Creating ModelExpireMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelExpireMemoryCommand(
+                memory_id=memory_id,
+            )  # type: ignore[call-arg]
+
+    def test_command_rejects_negative_revision(self, memory_id: UUID) -> None:
+        """Test command rejects negative expected_revision.
+
+        Given: negative expected_revision
+        When: Creating ModelExpireMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelExpireMemoryCommand(
+                memory_id=memory_id,
+                expected_revision=-1,
+            )
+
+    def test_command_accepts_zero_revision(self, memory_id: UUID) -> None:
+        """Test command accepts zero expected_revision.
+
+        Given: expected_revision = 0
+        When: Creating ModelExpireMemoryCommand
+        Then: Command is created successfully
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=0,
+        )
+        assert command.expected_revision == 0
+
+    def test_command_default_reason(self, memory_id: UUID) -> None:
+        """Test command has default reason of 'ttl_expired'.
+
+        Given: No reason provided
+        When: Creating ModelExpireMemoryCommand
+        Then: reason defaults to 'ttl_expired'
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+        )
+        assert command.reason == "ttl_expired"
+
+    def test_command_custom_reason(self, memory_id: UUID) -> None:
+        """Test command accepts custom reason.
+
+        Given: Custom reason provided
+        When: Creating ModelExpireMemoryCommand
+        Then: Command uses the custom reason
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+            reason="manual_expiration",
+        )
+        assert command.reason == "manual_expiration"
+
+    def test_command_reason_max_length(self, memory_id: UUID) -> None:
+        """Test command reason has max length of 256.
+
+        Given: reason longer than 256 characters
+        When: Creating ModelExpireMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelExpireMemoryCommand(
+                memory_id=memory_id,
+                expected_revision=1,
+                reason="x" * 257,
+            )
+
+    def test_command_reason_min_length(self, memory_id: UUID) -> None:
+        """Test command reason has min length of 1.
+
+        Given: empty reason
+        When: Creating ModelExpireMemoryCommand
+        Then: ValidationError is raised
+        """
+        with pytest.raises(ValidationError):
+            ModelExpireMemoryCommand(
+                memory_id=memory_id,
+                expected_revision=1,
+                reason="",
+            )
+
+    def test_command_is_frozen(self, memory_id: UUID) -> None:
+        """Test command model is immutable.
+
+        Given: A ModelExpireMemoryCommand instance
+        When: Attempting to modify a field
+        Then: Error is raised
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+        )
+
+        with pytest.raises(ValidationError):
+            command.expected_revision = 5  # type: ignore[misc]
+
+
+# =============================================================================
+# Result Model Tests
+# =============================================================================
+
+
+class TestResultModel:
+    """Tests for ModelMemoryExpireResult model."""
+
+    def test_result_success_state(self, memory_id: UUID) -> None:
+        """Test result model for successful expiration.
+
+        Given: Successful expiration data
+        When: Creating ModelMemoryExpireResult
+        Then: Model represents success correctly
+        """
+        result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=6,
+            conflict=False,
+            previous_state=EnumLifecycleState.ACTIVE,
+        )
+
+        assert result.success is True
+        assert result.new_revision == 6
+        assert result.conflict is False
+        assert result.error_message is None
+        assert result.previous_state == EnumLifecycleState.ACTIVE
+
+    def test_result_conflict_state(self, memory_id: UUID) -> None:
+        """Test result model for conflict scenario.
+
+        Given: Conflict expiration data
+        When: Creating ModelMemoryExpireResult
+        Then: Model represents conflict correctly
+        """
+        result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=True,
+            error_message="Revision conflict: expected 5, found 7",
+            previous_state=EnumLifecycleState.ACTIVE,
+        )
+
+        assert result.success is False
+        assert result.conflict is True
+        assert result.new_revision is None
+        assert "Revision conflict" in result.error_message
+        assert result.previous_state == EnumLifecycleState.ACTIVE
+
+    def test_result_hard_failure_state(self, memory_id: UUID) -> None:
+        """Test result model for hard failure (invalid state).
+
+        Given: Invalid state failure data
+        When: Creating ModelMemoryExpireResult
+        Then: Model represents hard failure correctly
+        """
+        result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=False,
+            error_message="Cannot expire memory in state archived",
+            previous_state=EnumLifecycleState.ARCHIVED,
+        )
+
+        assert result.success is False
+        assert result.conflict is False
+        assert result.new_revision is None
+        assert "Cannot expire" in result.error_message
+        assert result.previous_state == EnumLifecycleState.ARCHIVED
+
+    def test_result_is_frozen(self, memory_id: UUID) -> None:
+        """Test result model is immutable.
+
+        Given: A ModelMemoryExpireResult instance
+        When: Attempting to modify a field
+        Then: Error is raised
+        """
+        result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+
+        with pytest.raises(ValidationError):
+            result.success = False  # type: ignore[misc]
+
+
+# =============================================================================
+# Current State Model Tests
+# =============================================================================
+
+
+class TestCurrentStateModel:
+    """Tests for ModelMemoryCurrentState model."""
+
+    def test_current_state_creation(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test ModelMemoryCurrentState can be created with valid data.
+
+        Given: Valid current state data
+        When: Creating ModelMemoryCurrentState
+        Then: Model is created successfully
+        """
+        state = ModelMemoryCurrentState(
+            memory_id=memory_id,
+            lifecycle_state=EnumLifecycleState.ACTIVE,
+            lifecycle_revision=5,
+            updated_at=fixed_now,
+        )
+
+        assert state.memory_id == memory_id
+        assert state.lifecycle_state == EnumLifecycleState.ACTIVE
+        assert state.lifecycle_revision == 5
+        assert state.updated_at == fixed_now
+
+    def test_current_state_is_frozen(
+        self,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test ModelMemoryCurrentState is immutable.
+
+        Given: A ModelMemoryCurrentState instance
+        When: Attempting to modify a field
+        Then: Error is raised
+        """
+        state = ModelMemoryCurrentState(
+            memory_id=memory_id,
+            lifecycle_state=EnumLifecycleState.ACTIVE,
+            lifecycle_revision=5,
+            updated_at=fixed_now,
+        )
+
+        with pytest.raises(ValidationError):
+            state.lifecycle_revision = 10  # type: ignore[misc]
+
+
+# =============================================================================
+# Retry Logic Tests (Stub Mode)
+# =============================================================================
+
+
+class TestRetryLogic:
+    """Tests for handle_with_retry() behavior in stub mode."""
+
+    @pytest.mark.asyncio
+    async def test_retry_succeeds_first_attempt_in_stub_mode(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test handle_with_retry succeeds on first attempt in stub mode.
+
+        Given: Handler in stub mode
+        When: Calling handle_with_retry
+        Then: Returns success on first attempt
+        """
+        result = await handler_stub.handle_with_retry(
+            memory_id=memory_id,
+            initial_revision=1,
+            reason="test_retry",
+            expired_at=fixed_now,
+        )
+
+        assert result.success is True
+        assert result.new_revision == 2
+        assert result.conflict is False
+
+    @pytest.mark.asyncio
+    async def test_retry_uses_correct_parameters(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test handle_with_retry passes correct parameters to handle().
+
+        Given: Specific parameters for retry
+        When: Calling handle_with_retry
+        Then: Parameters are correctly used
+        """
+        result = await handler_stub.handle_with_retry(
+            memory_id=memory_id,
+            initial_revision=10,
+            reason="custom_reason",
+        )
+
+        assert result.memory_id == memory_id
+        assert result.new_revision == 11
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    @pytest.mark.asyncio
+    async def test_large_revision_number(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test handler handles large revision numbers correctly.
+
+        Given: Very large expected_revision
+        When: Handling expire command
+        Then: Returns success with incremented revision
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=999999999,
+        )
+
+        result = await handler_stub.handle(command)
+
+        assert result.success is True
+        assert result.new_revision == 1000000000
+
+    @pytest.mark.asyncio
+    async def test_zero_revision(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test handler handles revision 0 correctly.
+
+        Given: expected_revision = 0 (first revision)
+        When: Handling expire command
+        Then: Returns success with new_revision = 1
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=0,
+        )
+
+        result = await handler_stub.handle(command)
+
+        assert result.success is True
+        assert result.new_revision == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_expired_at_timestamp(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test handler accepts custom expired_at timestamp.
+
+        Given: Custom expired_at timestamp
+        When: Handling expire command
+        Then: Command is processed successfully
+        """
+        custom_time = datetime(2020, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+            expired_at=custom_time,
+        )
+
+        result = await handler_stub.handle(command)
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_none_expired_at_uses_current_time(
+        self,
+        handler_stub: HandlerMemoryExpire,
+        memory_id: UUID,
+    ) -> None:
+        """Test handler uses current time when expired_at is None.
+
+        Given: No expired_at provided
+        When: Handling expire command
+        Then: Command is processed using current time
+        """
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=1,
+            expired_at=None,
+        )
+
+        result = await handler_stub.handle(command)
+
+        assert result.success is True
+
+
+# =============================================================================
+# SQL Pattern Documentation Tests
+# =============================================================================
+
+
+class TestSQLPatternDocumentation:
+    """Tests verifying SQL patterns are properly documented.
+
+    These tests verify the handler has the expected SQL constants
+    documented for future database implementation (OMN-1524).
+    """
+
+    def test_expire_sql_constant_exists(self) -> None:
+        """Test EXPIRE_SQL constant is defined.
+
+        Given: HandlerMemoryExpire class
+        When: Checking for _EXPIRE_SQL attribute
+        Then: Attribute exists and contains expected SQL pattern
+        """
+        assert hasattr(HandlerMemoryExpire, "_EXPIRE_SQL")
+        sql = HandlerMemoryExpire._EXPIRE_SQL
+
+        # Verify SQL contains key elements
+        assert "UPDATE memories" in sql
+        assert "lifecycle_state" in sql
+        assert "expired_at" in sql
+        assert "lifecycle_revision" in sql
+        assert "WHERE" in sql
+        assert "RETURNING" in sql
+
+    def test_read_state_sql_constant_exists(self) -> None:
+        """Test READ_STATE_SQL constant is defined.
+
+        Given: HandlerMemoryExpire class
+        When: Checking for _READ_STATE_SQL attribute
+        Then: Attribute exists and contains expected SQL pattern
+        """
+        assert hasattr(HandlerMemoryExpire, "_READ_STATE_SQL")
+        sql = HandlerMemoryExpire._READ_STATE_SQL
+
+        # Verify SQL contains key elements
+        assert "SELECT" in sql
+        assert "lifecycle_state" in sql
+        assert "lifecycle_revision" in sql
+        assert "FROM memories" in sql
+
+    def test_valid_from_states_constant_exists(self) -> None:
+        """Test VALID_FROM_STATES constant is defined.
+
+        Given: HandlerMemoryExpire class
+        When: Checking for _VALID_FROM_STATES attribute
+        Then: Attribute exists and contains expected states
+        """
+        assert hasattr(HandlerMemoryExpire, "_VALID_FROM_STATES")
+        valid_states = HandlerMemoryExpire._VALID_FROM_STATES
+
+        # Verify contains expected states
+        assert EnumLifecycleState.ACTIVE in valid_states
+        assert EnumLifecycleState.EXPIRED in valid_states
+        assert EnumLifecycleState.ARCHIVED not in valid_states
+        assert EnumLifecycleState.DELETED not in valid_states

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_tick.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_tick.py
@@ -1,0 +1,971 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerMemoryTick.
+
+Tests the RuntimeTick handler that evaluates memory entities for TTL
+expiration and archive eligibility. Tests cover the handler's behavior
+with mocked projection readers and various memory lifecycle scenarios.
+
+Test Categories:
+    - Initialization: Handler setup and configuration
+    - No Candidates: Empty projection reader scenarios
+    - Expiration Detection: Finding expired memories correctly
+    - Archive Detection: Finding archive candidates correctly
+    - Deduplication: Same memory not re-emitted
+    - Batch Limiting: Respecting batch_size configuration
+
+Related Tickets:
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_tick.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from omnibase_core.enums import EnumMessageCategory, EnumNodeKind
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick import (
+    HandlerMemoryTick,
+    ModelMemoryArchiveInitiated,
+    ModelMemoryExpiredEvent,
+    ModelMemoryLifecycleProjection,
+    ModelMemoryTickResult,
+)
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """Provide a fixed timestamp for deterministic testing.
+
+    Returns:
+        A fixed datetime in UTC timezone.
+    """
+    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def tick_id() -> UUID:
+    """Provide a fixed tick ID for testing.
+
+    Returns:
+        A deterministic UUID for the tick.
+    """
+    return UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def correlation_id() -> UUID:
+    """Provide a fixed correlation ID for testing.
+
+    Returns:
+        A deterministic UUID for correlation.
+    """
+    return UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+
+@pytest.fixture
+def runtime_tick(fixed_now: datetime, tick_id: UUID) -> ModelRuntimeTick:
+    """Create a runtime tick event for testing.
+
+    Args:
+        fixed_now: Fixed timestamp for the tick.
+        tick_id: Tick identifier.
+
+    Returns:
+        Configured ModelRuntimeTick instance.
+    """
+    return ModelRuntimeTick(
+        now=fixed_now,
+        tick_id=tick_id,
+        sequence_number=1,
+        scheduled_at=fixed_now,
+        correlation_id=uuid4(),
+        scheduler_id="test-scheduler-001",
+        tick_interval_ms=1000,
+    )
+
+
+@pytest.fixture
+def tick_envelope(
+    runtime_tick: ModelRuntimeTick,
+    fixed_now: datetime,
+    correlation_id: UUID,
+) -> ModelEventEnvelope[ModelRuntimeTick]:
+    """Create an event envelope containing a runtime tick.
+
+    Args:
+        runtime_tick: The tick event payload.
+        fixed_now: Fixed timestamp.
+        correlation_id: Correlation ID for tracing.
+
+    Returns:
+        Event envelope wrapping the runtime tick.
+    """
+    return ModelEventEnvelope(
+        envelope_id=uuid4(),
+        envelope_timestamp=fixed_now,
+        correlation_id=correlation_id,
+        payload=runtime_tick,
+        source_service="test-runtime",
+        event_type="RuntimeTick",
+    )
+
+
+def create_projection(
+    entity_id: UUID | None = None,
+    lifecycle_state: str = "active",
+    expires_at: datetime | None = None,
+    expired_at: datetime | None = None,
+    archived_at: datetime | None = None,
+    lifecycle_revision: int = 1,
+    expiration_emitted_at: datetime | None = None,
+    archive_initiated_at: datetime | None = None,
+) -> ModelMemoryLifecycleProjection:
+    """Create a memory lifecycle projection for testing.
+
+    Args:
+        entity_id: Memory entity ID (auto-generated if not provided).
+        lifecycle_state: Current lifecycle state.
+        expires_at: TTL deadline.
+        expired_at: When memory transitioned to EXPIRED.
+        archived_at: When memory was archived.
+        lifecycle_revision: Revision for optimistic locking.
+        expiration_emitted_at: When expiration event was emitted.
+        archive_initiated_at: When archive initiation was emitted.
+
+    Returns:
+        Configured ModelMemoryLifecycleProjection instance.
+    """
+    return ModelMemoryLifecycleProjection(
+        entity_id=entity_id or uuid4(),
+        lifecycle_state=lifecycle_state,
+        expires_at=expires_at,
+        expired_at=expired_at,
+        archived_at=archived_at,
+        lifecycle_revision=lifecycle_revision,
+        expiration_emitted_at=expiration_emitted_at,
+        archive_initiated_at=archive_initiated_at,
+    )
+
+
+class MockProjectionReader:
+    """Mock implementation of ProtocolModelMemoryLifecycleProjectionReader."""
+
+    def __init__(
+        self,
+        expired_candidates: list[ModelMemoryLifecycleProjection] | None = None,
+        archive_candidates: list[ModelMemoryLifecycleProjection] | None = None,
+    ) -> None:
+        """Initialize mock reader with test data.
+
+        Args:
+            expired_candidates: List of projections to return for expired queries.
+            archive_candidates: List of projections to return for archive queries.
+        """
+        self._expired_candidates = expired_candidates or []
+        self._archive_candidates = archive_candidates or []
+        self.get_expired_candidates_calls: list[dict] = []
+        self.get_archive_candidates_calls: list[dict] = []
+
+    async def get_expired_candidates(
+        self,
+        now: datetime,
+        domain: str,
+        correlation_id: UUID,
+        limit: int = 100,
+    ) -> list[ModelMemoryLifecycleProjection]:
+        """Return mock expired candidates.
+
+        Args:
+            now: Current time for deadline comparison.
+            domain: Domain scope for the query.
+            correlation_id: Correlation ID for tracing.
+            limit: Maximum results to return.
+
+        Returns:
+            Configured list of expired candidate projections.
+        """
+        self.get_expired_candidates_calls.append(
+            {
+                "now": now,
+                "domain": domain,
+                "correlation_id": correlation_id,
+                "limit": limit,
+            }
+        )
+        return self._expired_candidates[:limit]
+
+    async def get_archive_candidates(
+        self,
+        now: datetime,
+        domain: str,
+        correlation_id: UUID,
+        limit: int = 100,
+    ) -> list[ModelMemoryLifecycleProjection]:
+        """Return mock archive candidates.
+
+        Args:
+            now: Current time for consistent evaluation.
+            domain: Domain scope for the query.
+            correlation_id: Correlation ID for tracing.
+            limit: Maximum results to return.
+
+        Returns:
+            Configured list of archive candidate projections.
+        """
+        self.get_archive_candidates_calls.append(
+            {
+                "now": now,
+                "domain": domain,
+                "correlation_id": correlation_id,
+                "limit": limit,
+            }
+        )
+        return self._archive_candidates[:limit]
+
+
+# =============================================================================
+# Initialization Tests
+# =============================================================================
+
+
+class TestHandlerMemoryTickInitialization:
+    """Tests for HandlerMemoryTick initialization."""
+
+    def test_handler_creates_without_projection_reader(self) -> None:
+        """Test handler can be created without projection reader.
+
+        Given: No projection reader provided
+        When: Creating HandlerMemoryTick
+        Then: Handler is created successfully in stub mode
+        """
+        handler = HandlerMemoryTick()
+        assert handler is not None
+        assert handler._projection_reader is None
+
+    def test_handler_creates_with_projection_reader(self) -> None:
+        """Test handler can be created with projection reader.
+
+        Given: A mock projection reader
+        When: Creating HandlerMemoryTick
+        Then: Handler is created with the reader attached
+        """
+        reader = MockProjectionReader()
+        handler = HandlerMemoryTick(projection_reader=reader)
+        assert handler._projection_reader is reader
+
+    def test_handler_creates_with_custom_batch_size(self) -> None:
+        """Test handler can be created with custom batch size.
+
+        Given: A custom batch_size value
+        When: Creating HandlerMemoryTick
+        Then: Handler uses the custom batch size
+        """
+        handler = HandlerMemoryTick(batch_size=50)
+        assert handler._batch_size == 50
+
+    def test_handler_default_batch_size(self) -> None:
+        """Test handler uses default batch size of 100.
+
+        Given: No batch_size provided
+        When: Creating HandlerMemoryTick
+        Then: Handler uses default batch size of 100
+        """
+        handler = HandlerMemoryTick()
+        assert handler._batch_size == 100
+
+    def test_handler_properties(self) -> None:
+        """Test handler exposes correct properties.
+
+        Given: A HandlerMemoryTick instance
+        When: Accessing handler properties
+        Then: Properties return expected values
+        """
+        handler = HandlerMemoryTick()
+
+        assert handler.handler_id == "handler-memory-tick"
+        assert handler.category == EnumMessageCategory.EVENT
+        assert handler.message_types == {"ModelRuntimeTick"}
+        assert handler.node_kind == EnumNodeKind.ORCHESTRATOR
+
+
+# =============================================================================
+# No Candidates Tests
+# =============================================================================
+
+
+class TestNoCandidates:
+    """Tests for scenarios with no lifecycle candidates."""
+
+    @pytest.mark.asyncio
+    async def test_tick_with_no_projection_reader(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """Test tick returns empty result when no projection reader.
+
+        Given: Handler with no projection reader (stub mode)
+        When: Processing a runtime tick
+        Then: Result contains zero events and success metrics
+        """
+        handler = HandlerMemoryTick()
+
+        output = await handler.handle(tick_envelope)
+
+        assert isinstance(output, ModelHandlerOutput)
+        assert output.events == ()
+        assert output.metrics["expired_count"] == 0.0
+        assert output.metrics["archive_initiated_count"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_tick_with_empty_projection(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """Test tick returns empty result when projection has no candidates.
+
+        Given: Handler with empty projection reader
+        When: Processing a runtime tick
+        Then: Result contains zero events
+        """
+        reader = MockProjectionReader(
+            expired_candidates=[],
+            archive_candidates=[],
+        )
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert output.events == ()
+        assert output.metrics["expired_count"] == 0.0
+        assert output.metrics["archive_initiated_count"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_projection_reader_called_correctly(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+        correlation_id: UUID,
+    ) -> None:
+        """Test projection reader methods are called with correct parameters.
+
+        Given: Handler with mock projection reader
+        When: Processing a runtime tick
+        Then: Projection reader methods are called with correct args
+        """
+        reader = MockProjectionReader()
+        handler = HandlerMemoryTick(projection_reader=reader, batch_size=50)
+
+        await handler.handle(tick_envelope)
+
+        # Verify expired candidates call
+        assert len(reader.get_expired_candidates_calls) == 1
+        call = reader.get_expired_candidates_calls[0]
+        assert call["now"] == fixed_now
+        assert call["domain"] == "memory"
+        assert call["correlation_id"] == correlation_id
+        assert call["limit"] == 50
+
+        # Verify archive candidates call
+        assert len(reader.get_archive_candidates_calls) == 1
+        call = reader.get_archive_candidates_calls[0]
+        assert call["now"] == fixed_now
+        assert call["domain"] == "memory"
+        assert call["limit"] == 50
+
+
+# =============================================================================
+# Expiration Detection Tests
+# =============================================================================
+
+
+class TestExpirationDetection:
+    """Tests for memory expiration detection."""
+
+    @pytest.mark.asyncio
+    async def test_finds_expired_memory(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler finds and emits event for expired memory.
+
+        Given: A projection with one expired memory
+        When: Processing a runtime tick
+        Then: One ModelMemoryExpiredEvent is emitted
+        """
+        expired_memory = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),  # Expired 1 hour ago
+            lifecycle_revision=3,
+        )
+        reader = MockProjectionReader(expired_candidates=[expired_memory])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 1
+        event = output.events[0]
+        assert isinstance(event, ModelMemoryExpiredEvent)
+        assert event.entity_id == expired_memory.entity_id
+        assert event.memory_id == expired_memory.entity_id
+        assert event.expires_at == expired_memory.expires_at
+        assert event.lifecycle_revision == 3
+
+    @pytest.mark.asyncio
+    async def test_finds_multiple_expired_memories(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler finds and emits events for multiple expired memories.
+
+        Given: A projection with multiple expired memories
+        When: Processing a runtime tick
+        Then: Multiple ModelMemoryExpiredEvent events are emitted
+        """
+        expired_memories = [
+            create_projection(
+                lifecycle_state="active",
+                expires_at=fixed_now - timedelta(hours=i),
+            )
+            for i in range(1, 4)
+        ]
+        reader = MockProjectionReader(expired_candidates=expired_memories)
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 3
+        assert all(isinstance(e, ModelMemoryExpiredEvent) for e in output.events)
+        assert output.metrics["expired_count"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_skips_memory_not_needing_expiration(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler skips memories that don't need expiration event.
+
+        Given: A projection with memory that already has expiration emitted
+        When: Processing a runtime tick
+        Then: No event is emitted for that memory
+        """
+        # Memory that already had expiration emitted
+        already_emitted = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),
+            expiration_emitted_at=fixed_now - timedelta(minutes=30),
+        )
+        reader = MockProjectionReader(expired_candidates=[already_emitted])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        # Event should be filtered out by needs_expiration_event() check
+        assert len(output.events) == 0
+
+    @pytest.mark.asyncio
+    async def test_expiration_event_contains_correct_causation_id(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        tick_id: UUID,
+        fixed_now: datetime,
+    ) -> None:
+        """Test expired event has tick_id as causation_id.
+
+        Given: A runtime tick with specific tick_id
+        When: Processing a tick with expired memory
+        Then: Emitted event has tick_id as causation_id
+        """
+        expired_memory = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),
+        )
+        reader = MockProjectionReader(expired_candidates=[expired_memory])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 1
+        event = output.events[0]
+        assert isinstance(event, ModelMemoryExpiredEvent)
+        assert event.causation_id == tick_id
+
+
+# =============================================================================
+# Archive Detection Tests
+# =============================================================================
+
+
+class TestArchiveDetection:
+    """Tests for archive candidate detection."""
+
+    @pytest.mark.asyncio
+    async def test_finds_archive_candidate(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler finds and emits event for archive candidate.
+
+        Given: A projection with one expired memory pending archive
+        When: Processing a runtime tick
+        Then: One ModelMemoryArchiveInitiated event is emitted
+        """
+        archive_candidate = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+            lifecycle_revision=5,
+        )
+        reader = MockProjectionReader(archive_candidates=[archive_candidate])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 1
+        event = output.events[0]
+        assert isinstance(event, ModelMemoryArchiveInitiated)
+        assert event.entity_id == archive_candidate.entity_id
+        assert event.memory_id == archive_candidate.entity_id
+        assert event.expired_at == archive_candidate.expired_at
+        assert event.lifecycle_revision == 5
+
+    @pytest.mark.asyncio
+    async def test_finds_multiple_archive_candidates(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler finds and emits events for multiple archive candidates.
+
+        Given: A projection with multiple expired memories pending archive
+        When: Processing a runtime tick
+        Then: Multiple ModelMemoryArchiveInitiated events are emitted
+        """
+        archive_candidates = [
+            create_projection(
+                lifecycle_state="expired",
+                expired_at=fixed_now - timedelta(hours=i),
+            )
+            for i in range(1, 4)
+        ]
+        reader = MockProjectionReader(archive_candidates=archive_candidates)
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 3
+        assert all(isinstance(e, ModelMemoryArchiveInitiated) for e in output.events)
+        assert output.metrics["archive_initiated_count"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_skips_already_initiated_archive(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler skips memories that already have archive initiated.
+
+        Given: A projection with memory that already has archive initiated
+        When: Processing a runtime tick
+        Then: No event is emitted for that memory
+        """
+        already_initiated = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+            archive_initiated_at=fixed_now - timedelta(hours=1),
+        )
+        reader = MockProjectionReader(archive_candidates=[already_initiated])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        # Event should be filtered out by needs_archive_event() check
+        assert len(output.events) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_already_archived_memory(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler skips memories that are already archived.
+
+        Given: A projection with memory that is already archived
+        When: Processing a runtime tick
+        Then: No event is emitted for that memory
+        """
+        already_archived = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+            archived_at=fixed_now - timedelta(hours=1),
+        )
+        reader = MockProjectionReader(archive_candidates=[already_archived])
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 0
+
+
+# =============================================================================
+# Combined Scenarios Tests
+# =============================================================================
+
+
+class TestCombinedScenarios:
+    """Tests for combined expiration and archive scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_finds_both_expired_and_archive_candidates(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler processes both expirations and archives in one tick.
+
+        Given: Projections with both expired and archive candidate memories
+        When: Processing a runtime tick
+        Then: Events for both categories are emitted
+        """
+        expired_memory = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),
+        )
+        archive_candidate = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+        )
+        reader = MockProjectionReader(
+            expired_candidates=[expired_memory],
+            archive_candidates=[archive_candidate],
+        )
+        handler = HandlerMemoryTick(projection_reader=reader)
+
+        output = await handler.handle(tick_envelope)
+
+        assert len(output.events) == 2
+        assert output.metrics["expired_count"] == 1.0
+        assert output.metrics["archive_initiated_count"] == 1.0
+
+        # Check event types
+        event_types = [type(e) for e in output.events]
+        assert ModelMemoryExpiredEvent in event_types
+        assert ModelMemoryArchiveInitiated in event_types
+
+
+# =============================================================================
+# Batch Limiting Tests
+# =============================================================================
+
+
+class TestBatchLimiting:
+    """Tests for batch size limiting behavior."""
+
+    @pytest.mark.asyncio
+    async def test_respects_batch_size_for_expirations(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        fixed_now: datetime,
+    ) -> None:
+        """Test handler respects batch_size when processing expirations.
+
+        Given: More expired memories than batch_size
+        When: Processing a runtime tick
+        Then: Only batch_size events are emitted
+        """
+        # Create 10 expired memories
+        expired_memories = [
+            create_projection(
+                lifecycle_state="active",
+                expires_at=fixed_now - timedelta(hours=i),
+            )
+            for i in range(1, 11)
+        ]
+        reader = MockProjectionReader(expired_candidates=expired_memories)
+        handler = HandlerMemoryTick(projection_reader=reader, batch_size=5)
+
+        output = await handler.handle(tick_envelope)
+
+        # Should only emit batch_size (5) events
+        assert len(output.events) == 5
+        assert output.metrics["expired_count"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_batch_size_passed_to_reader(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """Test batch_size is passed to projection reader.
+
+        Given: Handler with custom batch_size
+        When: Processing a runtime tick
+        Then: Projection reader receives the batch_size as limit
+        """
+        reader = MockProjectionReader()
+        handler = HandlerMemoryTick(projection_reader=reader, batch_size=25)
+
+        await handler.handle(tick_envelope)
+
+        # Both reader calls should have limit=25
+        assert reader.get_expired_candidates_calls[0]["limit"] == 25
+        assert reader.get_archive_candidates_calls[0]["limit"] == 25
+
+
+# =============================================================================
+# Handler Output Tests
+# =============================================================================
+
+
+class TestHandlerOutput:
+    """Tests for handler output structure."""
+
+    @pytest.mark.asyncio
+    async def test_output_structure(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+        correlation_id: UUID,
+    ) -> None:
+        """Test handler returns correctly structured output.
+
+        Given: A handler processing a tick
+        When: Tick processing completes
+        Then: Output has correct structure and metadata
+        """
+        handler = HandlerMemoryTick()
+
+        output = await handler.handle(tick_envelope)
+
+        assert isinstance(output, ModelHandlerOutput)
+        assert output.handler_id == "handler-memory-tick"
+        assert output.correlation_id == correlation_id
+        assert output.input_envelope_id == tick_envelope.envelope_id
+        assert output.processing_time_ms >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_output_metrics_present(
+        self,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """Test handler output includes required metrics.
+
+        Given: A handler processing a tick
+        When: Tick processing completes
+        Then: Output metrics include all expected keys
+        """
+        handler = HandlerMemoryTick()
+
+        output = await handler.handle(tick_envelope)
+
+        assert "expired_count" in output.metrics
+        assert "archive_initiated_count" in output.metrics
+        assert "batch_size" in output.metrics
+        assert output.metrics["batch_size"] == 100.0  # Default batch size
+
+
+# =============================================================================
+# Model Tests
+# =============================================================================
+
+
+class TestModelMemoryLifecycleProjection:
+    """Tests for ModelMemoryLifecycleProjection model."""
+
+    def test_needs_expiration_event_returns_true(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_expiration_event returns True for valid candidate.
+
+        Given: Active memory with expired TTL and no emission marker
+        When: Checking needs_expiration_event
+        Then: Returns True
+        """
+        projection = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),
+            expiration_emitted_at=None,
+        )
+
+        assert projection.needs_expiration_event(fixed_now) is True
+
+    def test_needs_expiration_event_false_when_already_emitted(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_expiration_event returns False when already emitted.
+
+        Given: Active memory with expiration already emitted
+        When: Checking needs_expiration_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now - timedelta(hours=1),
+            expiration_emitted_at=fixed_now - timedelta(minutes=30),
+        )
+
+        assert projection.needs_expiration_event(fixed_now) is False
+
+    def test_needs_expiration_event_false_when_not_expired(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_expiration_event returns False when not yet expired.
+
+        Given: Active memory with future expiration
+        When: Checking needs_expiration_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="active",
+            expires_at=fixed_now + timedelta(hours=1),  # Future
+        )
+
+        assert projection.needs_expiration_event(fixed_now) is False
+
+    def test_needs_expiration_event_false_when_not_active(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_expiration_event returns False when not active.
+
+        Given: Expired memory (wrong state)
+        When: Checking needs_expiration_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="expired",
+            expires_at=fixed_now - timedelta(hours=1),
+        )
+
+        assert projection.needs_expiration_event(fixed_now) is False
+
+    def test_needs_archive_event_returns_true(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_archive_event returns True for valid candidate.
+
+        Given: Expired memory with no archive markers
+        When: Checking needs_archive_event
+        Then: Returns True
+        """
+        projection = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=1),
+            archived_at=None,
+            archive_initiated_at=None,
+        )
+
+        assert projection.needs_archive_event(fixed_now) is True
+
+    def test_needs_archive_event_false_when_already_initiated(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_archive_event returns False when already initiated.
+
+        Given: Expired memory with archive already initiated
+        When: Checking needs_archive_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+            archive_initiated_at=fixed_now - timedelta(hours=1),
+        )
+
+        assert projection.needs_archive_event(fixed_now) is False
+
+    def test_needs_archive_event_false_when_already_archived(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_archive_event returns False when already archived.
+
+        Given: Expired memory that is already archived
+        When: Checking needs_archive_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="expired",
+            expired_at=fixed_now - timedelta(hours=2),
+            archived_at=fixed_now - timedelta(hours=1),
+        )
+
+        assert projection.needs_archive_event(fixed_now) is False
+
+    def test_needs_archive_event_false_when_not_expired(
+        self,
+        fixed_now: datetime,
+    ) -> None:
+        """Test needs_archive_event returns False when not expired state.
+
+        Given: Active memory (wrong state for archive)
+        When: Checking needs_archive_event
+        Then: Returns False
+        """
+        projection = create_projection(
+            lifecycle_state="active",
+        )
+
+        assert projection.needs_archive_event(fixed_now) is False
+
+
+class TestModelMemoryTickResult:
+    """Tests for ModelMemoryTickResult model."""
+
+    def test_result_model_creation(self, fixed_now: datetime) -> None:
+        """Test ModelMemoryTickResult can be created with valid data.
+
+        Given: Valid tick result data
+        When: Creating ModelMemoryTickResult
+        Then: Model is created successfully
+        """
+        tick_id = uuid4()
+        result = ModelMemoryTickResult(
+            expired_count=5,
+            archive_initiated_count=3,
+            tick_id=tick_id,
+            sequence_number=42,
+            evaluated_at=fixed_now,
+        )
+
+        assert result.expired_count == 5
+        assert result.archive_initiated_count == 3
+        assert result.tick_id == tick_id
+        assert result.sequence_number == 42
+        assert result.evaluated_at == fixed_now
+
+    def test_result_model_is_frozen(self, fixed_now: datetime) -> None:
+        """Test ModelMemoryTickResult is immutable.
+
+        Given: A ModelMemoryTickResult instance
+        When: Attempting to modify a field
+        Then: Raises an error
+        """
+        result = ModelMemoryTickResult(
+            expired_count=5,
+            archive_initiated_count=3,
+            tick_id=uuid4(),
+            sequence_number=1,
+            evaluated_at=fixed_now,
+        )
+
+        with pytest.raises(Exception):  # Pydantic ValidationError for frozen models
+            result.expired_count = 10  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements the memory lifecycle orchestrator node for managing memory expiration, archival, and cleanup operations.

- Add `memories` table migration with lifecycle columns and optimistic locking support
- Add lifecycle handlers: tick evaluation, archive, and expire with state transitions
- Add `intent_storage_effect` node for memory persistence operations
- Add `EnumLifecycleState` for ACTIVE/STALE/EXPIRED/ARCHIVED state management
- Add unit and integration tests for all handlers

## Related

- Closes [OMN-1453](https://linear.app/omninode/issue/OMN-1453)
- Builds on OMN-1392 (P4A foundation)

## Test plan

- [ ] Run unit tests: `pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/`
- [ ] Run integration tests: `pytest tests/integration/nodes/`
- [ ] Verify database migration applies cleanly
- [ ] Verify pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory lifecycle: explicit states (active/expired/archived/deleted), automated expiration and archival workflows, compressed atomic archives, optimistic concurrency and lifecycle metadata, and a lifecycle orchestrator.
  * Intent storage node: persist and query classified intents (store, session read, distribution) with strict input validation and structured responses.

* **Tests**
  * Extensive unit and integration tests for tick/expire/archive handlers, archival atomicity, optimistic locking, and intent storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->