### PR TITLE
feat(intent_query): Add intent_query_effect node for event-driven intent reads [OMN-1504]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,9 @@ asyncio-mqtt = "^0.16.0"
 pyyaml = "^6.0.2"
 
 # ONEX dependencies - versioned releases from PyPI
-omnibase-core = "^0.9.1"
-omnibase-spi = "^0.5.0"
-omnibase-infra = "^0.2.2"
+omnibase-core = "^0.9.4"
+omnibase-spi = "^0.6.0"
+omnibase-infra = "^0.2.3"
 
 # Logging and monitoring
 # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -8,6 +8,7 @@ HandlerGraph to provide intent-specific operations:
 
 - store_intent(): Store an intent classification linked to a session
 - get_session_intents(): Retrieve intents for a given session
+- get_recent_intents(): Query recent intents across all sessions within a time range
 - get_intent_distribution(): Get aggregate intent statistics
 
 The adapter handles:
@@ -171,6 +172,39 @@ class IntentCypherTemplates:
         """
 
     @staticmethod
+    def get_recent_intents_query(
+        session_label: str, intent_label: str, rel_type: str
+    ) -> str:
+        """Generate query to retrieve recent intents across all sessions.
+
+        Returns intents created within a time range, optionally filtered by
+        confidence threshold, ordered by creation time (most recent first).
+
+        Args:
+            session_label: Label for session nodes (e.g., "Session").
+            intent_label: Label for intent nodes (e.g., "Intent").
+            rel_type: Relationship type connecting sessions to intents
+                (e.g., "HAD_INTENT").
+
+        Returns:
+            Parameterized Cypher query string expecting:
+            - $cutoff_time: ISO datetime string for time boundary
+            - $min_confidence: Minimum confidence threshold (or null to skip)
+            - $limit: Maximum number of results to return
+        """
+        return f"""
+        MATCH (s:{session_label})-[r:{rel_type}]->(i:{intent_label})
+        WHERE i.created_at_utc >= $cutoff_time
+          AND ($min_confidence IS NULL OR i.confidence >= $min_confidence)
+        RETURN s.session_id AS session_id, i.intent_id AS intent_id,
+               i.intent_category AS intent_category, i.confidence AS confidence,
+               i.keywords AS keywords, i.created_at_utc AS created_at_utc,
+               r.correlation_id AS correlation_id
+        ORDER BY i.created_at_utc DESC
+        LIMIT $limit
+        """
+
+    @staticmethod
     def create_indexes_queries(
         session_label: str, intent_label: str, rel_type: str
     ) -> list[str]:
@@ -226,6 +260,7 @@ class AdapterIntentGraph:
 
     - store_intent(session_id, intent_data): Store intent linked to session
     - get_session_intents(session_id): Retrieve intents for a session
+    - get_recent_intents(time_range, min_confidence): Query recent intents across sessions
     - get_intent_distribution(time_range): Get intent category statistics
 
     The adapter handles:
@@ -984,6 +1019,242 @@ class AdapterIntentGraph:
             return ModelIntentDistributionResult(
                 status="error",
                 time_range_hours=time_range_hours,
+                execution_time_ms=execution_time_ms,
+                error_message=f"Query failed: {e}",
+            )
+
+    async def get_recent_intents(
+        self,
+        time_range_hours: int = 24,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        """Get recent intents across all sessions within a time range.
+
+        Retrieves intent classifications created within the specified time
+        range, optionally filtered by confidence threshold. Results are
+        ordered by creation time (most recent first) and include the
+        associated session reference.
+
+        Args:
+            time_range_hours: Number of hours to look back from now.
+                Defaults to 24 hours. Values less than 1 are clamped to
+                a minimum of 1 hour.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+                If None, no confidence filtering is applied.
+            limit: Maximum number of results to return.
+                Defaults to config.max_intents_per_session.
+                Clamped to config.max_intents_per_session maximum.
+
+        Returns:
+            ModelIntentQueryResult with the list of intents or error status.
+            Each intent record includes session_ref populated with the
+            session_id it belongs to.
+
+            Possible status values:
+            - "success": Query completed with results
+            - "no_results": No intents found matching criteria
+            - "error": Query failed
+
+        Example::
+
+            # Get all intents from the last 48 hours with high confidence
+            result = await adapter.get_recent_intents(
+                time_range_hours=48,
+                min_confidence=0.8,
+                limit=100,
+            )
+            if result.status == "success":
+                for intent in result.intents:
+                    print(f"Session {intent.session_ref}: {intent.intent_category}")
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+
+        .. versionadded:: 0.1.0
+            Added for OMN-1504 to support querying recent intents across sessions.
+        """
+        start_time = time.perf_counter()
+
+        try:
+            handler = self._ensure_initialized()
+        except RuntimeError as e:
+            end_time = time.perf_counter()
+            execution_time_ms = (end_time - start_time) * 1000
+            return ModelIntentQueryResult(
+                status="error",
+                execution_time_ms=execution_time_ms,
+                error_message=str(e),
+            )
+
+        # Clamp time_range_hours to valid range (minimum 1 hour)
+        effective_time_range = max(1, time_range_hours)
+
+        # Apply defaults from config for limit
+        effective_limit = (
+            limit if limit is not None else self._config.max_intents_per_session
+        )
+        # Clamp limit to valid range
+        effective_limit = max(
+            1, min(effective_limit, self._config.max_intents_per_session)
+        )
+
+        # Clamp min_confidence if provided
+        effective_min_confidence: float | None = None
+        if min_confidence is not None:
+            effective_min_confidence = max(0.0, min(min_confidence, 1.0))
+
+        # Calculate time boundary
+        cutoff_time = (
+            datetime.now(UTC) - timedelta(hours=effective_time_range)
+        ).isoformat()
+
+        try:
+            async with asyncio.timeout(self._config.timeout_seconds):
+                query = IntentCypherTemplates.get_recent_intents_query(
+                    session_label=self._config.session_node_label,
+                    intent_label=self._config.intent_node_label,
+                    rel_type=self._config.relationship_type,
+                )
+
+                parameters: dict[str, JsonType] = {
+                    "cutoff_time": cutoff_time,
+                    "min_confidence": effective_min_confidence,
+                    "limit": effective_limit,
+                }
+
+                result = await handler.execute_query(
+                    query=query,
+                    parameters=parameters,
+                )
+
+                end_time = time.perf_counter()
+                execution_time_ms = (end_time - start_time) * 1000
+
+                if not result.records:
+                    logger.debug(
+                        "No recent intents found in last %d hours",
+                        effective_time_range,
+                    )
+                    return ModelIntentQueryResult(
+                        status="no_results",
+                        intents=[],
+                        total_count=0,
+                        execution_time_ms=execution_time_ms,
+                    )
+
+                # Convert records to intent models
+                intents: list[ModelIntentRecord] = []
+                for record in result.records:
+                    intent_id_raw = record.get("intent_id")
+                    if not isinstance(intent_id_raw, str):
+                        logger.warning(
+                            "Skipping intent record with missing or non-string intent_id: %s",
+                            intent_id_raw,
+                        )
+                        continue
+
+                    # Parse UUID from database string
+                    try:
+                        intent_id = UUID(intent_id_raw)
+                    except ValueError:
+                        logger.warning(
+                            "Skipping intent record with invalid intent_id UUID: %s",
+                            intent_id_raw,
+                        )
+                        continue
+
+                    # Extract session_id for session_ref field
+                    session_id_raw = record.get("session_id")
+                    session_ref: str | None = (
+                        str(session_id_raw) if session_id_raw is not None else None
+                    )
+
+                    keywords_raw = record.get("keywords", [])
+                    keywords: list[str] = (
+                        [str(k) for k in keywords_raw]
+                        if isinstance(keywords_raw, list)
+                        else []
+                    )
+
+                    # Extract and validate confidence (defaults to 0.0 if not a number)
+                    confidence_raw = record.get("confidence", 0.0)
+                    confidence_val = (
+                        float(confidence_raw)
+                        if isinstance(confidence_raw, int | float)
+                        else 0.0
+                    )
+
+                    # Parse correlation_id UUID from database string
+                    correlation_id_raw = record.get("correlation_id")
+                    correlation_id: UUID | None = None
+                    if correlation_id_raw is not None:
+                        try:
+                            correlation_id = UUID(str(correlation_id_raw))
+                        except ValueError:
+                            logger.warning(
+                                "Invalid correlation_id UUID: %s", correlation_id_raw
+                            )
+
+                    # Parse datetime from ISO string
+                    created_at_raw = record.get("created_at_utc", "")
+                    try:
+                        created_at_utc = datetime.fromisoformat(str(created_at_raw))
+                    except ValueError:
+                        logger.warning(
+                            "Skipping intent record with invalid created_at_utc: %s",
+                            created_at_raw,
+                        )
+                        continue
+
+                    intents.append(
+                        ModelIntentRecord(
+                            intent_id=intent_id,
+                            session_ref=session_ref,
+                            intent_category=str(record.get("intent_category", "")),
+                            confidence=confidence_val,
+                            keywords=keywords,
+                            created_at_utc=created_at_utc,
+                            correlation_id=correlation_id,
+                        )
+                    )
+
+                logger.debug(
+                    "Retrieved %d recent intents from last %d hours",
+                    len(intents),
+                    effective_time_range,
+                )
+
+                return ModelIntentQueryResult(
+                    status="success",
+                    intents=intents,
+                    total_count=len(intents),
+                    execution_time_ms=execution_time_ms,
+                )
+
+        except TimeoutError:
+            end_time = time.perf_counter()
+            execution_time_ms = (end_time - start_time) * 1000
+            logger.warning(
+                "Timeout querying recent intents after %.2fms",
+                execution_time_ms,
+            )
+            return ModelIntentQueryResult(
+                status="error",
+                execution_time_ms=execution_time_ms,
+                error_message=f"Query timed out after {self._config.timeout_seconds}s",
+            )
+
+        except Exception as e:
+            end_time = time.perf_counter()
+            execution_time_ms = (end_time - start_time) * 1000
+            logger.error(
+                "Error querying recent intents: %s",
+                e,
+            )
+            return ModelIntentQueryResult(
+                status="error",
                 execution_time_ms=execution_time_ms,
                 error_message=f"Query failed: {e}",
             )

--- a/src/omnimemory/handlers/adapters/models/model_intent_domain.py
+++ b/src/omnimemory/handlers/adapters/models/model_intent_domain.py
@@ -184,6 +184,8 @@ class ModelIntentRecord(BaseModel):  # omnimemory-model-exempt: adapter-internal
 
     Attributes:
         intent_id: Unique identifier (UUID) for the intent node in the graph.
+        session_ref: Optional session reference this intent belongs to, used
+            for mapping to IntentRecordPayload.
         intent_category: The classified intent category.
         confidence: Confidence score from the original classification.
         keywords: Keywords associated with this intent.
@@ -200,6 +202,10 @@ class ModelIntentRecord(BaseModel):  # omnimemory-model-exempt: adapter-internal
     intent_id: UUID = Field(
         ...,
         description="Unique identifier for the intent node",
+    )
+    session_ref: str | None = Field(
+        default=None,
+        description="Session reference this intent belongs to",
     )
     intent_category: str = Field(
         ...,

--- a/src/omnimemory/nodes/intent_query_effect/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/__init__.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent Query Effect - ONEX Node.
+
+This node provides event-driven intent query operations via Kafka,
+supporting multiple query types:
+
+- **Distribution Query**: Get intent distribution across categories
+- **Session Query**: Get intents for a specific session
+- **Recent Query**: Get recent intents across all sessions
+
+The node follows the ONEX EFFECT pattern, consuming events from Kafka,
+querying Memgraph for intent data, and publishing response events.
+
+Example::
+
+    import asyncio
+    from omnimemory.nodes.intent_query_effect import HandlerIntentQuery
+    from omnimemory.handlers.adapters import (
+        AdapterIntentGraph,
+        ModelAdapterIntentGraphConfig,
+    )
+
+    async def main():
+        # Initialize adapter first
+        adapter_config = ModelAdapterIntentGraphConfig()
+        adapter = AdapterIntentGraph(adapter_config)
+        await adapter.initialize(connection_uri="bolt://localhost:7687")
+
+        # Initialize handler with adapter
+        handler = HandlerIntentQuery()
+        await handler.initialize(adapter)
+
+        # Handler processes Kafka events automatically
+        # Or can be called directly for testing
+
+        await handler.shutdown()
+        await adapter.shutdown()
+
+    asyncio.run(main())
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+from omnimemory.nodes.intent_query_effect.models import ModelHandlerIntentQueryConfig
+from omnimemory.nodes.intent_query_effect.registry import RegistryIntentQueryEffect
+from omnimemory.nodes.intent_query_effect.utils import (
+    map_intent_records,
+    map_to_intent_payload,
+)
+
+__all__ = [
+    "HandlerIntentQuery",
+    "ModelHandlerIntentQueryConfig",
+    "RegistryIntentQueryEffect",
+    "map_intent_records",
+    "map_to_intent_payload",
+]

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -98,6 +98,17 @@ performance:
 
 # === EVENT TYPE CONFIGURATION ===
 # NOTE: Using version per ModelEventTypeSubcontract from omnibase_core
+#
+# Topic Naming Convention:
+#   - These are SUFFIXES only (no env prefix like "dev.")
+#   - Runtime composes full topic: f"{topic_env_prefix}.{suffix}"
+#   - Example: dev.onex.cmd.omnimemory.intent-query-requested.v1
+#
+# Invocation Mode: SUBSCRIPTION
+#   - This node subscribes to request topics (runtime dispatches inbound)
+#   - This node publishes response topics
+#   - NOT orchestrator-invoked (has explicit topic subscription)
+#
 event_type:
   version: {major: 1, minor: 0, patch: 0}
   primary_events: ["intent_queried"]
@@ -105,8 +116,10 @@ event_type:
   publish_events: true
   subscribe_events: true
   event_routing: "intent"
-  input_topic: "onex.cmd.omnimemory.intent-query-requested.v1"
-  output_topic: "onex.evt.omnimemory.intent-query-response.v1"
+  invocation_mode: "subscription"  # vs "orchestrator" - explicit per contract checklist
+  # Topic suffixes - runtime adds env prefix (e.g., "dev.", "prod.")
+  subscribe_topic_suffix: "onex.cmd.omnimemory.intent-query-requested.v1"
+  publish_topic_suffix: "onex.evt.omnimemory.intent-query-response.v1"
 
 # === INFRASTRUCTURE ===
 infrastructure:

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -1,0 +1,139 @@
+---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+
+# Intent Query EFFECT - ONEX Contract
+# EFFECT node for event-driven intent queries via Kafka.
+
+# === REQUIRED ROOT FIELDS ===
+name: "intent_query_effect"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: "Effect node for event-driven intent queries via Kafka. Provides distribution analysis, session-based
+  lookups, and recent intent retrieval from Memgraph."
+node_type: "EFFECT"
+input_model: "ModelIntentQueryRequestedEvent"
+output_model: "ModelIntentQueryResponseEvent"
+
+# === IO OPERATIONS (Required for EFFECT nodes) ===
+# Graph traversal queries - read-only, no atomicity required
+io_operations:
+  - operation_type: "graph_traversal"
+    atomic: false
+    timeout_seconds: 10
+    validation_enabled: true
+
+# === TRANSACTION MANAGEMENT ===
+# Disabled: All operations are read-only queries, no transactions needed
+transaction_management:
+  enabled: false
+
+# === NODE CONFIGURATION ===
+# NOTE: tool_name and main_tool_class are required per ModelContractEffect validation
+tool_specification:
+  tool_name: "intent_query_effect"
+  main_tool_class: "HandlerIntentQuery"
+
+# === SERVICE CONFIGURATION ===
+service_configuration:
+  is_persistent_service: false
+  requires_external_dependencies: true
+
+# === INPUT/OUTPUT STATE ===
+input_state:
+  object_type: "object"
+  required: ["query_type", "query_id"]
+  optional: ["session_ref", "time_range_hours", "min_confidence", "limit"]
+
+output_state:
+  object_type: "object"
+  required: ["query_id", "query_type", "status"]
+  optional: ["distribution", "intents", "total_count", "execution_time_ms", "error_message"]
+
+# === ACTIONS ===
+actions:
+  - name: "query_distribution"
+    description: "Get intent distribution across categories"
+    inputs: ["time_range_hours", "min_confidence"]
+    outputs: ["distribution", "total_intents"]
+
+  - name: "query_session"
+    description: "Get intents for a specific session"
+    inputs: ["session_ref", "min_confidence", "limit"]
+    outputs: ["intents", "total_count"]
+
+  - name: "query_recent"
+    description: "Get recent intents across all sessions"
+    inputs: ["time_range_hours", "min_confidence", "limit"]
+    outputs: ["intents", "total_count"]
+
+  - name: "health_check"
+    description: "Check node health status"
+    inputs: []
+    outputs: ["status"]
+
+# === DEPENDENCIES ===
+dependencies:
+  # Primary Backend
+  - name: memgraph
+    dependency_type: service
+    description: Memgraph graph database for intent storage and queries
+    required: true
+
+  # Adapter Dependencies
+  - name: AdapterIntentGraph
+    dependency_type: adapter
+    description: Intent graph adapter for Memgraph queries
+    required: true
+
+  # Event Bus
+  - name: kafka
+    dependency_type: service
+    description: Kafka event bus for request/response events
+    required: true
+
+# === PERFORMANCE ===
+performance:
+  max_response_time_ms: 100
+
+# === EVENT TYPE CONFIGURATION ===
+# NOTE: Using version per ModelEventTypeSubcontract from omnibase_core
+event_type:
+  version: {major: 1, minor: 0, patch: 0}
+  primary_events: ["intent_queried"]
+  event_categories: ["intent", "effect", "query"]
+  publish_events: true
+  subscribe_events: true
+  event_routing: "intent"
+  input_topic: "onex.cmd.omnimemory.intent-query-requested.v1"
+  output_topic: "onex.evt.omnimemory.intent-query-response.v1"
+
+# === INFRASTRUCTURE ===
+infrastructure:
+  query_backends:
+    - memgraph  # Primary - graph queries
+
+# === VALIDATION RULES ===
+validation_rules:
+  strict_typing_enabled: true
+  input_validation_enabled: true
+  output_validation_enabled: true
+  performance_validation_enabled: true
+  constraint_definitions:
+    query_type: "Literal['distribution', 'session', 'recent'] - type of intent query"
+    query_id: "string type - unique identifier for this query request"
+    status: "Literal['success', 'error', 'no_results'] - query result status"
+    session_ref: "string type - session reference for session-based queries"
+    time_range_hours: "int (1-720) - time window in hours for queries"
+    min_confidence: "float (0.0-1.0) - minimum confidence threshold"
+    limit: "int (1-1000) - maximum number of results"
+
+# === TAGS ===
+tags:
+  - intent
+  - query
+  - effect
+  - memgraph
+  - kafka
+  - distribution
+  - session

--- a/src/omnimemory/nodes/intent_query_effect/handlers/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/handlers/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Intent Query Effect handlers.
+
+This package contains IHandler implementations for the intent_query_effect node.
+
+Handlers:
+    - HandlerIntentQuery: Main handler for processing intent query events
+
+Example::
+
+    from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+
+    # Initialize adapter
+    adapter = AdapterIntentGraph(config)
+    await adapter.initialize(connection_uri="bolt://localhost:7687")
+
+    # Initialize handler
+    handler = HandlerIntentQuery()
+    await handler.initialize(adapter)
+
+    # Execute query
+    response = await handler.execute(request_event)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from omnimemory.nodes.intent_query_effect.handlers.handler_intent_query import (
+    HandlerIntentQuery,
+)
+
+__all__ = ["HandlerIntentQuery"]

--- a/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Contract SLA: max response time in milliseconds
+_CONTRACT_MAX_RESPONSE_TIME_MS = 100.0
+
 __all__ = ["HandlerIntentQuery"]
 
 
@@ -156,20 +159,28 @@ class HandlerIntentQuery:
         start = time.monotonic()
 
         try:
-            match request.query_type:
-                case "distribution":
-                    return await self._handle_distribution(request, start)
-                case "session":
-                    return await self._handle_session(request, start)
-                case "recent":
-                    return await self._handle_recent(request, start)
-                case _:
-                    return ModelIntentQueryResponseEvent.from_error(
-                        query_id=request.query_id,
-                        query_type=request.query_type,
-                        error_message=f"Unknown query_type: {request.query_type}",
-                        correlation_id=request.correlation_id,
-                    )
+            async with asyncio.timeout(self._config.timeout_seconds):
+                match request.query_type:
+                    case "distribution":
+                        return await self._handle_distribution(request, start)
+                    case "session":
+                        return await self._handle_session(request, start)
+                    case "recent":
+                        return await self._handle_recent(request, start)
+                    case _:
+                        return ModelIntentQueryResponseEvent.from_error(
+                            query_id=request.query_id,
+                            query_type=request.query_type,
+                            error_message=f"Unknown query_type: {request.query_type}",
+                            correlation_id=request.correlation_id,
+                        )
+        except TimeoutError:
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type=request.query_type,
+                error_message=f"Handler timeout after {self._config.timeout_seconds}s",
+                correlation_id=request.correlation_id,
+            )
         except Exception as e:
             logger.exception("Error executing intent query: %s", request.query_type)
             return ModelIntentQueryResponseEvent.from_error(
@@ -200,6 +211,14 @@ class HandlerIntentQuery:
         )
 
         execution_time_ms = (time.monotonic() - start) * 1000
+
+        if execution_time_ms > _CONTRACT_MAX_RESPONSE_TIME_MS:
+            logger.warning(
+                "Query %s exceeded SLA: %.2fms (max: %.2fms)",
+                request.query_type,
+                execution_time_ms,
+                _CONTRACT_MAX_RESPONSE_TIME_MS,
+            )
 
         if result.status == "error":
             return ModelIntentQueryResponseEvent.from_error(
@@ -244,12 +263,20 @@ class HandlerIntentQuery:
         result = await self._adapter.get_session_intents(
             session_id=request.session_ref,
             min_confidence=request.min_confidence
-            if request.min_confidence > 0
+            if request.min_confidence is not None and request.min_confidence > 0
             else None,
             limit=request.limit,
         )
 
         execution_time_ms = (time.monotonic() - start) * 1000
+
+        if execution_time_ms > _CONTRACT_MAX_RESPONSE_TIME_MS:
+            logger.warning(
+                "Query %s exceeded SLA: %.2fms (max: %.2fms)",
+                request.query_type,
+                execution_time_ms,
+                _CONTRACT_MAX_RESPONSE_TIME_MS,
+            )
 
         if result.status == "error":
             return ModelIntentQueryResponseEvent.from_error(
@@ -260,11 +287,26 @@ class HandlerIntentQuery:
             )
 
         # Session queries need session_ref populated in records for mapping
+        # Create new instances instead of mutating adapter results
+        intents_with_ref = []
         for intent in result.intents:
             if intent.session_ref is None:
-                intent.session_ref = request.session_ref
+                intents_with_ref.append(
+                    intent.model_copy(update={"session_ref": request.session_ref})
+                )
+            else:
+                intents_with_ref.append(intent)
 
-        payloads = map_intent_records(result.intents)
+        try:
+            payloads = map_intent_records(intents_with_ref)
+        except ValueError as e:
+            logger.warning("Failed to map intent records: %s", e)
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="session",
+                error_message=f"Failed to map intent records: {e}",
+                correlation_id=request.correlation_id,
+            )
 
         return ModelIntentQueryResponseEvent.create_session_response(
             query_id=request.query_id,
@@ -292,12 +334,20 @@ class HandlerIntentQuery:
         result = await self._adapter.get_recent_intents(
             time_range_hours=request.time_range_hours,
             min_confidence=request.min_confidence
-            if request.min_confidence > 0
+            if request.min_confidence is not None and request.min_confidence > 0
             else None,
             limit=request.limit,
         )
 
         execution_time_ms = (time.monotonic() - start) * 1000
+
+        if execution_time_ms > _CONTRACT_MAX_RESPONSE_TIME_MS:
+            logger.warning(
+                "Query %s exceeded SLA: %.2fms (max: %.2fms)",
+                request.query_type,
+                execution_time_ms,
+                _CONTRACT_MAX_RESPONSE_TIME_MS,
+            )
 
         if result.status == "error":
             return ModelIntentQueryResponseEvent.from_error(
@@ -307,7 +357,16 @@ class HandlerIntentQuery:
                 correlation_id=request.correlation_id,
             )
 
-        payloads = map_intent_records(result.intents)
+        try:
+            payloads = map_intent_records(result.intents)
+        except ValueError as e:
+            logger.warning("Failed to map intent records: %s", e)
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="recent",
+                error_message=f"Failed to map intent records: {e}",
+                correlation_id=request.correlation_id,
+            )
 
         return ModelIntentQueryResponseEvent.create_recent_response(
             query_id=request.query_id,

--- a/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Handler for intent query operations via Kafka events.
+
+Processes intent query requests (distribution, session, recent) and returns
+responses via the event bus. Part of the event-driven architecture where
+OmniDash queries intent data without direct database access.
+
+Example::
+
+    from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+
+    handler = HandlerIntentQuery()
+    await handler.initialize(adapter)
+    response = await handler.execute(request_event)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from omnibase_core.models.events import (
+    ModelIntentQueryRequestedEvent,
+    ModelIntentQueryResponseEvent,
+)
+
+from omnimemory.nodes.intent_query_effect.models import ModelHandlerIntentQueryConfig
+from omnimemory.nodes.intent_query_effect.utils import map_intent_records
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HandlerIntentQuery"]
+
+
+class HandlerIntentQuery:
+    """Handler for event-driven intent queries.
+
+    Routes intent query requests to the appropriate adapter method and
+    constructs response events with proper correlation tracking.
+
+    This handler is designed for use in event-driven architectures where
+    clients (e.g., dashboards) request intent data via Kafka events rather
+    than direct database queries.
+
+    Supported query types:
+        - distribution: Get intent counts grouped by category
+        - session: Get intents for a specific session
+        - recent: Get recent intents across all sessions
+
+    Attributes:
+        config: Handler configuration controlling timeouts and defaults.
+        is_initialized: Whether the handler has been initialized.
+
+    Example::
+
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+        from omnimemory.handlers.adapters import (
+            AdapterIntentGraph,
+            ModelAdapterIntentGraphConfig,
+        )
+
+        # Create and initialize adapter
+        adapter_config = ModelAdapterIntentGraphConfig()
+        adapter = AdapterIntentGraph(adapter_config)
+        await adapter.initialize(connection_uri="bolt://localhost:7687")
+
+        # Create and initialize handler
+        handler = HandlerIntentQuery()
+        await handler.initialize(adapter)
+
+        # Execute a query
+        request = ModelIntentQueryRequestedEvent(
+            query_type="distribution",
+            time_range_hours=24,
+        )
+        response = await handler.execute(request)
+        if response.status == "success":
+            print(f"Distribution: {response.distribution}")
+
+        await handler.shutdown()
+    """
+
+    def __init__(self, config: ModelHandlerIntentQueryConfig | None = None) -> None:
+        """Initialize the handler.
+
+        Args:
+            config: Optional configuration. Uses defaults if not provided.
+        """
+        self._config = config or ModelHandlerIntentQueryConfig()
+        self._adapter: AdapterIntentGraph | None = None
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+
+    @property
+    def config(self) -> ModelHandlerIntentQueryConfig:
+        """Get handler configuration."""
+        return self._config
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if handler is initialized."""
+        return self._initialized
+
+    async def initialize(self, adapter: AdapterIntentGraph) -> None:
+        """Initialize with adapter dependency.
+
+        Thread-safe initialization using asyncio.Lock.
+
+        Args:
+            adapter: The intent graph adapter for database operations.
+        """
+        if self._initialized:
+            return
+
+        async with self._init_lock:
+            if self._initialized:
+                return
+
+            self._adapter = adapter
+            self._initialized = True
+            logger.info("HandlerIntentQuery initialized")
+
+    async def execute(
+        self,
+        request: ModelIntentQueryRequestedEvent,
+    ) -> ModelIntentQueryResponseEvent:
+        """Execute an intent query request.
+
+        Routes the request to the appropriate handler method based on query_type.
+        This method never raises - all errors are captured in the response.
+
+        Args:
+            request: The incoming query request event.
+
+        Returns:
+            Response event with query results or error details.
+        """
+        if not self._initialized or self._adapter is None:
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type=request.query_type,
+                error_message="Handler not initialized",
+                correlation_id=request.correlation_id,
+            )
+
+        start = time.monotonic()
+
+        try:
+            match request.query_type:
+                case "distribution":
+                    return await self._handle_distribution(request, start)
+                case "session":
+                    return await self._handle_session(request, start)
+                case "recent":
+                    return await self._handle_recent(request, start)
+                case _:
+                    return ModelIntentQueryResponseEvent.from_error(
+                        query_id=request.query_id,
+                        query_type=request.query_type,
+                        error_message=f"Unknown query_type: {request.query_type}",
+                        correlation_id=request.correlation_id,
+                    )
+        except Exception as e:
+            logger.exception("Error executing intent query: %s", request.query_type)
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type=request.query_type,
+                error_message=str(e),
+                correlation_id=request.correlation_id,
+            )
+
+    async def _handle_distribution(
+        self,
+        request: ModelIntentQueryRequestedEvent,
+        start: float,
+    ) -> ModelIntentQueryResponseEvent:
+        """Handle distribution query - get intent counts by category.
+
+        Args:
+            request: The query request event.
+            start: Start time for execution timing.
+
+        Returns:
+            Response event with distribution data or error.
+        """
+        assert self._adapter is not None
+
+        result = await self._adapter.get_intent_distribution(
+            time_range_hours=request.time_range_hours,
+        )
+
+        execution_time_ms = (time.monotonic() - start) * 1000
+
+        if result.status == "error":
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="distribution",
+                error_message=result.error_message or "Unknown error",
+                correlation_id=request.correlation_id,
+            )
+
+        return ModelIntentQueryResponseEvent.create_distribution_response(
+            query_id=request.query_id,
+            distribution=result.distribution,
+            time_range_hours=request.time_range_hours,
+            execution_time_ms=execution_time_ms,
+            correlation_id=request.correlation_id,
+        )
+
+    async def _handle_session(
+        self,
+        request: ModelIntentQueryRequestedEvent,
+        start: float,
+    ) -> ModelIntentQueryResponseEvent:
+        """Handle session query - get intents for a specific session.
+
+        Args:
+            request: The query request event.
+            start: Start time for execution timing.
+
+        Returns:
+            Response event with session intents or error.
+        """
+        assert self._adapter is not None
+
+        if not request.session_ref:
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="session",
+                error_message="session_ref is required for session queries",
+                correlation_id=request.correlation_id,
+            )
+
+        result = await self._adapter.get_session_intents(
+            session_id=request.session_ref,
+            min_confidence=request.min_confidence
+            if request.min_confidence > 0
+            else None,
+            limit=request.limit,
+        )
+
+        execution_time_ms = (time.monotonic() - start) * 1000
+
+        if result.status == "error":
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="session",
+                error_message=result.error_message or "Unknown error",
+                correlation_id=request.correlation_id,
+            )
+
+        # Session queries need session_ref populated in records for mapping
+        for intent in result.intents:
+            if intent.session_ref is None:
+                intent.session_ref = request.session_ref
+
+        payloads = map_intent_records(result.intents)
+
+        return ModelIntentQueryResponseEvent.create_session_response(
+            query_id=request.query_id,
+            intents=payloads,
+            execution_time_ms=execution_time_ms,
+            correlation_id=request.correlation_id,
+        )
+
+    async def _handle_recent(
+        self,
+        request: ModelIntentQueryRequestedEvent,
+        start: float,
+    ) -> ModelIntentQueryResponseEvent:
+        """Handle recent query - get recent intents across all sessions.
+
+        Args:
+            request: The query request event.
+            start: Start time for execution timing.
+
+        Returns:
+            Response event with recent intents or error.
+        """
+        assert self._adapter is not None
+
+        result = await self._adapter.get_recent_intents(
+            time_range_hours=request.time_range_hours,
+            min_confidence=request.min_confidence
+            if request.min_confidence > 0
+            else None,
+            limit=request.limit,
+        )
+
+        execution_time_ms = (time.monotonic() - start) * 1000
+
+        if result.status == "error":
+            return ModelIntentQueryResponseEvent.from_error(
+                query_id=request.query_id,
+                query_type="recent",
+                error_message=result.error_message or "Unknown error",
+                correlation_id=request.correlation_id,
+            )
+
+        payloads = map_intent_records(result.intents)
+
+        return ModelIntentQueryResponseEvent.create_recent_response(
+            query_id=request.query_id,
+            intents=payloads,
+            time_range_hours=request.time_range_hours,
+            execution_time_ms=execution_time_ms,
+            correlation_id=request.correlation_id,
+        )
+
+    async def shutdown(self) -> None:
+        """Shutdown the handler and release resources.
+
+        Safe to call multiple times. Does not shutdown the adapter
+        (caller is responsible for adapter lifecycle).
+        """
+        if self._initialized:
+            self._adapter = None
+            self._initialized = False
+            logger.info("HandlerIntentQuery shutdown")

--- a/src/omnimemory/nodes/intent_query_effect/models/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/models/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Models for the intent_query_effect node.
+
+This module exports configuration models for the intent query effect node.
+
+Exports:
+    ModelHandlerIntentQueryConfig: Handler configuration model.
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from omnimemory.nodes.intent_query_effect.models.model_handler_intent_query_config import (
+    ModelHandlerIntentQueryConfig,
+)
+
+__all__ = [
+    "ModelHandlerIntentQueryConfig",
+]

--- a/src/omnimemory/nodes/intent_query_effect/models/model_handler_intent_query_config.py
+++ b/src/omnimemory/nodes/intent_query_effect/models/model_handler_intent_query_config.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Configuration model for the intent query handler.
+
+This module defines the configuration model for HandlerIntentQuery,
+providing validated settings for timeout, time ranges, and defaults.
+
+Example::
+
+    from omnimemory.nodes.intent_query_effect.models import (
+        ModelHandlerIntentQueryConfig,
+    )
+
+    # Default configuration
+    config = ModelHandlerIntentQueryConfig()
+
+    # Custom configuration
+    config = ModelHandlerIntentQueryConfig(
+        timeout_seconds=30.0,
+        default_time_range_hours=48,
+        default_limit=50,
+        default_min_confidence=0.5,
+    )
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelHandlerIntentQueryConfig"]
+
+
+class ModelHandlerIntentQueryConfig(BaseModel):
+    """Configuration for HandlerIntentQuery.
+
+    Provides validated configuration settings for intent query operations
+    including timeouts, default query parameters, and thresholds.
+
+    Attributes:
+        timeout_seconds: Maximum time to wait for adapter operations.
+            Must be between 1.0 and 60.0 seconds.
+        default_time_range_hours: Default time range for distribution and
+            recent queries when not explicitly specified.
+        default_limit: Default result limit for session and recent queries
+            when not explicitly specified.
+        default_min_confidence: Default minimum confidence threshold for
+            filtering results.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+    )
+
+    timeout_seconds: float = Field(
+        default=10.0,
+        ge=1.0,
+        le=60.0,
+        description="Maximum time for adapter operations in seconds",
+    )
+    default_time_range_hours: int = Field(
+        default=24,
+        ge=1,
+        le=720,
+        description="Default time range in hours for distribution/recent queries",
+    )
+    default_limit: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Default result limit for session/recent queries",
+    )
+    default_min_confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Default minimum confidence threshold for filtering",
+    )

--- a/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
@@ -5,6 +5,16 @@
 Provides factory methods and metadata for the intent_query_effect node,
 following ONEX registry patterns for dependency injection and service discovery.
 
+Topic Naming:
+    This node uses topic SUFFIXES (not full topics). Runtime composes
+    full topics by adding env prefix::
+
+        full_topic = f"{topic_env_prefix}.{suffix}"
+
+    Example with "dev" env prefix:
+        - dev.onex.cmd.omnimemory.intent-query-requested.v1
+        - dev.onex.evt.omnimemory.intent-query-response.v1
+
 Example::
 
     from omnimemory.nodes.intent_query_effect.registry import (
@@ -16,7 +26,8 @@ Example::
 
     # Query node metadata
     node_type = RegistryIntentQueryEffect.get_node_type()  # "EFFECT"
-    topics = RegistryIntentQueryEffect.get_kafka_topics()
+    suffixes = RegistryIntentQueryEffect.get_topic_suffixes()
+    # {"subscribe": "onex.cmd...", "publish": "onex.evt..."}
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1504.

--- a/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Registry for intent_query_effect node.
+
+Provides factory methods and metadata for the intent_query_effect node,
+following ONEX registry patterns for dependency injection and service discovery.
+
+Example::
+
+    from omnimemory.nodes.intent_query_effect.registry import (
+        RegistryIntentQueryEffect,
+    )
+
+    # Create handler via registry
+    handler = await RegistryIntentQueryEffect.create_and_initialize(adapter)
+
+    # Query node metadata
+    node_type = RegistryIntentQueryEffect.get_node_type()  # "EFFECT"
+    topics = RegistryIntentQueryEffect.get_kafka_topics()
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from omnimemory.nodes.intent_query_effect.registry.registry_intent_query_effect import (
+    RegistryIntentQueryEffect,
+)
+
+__all__ = ["RegistryIntentQueryEffect"]

--- a/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
@@ -207,21 +207,38 @@ class RegistryIntentQueryEffect:
         return ["distribution", "session", "recent"]
 
     @staticmethod
-    def get_kafka_topics() -> dict[str, str]:
-        """Get Kafka topic configuration.
+    def get_topic_suffixes() -> dict[str, str]:
+        """Get Kafka topic suffixes for this node.
 
-        Returns the topic names used by this node for event
-        consumption and production.
+        Returns topic SUFFIXES (not full topics). Runtime composes
+        full topics by adding env prefix:
+            full_topic = f"{topic_env_prefix}.{suffix}"
+
+        Example full topics (with "dev" env prefix):
+            - dev.onex.cmd.omnimemory.intent-query-requested.v1
+            - dev.onex.evt.omnimemory.intent-query-response.v1
 
         Returns:
-            Dictionary with 'input' and 'output' topic names.
+            Dictionary with 'subscribe' and 'publish' topic suffixes.
 
         .. versionadded:: 0.1.0
         """
         return {
-            "input": "onex.cmd.omnimemory.intent-query-requested.v1",
-            "output": "onex.evt.omnimemory.intent-query-response.v1",
+            "subscribe": "onex.cmd.omnimemory.intent-query-requested.v1",
+            "publish": "onex.evt.omnimemory.intent-query-response.v1",
         }
+
+    @staticmethod
+    def get_invocation_mode() -> str:
+        """Get the invocation mode for this node.
+
+        Returns:
+            "subscription" - node subscribes to topic, runtime dispatches
+            "orchestrator" - node is invoked by orchestrator, no subscription
+
+        .. versionadded:: 0.1.0
+        """
+        return "subscription"
 
     @staticmethod
     def get_supported_operations() -> list[str]:

--- a/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Registry for intent_query_effect node dependency injection.
+
+This registry provides factory methods for creating HandlerIntentQuery
+instances with their required dependencies resolved.
+
+Following ONEX naming conventions:
+    - File: registry_<node_name>.py
+    - Class: Registry<NodeName>
+
+The registry serves as the entry point for creating properly configured
+handler instances, documenting required adapters, and providing
+node metadata for introspection.
+
+Related:
+    - models/: Configuration and mapping utilities
+    - handlers/: Handler implementation
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+    from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+    from omnimemory.nodes.intent_query_effect.models import (
+        ModelHandlerIntentQueryConfig,
+    )
+
+__all__ = ["RegistryIntentQueryEffect"]
+
+
+class RegistryIntentQueryEffect:
+    """Infrastructure registry for intent_query_effect node.
+
+    Provides factory methods for creating handler instances with
+    proper dependency injection.
+
+    This registry follows the ONEX infrastructure registry pattern:
+        - Factory methods for handler creation with adapter injection
+        - Adapter requirements documentation for validation
+        - Node type classification for routing decisions
+        - Capability listing for service discovery
+
+    Example:
+        >>> from omnimemory.handlers.adapters import (
+        ...     AdapterIntentGraph,
+        ...     ModelAdapterIntentGraphConfig,
+        ... )
+        >>> from omnimemory.nodes.intent_query_effect.registry import (
+        ...     RegistryIntentQueryEffect,
+        ... )
+        >>>
+        >>> # Create and initialize adapter
+        >>> adapter_config = ModelAdapterIntentGraphConfig()
+        >>> adapter = AdapterIntentGraph(adapter_config)
+        >>> await adapter.initialize(connection_uri="bolt://localhost:7687")
+        >>>
+        >>> # Create handler via registry
+        >>> handler = await RegistryIntentQueryEffect.create_and_initialize(adapter)
+
+    .. versionadded:: 0.1.0
+    """
+
+    @staticmethod
+    def create_handler(
+        config: ModelHandlerIntentQueryConfig | None = None,
+    ) -> HandlerIntentQuery:
+        """Create a HandlerIntentQuery with configuration.
+
+        Factory method that creates a HandlerIntentQuery instance
+        with optional configuration. The handler must be initialized
+        separately with an adapter before use.
+
+        Args:
+            config: Optional handler configuration. Uses defaults if not provided.
+
+        Returns:
+            Configured HandlerIntentQuery instance (not yet initialized).
+
+        Example:
+            >>> handler = RegistryIntentQueryEffect.create_handler()
+            >>> await handler.initialize(adapter)
+
+        .. versionadded:: 0.1.0
+        """
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        return HandlerIntentQuery(config=config)
+
+    @staticmethod
+    async def create_and_initialize(
+        adapter: AdapterIntentGraph,
+        config: ModelHandlerIntentQueryConfig | None = None,
+    ) -> HandlerIntentQuery:
+        """Create and initialize a HandlerIntentQuery.
+
+        Convenience method that creates and initializes in one call.
+
+        Args:
+            adapter: Initialized AdapterIntentGraph instance for database
+                operations. Must be initialized before passing.
+            config: Optional handler configuration. Uses defaults if not provided.
+
+        Returns:
+            Initialized HandlerIntentQuery ready to execute queries.
+
+        Example:
+            >>> handler = await RegistryIntentQueryEffect.create_and_initialize(
+            ...     adapter=adapter,
+            ...     config=ModelHandlerIntentQueryConfig(timeout_seconds=30.0),
+            ... )
+            >>> response = await handler.execute(request)
+
+        .. versionadded:: 0.1.0
+        """
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery(config=config)
+        await handler.initialize(adapter)
+        return handler
+
+    @staticmethod
+    def get_required_adapters() -> list[str]:
+        """Get list of adapters required by this node.
+
+        Returns the adapter class names that must be provided when
+        initializing handlers from this registry.
+
+        Returns:
+            List of adapter class names required for node operation.
+
+        Example:
+            >>> adapters = RegistryIntentQueryEffect.get_required_adapters()
+            >>> print(adapters)
+            ['AdapterIntentGraph']
+
+        .. versionadded:: 0.1.0
+        """
+        return ["AdapterIntentGraph"]
+
+    @staticmethod
+    def get_node_type() -> str:
+        """Get the ONEX node type classification.
+
+        Returns the ONEX node archetype for this node, used for
+        routing decisions and execution context selection.
+
+        Returns:
+            Node type string ("EFFECT").
+
+        Note:
+            EFFECT nodes perform external I/O operations and should
+            be treated as side-effecting by the runtime.
+
+        .. versionadded:: 0.1.0
+        """
+        return "EFFECT"
+
+    @staticmethod
+    def get_node_name() -> str:
+        """Get the canonical node name.
+
+        Returns:
+            The node name identifier.
+
+        .. versionadded:: 0.1.0
+        """
+        return "intent_query_effect"
+
+    @staticmethod
+    def get_capabilities() -> list[str]:
+        """Get list of capabilities provided by this node.
+
+        Returns capability identifiers that can be used for service
+        discovery and feature detection.
+
+        Returns:
+            List of capability identifiers.
+
+        .. versionadded:: 0.1.0
+        """
+        return [
+            "intent_distribution_query",
+            "intent_session_query",
+            "intent_recent_query",
+            "event_driven_response",
+        ]
+
+    @staticmethod
+    def get_supported_query_types() -> list[str]:
+        """Get list of supported query types.
+
+        Returns the query type values that can be passed in
+        intent query request events.
+
+        Returns:
+            List of supported query type strings.
+
+        .. versionadded:: 0.1.0
+        """
+        return ["distribution", "session", "recent"]
+
+    @staticmethod
+    def get_kafka_topics() -> dict[str, str]:
+        """Get Kafka topic configuration.
+
+        Returns the topic names used by this node for event
+        consumption and production.
+
+        Returns:
+            Dictionary with 'input' and 'output' topic names.
+
+        .. versionadded:: 0.1.0
+        """
+        return {
+            "input": "onex.cmd.omnimemory.intent-query-requested.v1",
+            "output": "onex.evt.omnimemory.intent-query-response.v1",
+        }
+
+    @staticmethod
+    def get_supported_operations() -> list[str]:
+        """Get list of operations supported by this node.
+
+        Returns:
+            List of operation identifiers.
+
+        .. versionadded:: 0.1.0
+        """
+        return [
+            "query_intent_distribution",
+            "query_session_intents",
+            "query_recent_intents",
+        ]
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get list of backend types this node interacts with.
+
+        Returns:
+            List of backend identifiers.
+
+        .. versionadded:: 0.1.0
+        """
+        return ["memgraph", "kafka"]

--- a/src/omnimemory/nodes/intent_query_effect/utils/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Utilities for the intent_query_effect node."""
+
+from omnimemory.nodes.intent_query_effect.utils.util_intent_mapping import (
+    map_intent_records,
+    map_to_intent_payload,
+)
+
+__all__ = [
+    "map_intent_records",
+    "map_to_intent_payload",
+]

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Utilities for mapping between omnimemory and core intent models.
+
+This module provides mapping functions to convert between internal
+omnimemory intent records and the core event payload models used
+for Kafka event transmission.
+
+The key difference between models:
+    - ModelIntentRecord.session_ref is optional (from graph queries)
+    - IntentRecordPayload.session_ref is required (for event transmission)
+    - Field name: created_at_utc (internal) -> created_at (payload)
+
+Example::
+
+    from omnimemory.handlers.adapters.models import ModelIntentRecord
+    from omnimemory.nodes.intent_query_effect.models import map_to_intent_payload
+
+    record = ModelIntentRecord(
+        intent_id=uuid4(),
+        session_ref="session_abc123",
+        intent_category="debugging",
+        confidence=0.9,
+        keywords=["error", "fix"],
+        created_at_utc=datetime.now(UTC),
+    )
+
+    payload = map_to_intent_payload(record)
+    # payload is ready for event transmission
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from omnibase_core.models.events import IntentRecordPayload
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters.models import ModelIntentRecord
+
+__all__ = ["map_intent_records", "map_to_intent_payload"]
+
+
+def map_to_intent_payload(record: ModelIntentRecord) -> IntentRecordPayload:
+    """Convert a ModelIntentRecord to IntentRecordPayload.
+
+    Maps from the omnimemory internal model to the core event payload model
+    for transmission in Kafka events.
+
+    Args:
+        record: The internal intent record from AdapterIntentGraph.
+
+    Returns:
+        IntentRecordPayload suitable for event transmission.
+
+    Raises:
+        ValueError: If session_ref is None (required for payload).
+
+    Note:
+        The field name differs between models:
+            - ModelIntentRecord uses ``created_at_utc``
+            - IntentRecordPayload uses ``created_at``
+    """
+    if record.session_ref is None:
+        raise ValueError(
+            f"Cannot map intent {record.intent_id} to payload: session_ref is required"
+        )
+
+    return IntentRecordPayload(
+        intent_id=record.intent_id,
+        session_ref=record.session_ref,
+        intent_category=record.intent_category,
+        confidence=record.confidence,
+        keywords=record.keywords,
+        created_at=record.created_at_utc,
+    )
+
+
+def map_intent_records(records: list[ModelIntentRecord]) -> list[IntentRecordPayload]:
+    """Convert a list of ModelIntentRecord to IntentRecordPayload.
+
+    Convenience function for bulk conversion of intent records.
+
+    Args:
+        records: List of internal intent records.
+
+    Returns:
+        List of payload models for event transmission.
+
+    Raises:
+        ValueError: If any record has a None session_ref.
+    """
+    return [map_to_intent_payload(record) for record in records]

--- a/tests/nodes/intent_query_effect/__init__.py
+++ b/tests/nodes/intent_query_effect/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for intent_query_effect node."""

--- a/tests/nodes/intent_query_effect/conftest.py
+++ b/tests/nodes/intent_query_effect/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Pytest configuration for intent_query_effect tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "memgraph: marks tests as requiring Memgraph database",
+    )

--- a/tests/nodes/intent_query_effect/test_handler_intent_query_integration.py
+++ b/tests/nodes/intent_query_effect/test_handler_intent_query_integration.py
@@ -9,6 +9,8 @@ Test Categories:
     - Distribution: Query intent distribution by category
     - Session: Query intents for a specific session
     - Recent: Query recent intents across all sessions
+    - Data round-trip: Create, query, and verify intent data
+    - Filtering: Test confidence and other filter criteria
     - Error handling: Test error conditions and edge cases
 
 Prerequisites:
@@ -38,7 +40,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -198,6 +200,70 @@ async def initialized_handler(
     await handler.shutdown()
 
 
+@pytest.fixture
+async def test_intents_in_db(
+    initialized_adapter: AdapterIntentGraph,
+    test_session_id: str,
+) -> list[dict[str, Any]]:
+    """Create test intents in database for query testing.
+
+    This fixture stores test intents with varying categories and confidence
+    levels to enable comprehensive query testing. The intents are linked to
+    the unique test_session_id to ensure test isolation.
+
+    Returns:
+        List of dictionaries containing stored intent metadata:
+        - intent_id: UUID of the stored intent
+        - session_id: Session the intent belongs to
+        - category: Intent category string
+        - confidence: Confidence score (0.0-1.0)
+        - keywords: List of keywords for this intent
+
+    Note:
+        No cleanup is needed since each test run uses a unique session_id,
+        providing natural test isolation without explicit deletion.
+    """
+    from uuid import uuid4
+
+    from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
+
+    # Create test intents with varying categories and confidence levels
+    test_intents: list[dict[str, Any]] = []
+    test_data = [
+        ("debugging", 0.80, ["error", "traceback"]),
+        ("feature_request", 0.85, ["add", "implement"]),
+        ("documentation", 0.90, ["docs", "explain"]),
+    ]
+
+    for category, confidence, keywords in test_data:
+        intent_data = ModelIntentClassificationOutput(
+            intent_category=category,
+            confidence=confidence,
+            keywords=keywords,
+        )
+        correlation_id = uuid4()
+
+        result = await initialized_adapter.store_intent(
+            session_id=test_session_id,
+            intent_data=intent_data,
+            correlation_id=correlation_id,
+        )
+
+        if result.status == "success" and result.intent_id is not None:
+            test_intents.append(
+                {
+                    "intent_id": result.intent_id,
+                    "session_id": test_session_id,
+                    "category": category,
+                    "confidence": confidence,
+                    "keywords": keywords,
+                    "correlation_id": correlation_id,
+                }
+            )
+
+    return test_intents
+
+
 # =============================================================================
 # Integration Tests
 # =============================================================================
@@ -324,6 +390,274 @@ class TestHandlerIntentQueryIntegration:
 
         assert response.execution_time_ms is not None
         assert response.execution_time_ms > 0
+
+    # =========================================================================
+    # Data Round-Trip Tests (Create -> Query -> Verify)
+    # =========================================================================
+
+    @pytest.mark.asyncio
+    async def test_session_query_returns_stored_intents(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+        test_session_id: str,
+    ) -> None:
+        """Test session query returns intents that were stored.
+
+        This test validates the full round-trip: intents are stored via the
+        adapter, then queried via the handler, and results are verified to
+        match the stored data.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        # Skip if no intents were stored (indicates storage failure)
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        request = ModelIntentQueryRequestedEvent.create_session_query(
+            session_ref=test_session_id,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success", f"Query failed: {response.error_message}"
+        assert len(response.intents) == len(test_intents_in_db)
+
+        # Verify all expected categories are present
+        response_categories = {i.intent_category for i in response.intents}
+        expected_categories = {i["category"] for i in test_intents_in_db}
+        assert response_categories == expected_categories
+
+        # Verify confidence values match
+        response_confidences = {
+            i.intent_category: i.confidence for i in response.intents
+        }
+        for stored_intent in test_intents_in_db:
+            category = stored_intent["category"]
+            expected_confidence = stored_intent["confidence"]
+            assert category in response_confidences
+            assert abs(response_confidences[category] - expected_confidence) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_recent_query_returns_stored_intents(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+    ) -> None:
+        """Test recent query returns recently stored intents.
+
+        Since test intents are created just before this test runs, they
+        should appear in a recent query with a short time range.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        request = ModelIntentQueryRequestedEvent.create_recent_query(
+            time_range_hours=1,  # Just created, should be within 1 hour
+            limit=100,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success", f"Query failed: {response.error_message}"
+        # Should have at least our test intents (might have more from other tests)
+        assert len(response.intents) >= len(test_intents_in_db)
+
+        # Verify our test categories appear in the results
+        response_categories = {i.intent_category for i in response.intents}
+        expected_categories = {i["category"] for i in test_intents_in_db}
+        assert expected_categories.issubset(response_categories)
+
+    @pytest.mark.asyncio
+    async def test_distribution_query_includes_stored_categories(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+    ) -> None:
+        """Test distribution query includes stored intent categories.
+
+        The distribution query aggregates intent counts by category. Our
+        test intents should appear in the distribution with correct counts.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        request = ModelIntentQueryRequestedEvent.create_distribution_query(
+            time_range_hours=1,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success", f"Query failed: {response.error_message}"
+        assert response.distribution is not None
+
+        # Our test categories should appear in distribution
+        for test_intent in test_intents_in_db:
+            category = test_intent["category"]
+            assert category in response.distribution, (
+                f"Expected category '{category}' not found in distribution. "
+                f"Available categories: {list(response.distribution.keys())}"
+            )
+            # Each category should have at least 1 intent
+            assert response.distribution[category] >= 1
+
+    @pytest.mark.asyncio
+    async def test_session_query_with_confidence_filter(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+        test_session_id: str,
+    ) -> None:
+        """Test session query filters by min_confidence.
+
+        Test data has confidence values: 0.80, 0.85, 0.90
+        Filtering with min_confidence=0.84 should exclude the first intent.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        # Filter for confidence > 0.84, should exclude 0.80
+        min_confidence = 0.84
+        request = ModelIntentQueryRequestedEvent.create_session_query(
+            session_ref=test_session_id,
+            min_confidence=min_confidence,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        # Should have filtered out the low-confidence intent
+        assert response.status in ("success", "no_results")
+
+        if response.status == "success":
+            # All returned intents should have confidence >= min_confidence
+            for intent in response.intents:
+                assert intent.confidence >= min_confidence, (
+                    f"Intent with confidence {intent.confidence} should have "
+                    f"been filtered out (min_confidence={min_confidence})"
+                )
+
+            # Count how many test intents should pass the filter
+            expected_count = sum(
+                1 for i in test_intents_in_db if i["confidence"] >= min_confidence
+            )
+            assert len(response.intents) == expected_count
+
+    @pytest.mark.asyncio
+    async def test_session_query_returns_intent_ids(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+        test_session_id: str,
+    ) -> None:
+        """Test session query returns valid intent IDs.
+
+        Verify that the returned intent records have valid UUIDs that match
+        the IDs returned during storage.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        request = ModelIntentQueryRequestedEvent.create_session_query(
+            session_ref=test_session_id,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success"
+
+        # All returned intents should have valid UUIDs
+        for intent in response.intents:
+            assert intent.intent_id is not None
+            # UUID should be valid (not raise on str conversion)
+            assert str(intent.intent_id)
+
+        # The returned intent_ids should match what was stored
+        response_ids = {intent.intent_id for intent in response.intents}
+        stored_ids = {i["intent_id"] for i in test_intents_in_db}
+        assert response_ids == stored_ids
+
+    @pytest.mark.asyncio
+    async def test_recent_query_with_limit(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+    ) -> None:
+        """Test recent query respects limit parameter.
+
+        When limit is less than the number of stored intents, only
+        that many should be returned.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if len(test_intents_in_db) < 2:
+            pytest.skip("Need at least 2 intents for limit test")
+
+        # Request fewer intents than we stored
+        limit = 2
+        request = ModelIntentQueryRequestedEvent.create_recent_query(
+            time_range_hours=1,
+            limit=limit,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success"
+        # Should not exceed the requested limit
+        assert len(response.intents) <= limit
+
+    @pytest.mark.asyncio
+    async def test_intent_keywords_preserved(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_intents_in_db: list[dict[str, Any]],
+        test_session_id: str,
+    ) -> None:
+        """Test that intent keywords are preserved through storage and retrieval.
+
+        Keywords are an important part of intent classification and should
+        be accurately stored and returned.
+        """
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        if not test_intents_in_db:
+            pytest.skip("No test intents were stored - storage may have failed")
+
+        request = ModelIntentQueryRequestedEvent.create_session_query(
+            session_ref=test_session_id,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "success"
+
+        # Build a map of category -> keywords from stored data
+        stored_keywords: dict[str, list[str]] = {
+            i["category"]: i["keywords"] for i in test_intents_in_db
+        }
+
+        # Verify keywords match for each returned intent
+        for intent in response.intents:
+            expected_keywords = stored_keywords.get(intent.intent_category)
+            assert expected_keywords is not None
+            assert set(intent.keywords) == set(expected_keywords), (
+                f"Keywords mismatch for category '{intent.intent_category}': "
+                f"expected {expected_keywords}, got {intent.keywords}"
+            )
 
 
 # =============================================================================

--- a/tests/nodes/intent_query_effect/test_handler_intent_query_integration.py
+++ b/tests/nodes/intent_query_effect/test_handler_intent_query_integration.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for HandlerIntentQuery with real Memgraph.
+
+These tests require a running Memgraph instance. They will be skipped
+if Memgraph is not available.
+
+Test Categories:
+    - Distribution: Query intent distribution by category
+    - Session: Query intents for a specific session
+    - Recent: Query recent intents across all sessions
+    - Error handling: Test error conditions and edge cases
+
+Prerequisites:
+    - Memgraph running at MEMGRAPH_URI (default: bolt://localhost:7687)
+    - omnibase_infra installed (dev dependency)
+
+Usage:
+    # Run only integration tests
+    pytest tests/nodes/intent_query_effect/test_handler_intent_query_integration.py -v
+
+    # Run with specific markers
+    pytest -m "integration and memgraph" -v
+
+    # Skip if Memgraph unavailable (automatic)
+    pytest -m integration -v
+
+Environment Variables:
+    MEMGRAPH_URI: Memgraph connection URI (default: bolt://localhost:7687)
+    MEMGRAPH_USER: Memgraph username (optional)
+    MEMGRAPH_PASSWORD: Memgraph password (optional)
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1504.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+# Environment configuration
+DEFAULT_MEMGRAPH_URI = "bolt://localhost:7687"
+DEFAULT_MEMGRAPH_USER = "memgraph"
+DEFAULT_MEMGRAPH_PASSWORD = ""
+
+
+def get_memgraph_uri() -> str:
+    """Get Memgraph URI from environment."""
+    return os.environ.get("MEMGRAPH_URI", DEFAULT_MEMGRAPH_URI)
+
+
+def get_memgraph_auth() -> tuple[str, str] | None:
+    """Get Memgraph auth from environment.
+
+    Returns a (username, password) tuple if both are configured, or None for
+    anonymous authentication.
+    """
+    user = os.environ.get("MEMGRAPH_USER", DEFAULT_MEMGRAPH_USER)
+    password = os.environ.get("MEMGRAPH_PASSWORD", DEFAULT_MEMGRAPH_PASSWORD)
+    if user and password:
+        return (user, password)
+    return None
+
+
+# =============================================================================
+# Availability Check
+# =============================================================================
+
+_MEMGRAPH_AVAILABLE = False
+_SKIP_REASON = "Memgraph not available"
+
+try:
+    from neo4j import AsyncGraphDatabase
+    from neo4j.exceptions import ServiceUnavailable
+
+    from omnimemory.handlers.adapters import AdapterIntentGraph
+    from omnimemory.handlers.adapters.models import ModelAdapterIntentGraphConfig
+    from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+    from omnimemory.nodes.intent_query_effect.models import (
+        ModelHandlerIntentQueryConfig,
+    )
+
+    _MEMGRAPH_AVAILABLE = True
+    _SKIP_REASON = ""
+except ImportError as e:
+    _SKIP_REASON = f"Required dependencies not installed: {e}"
+
+
+async def check_memgraph_available() -> bool:
+    """Check if Memgraph is reachable."""
+    if not _MEMGRAPH_AVAILABLE:
+        return False
+
+    try:
+        uri = get_memgraph_uri()
+        auth = get_memgraph_auth()
+        driver = AsyncGraphDatabase.driver(uri, auth=auth)
+        async with driver.session() as session:
+            result = await session.run("RETURN 1 AS test")
+            await result.consume()
+        await driver.close()
+        return True
+    except (ServiceUnavailable, OSError, Exception):
+        return False
+
+
+# Check availability at module load time
+try:
+    import asyncio
+
+    _loop = asyncio.new_event_loop()
+    _MEMGRAPH_AVAILABLE = _loop.run_until_complete(check_memgraph_available())
+    _loop.close()
+    if not _MEMGRAPH_AVAILABLE:
+        _SKIP_REASON = "Memgraph is not available or not responding"
+except Exception as e:
+    _MEMGRAPH_AVAILABLE = False
+    _SKIP_REASON = f"Failed to check Memgraph availability: {e}"
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.memgraph,
+    pytest.mark.skipif(not _MEMGRAPH_AVAILABLE, reason=_SKIP_REASON),
+]
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def test_session_id() -> str:
+    """Generate unique session ID for test isolation."""
+    return f"test_session_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def memgraph_available() -> bool:
+    """Check if Memgraph is available for tests."""
+    return await check_memgraph_available()
+
+
+@pytest.fixture
+def adapter_config() -> ModelAdapterIntentGraphConfig:
+    """Create adapter configuration for tests."""
+    return ModelAdapterIntentGraphConfig(
+        timeout_seconds=30.0,
+        auto_create_indexes=False,  # Skip index creation in tests
+    )
+
+
+@pytest.fixture
+def handler_config() -> ModelHandlerIntentQueryConfig:
+    """Create handler configuration for tests."""
+    return ModelHandlerIntentQueryConfig(
+        timeout_seconds=30.0,
+        default_time_range_hours=24,
+        default_limit=100,
+    )
+
+
+@pytest.fixture
+async def initialized_adapter(
+    memgraph_available: bool,
+    adapter_config: ModelAdapterIntentGraphConfig,
+) -> AsyncGenerator[AdapterIntentGraph, None]:
+    """Create and initialize adapter for tests."""
+    if not memgraph_available:
+        pytest.skip("Memgraph is not available")
+
+    adapter = AdapterIntentGraph(adapter_config)
+    await adapter.initialize(get_memgraph_uri(), get_memgraph_auth())
+
+    yield adapter
+
+    await adapter.shutdown()
+
+
+@pytest.fixture
+async def initialized_handler(
+    initialized_adapter: AdapterIntentGraph,
+    handler_config: ModelHandlerIntentQueryConfig,
+) -> AsyncGenerator[HandlerIntentQuery, None]:
+    """Create and initialize handler for tests."""
+    handler = HandlerIntentQuery(handler_config)
+    await handler.initialize(initialized_adapter)
+
+    yield handler
+
+    await handler.shutdown()
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestHandlerIntentQueryIntegration:
+    """Integration tests for HandlerIntentQuery with real Memgraph."""
+
+    @pytest.mark.asyncio
+    async def test_distribution_query_empty(
+        self,
+        initialized_handler: HandlerIntentQuery,
+    ) -> None:
+        """Test distribution query returns valid response even with no data."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        request = ModelIntentQueryRequestedEvent.create_distribution_query(
+            time_range_hours=1,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.query_id == request.query_id
+        assert response.query_type == "distribution"
+        assert response.status in ("success", "no_results")
+        assert response.correlation_id == request.correlation_id
+        assert response.execution_time_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_session_query_not_found(
+        self,
+        initialized_handler: HandlerIntentQuery,
+        test_session_id: str,
+    ) -> None:
+        """Test session query for non-existent session."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        request = ModelIntentQueryRequestedEvent.create_session_query(
+            session_ref=test_session_id,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.query_id == request.query_id
+        assert response.query_type == "session"
+        assert response.status in ("success", "no_results", "not_found")
+        assert response.intents == []
+        assert response.execution_time_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_recent_query_empty(
+        self,
+        initialized_handler: HandlerIntentQuery,
+    ) -> None:
+        """Test recent query returns valid response."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        request = ModelIntentQueryRequestedEvent.create_recent_query(
+            time_range_hours=1,
+            limit=10,
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.query_id == request.query_id
+        assert response.query_type == "recent"
+        assert response.status in ("success", "no_results")
+        assert response.execution_time_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_session_query_missing_ref_returns_error(
+        self,
+        initialized_handler: HandlerIntentQuery,
+    ) -> None:
+        """Test session query without session_ref returns error."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        # Manually create request without session_ref
+        request = ModelIntentQueryRequestedEvent(
+            query_type="session",
+            session_ref=None,  # Missing!
+            requester_name="test",
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.status == "error"
+        assert "session_ref" in (response.error_message or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_correlation_id_preserved(
+        self,
+        initialized_handler: HandlerIntentQuery,
+    ) -> None:
+        """Test correlation_id is echoed in response."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        correlation_id = uuid.uuid4()
+        request = ModelIntentQueryRequestedEvent.create_distribution_query(
+            time_range_hours=1,
+            correlation_id=correlation_id,
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.correlation_id == correlation_id
+
+    @pytest.mark.asyncio
+    async def test_execution_time_is_positive(
+        self,
+        initialized_handler: HandlerIntentQuery,
+    ) -> None:
+        """Test execution time is tracked and positive."""
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        request = ModelIntentQueryRequestedEvent.create_distribution_query(
+            time_range_hours=24,
+        )
+
+        response = await initialized_handler.execute(request)
+
+        assert response.execution_time_ms is not None
+        assert response.execution_time_ms > 0
+
+
+# =============================================================================
+# Unit Tests (No Memgraph Required)
+# =============================================================================
+
+
+class TestHandlerIntentQueryUnit:
+    """Unit tests that don't require Memgraph."""
+
+    @pytest.mark.asyncio
+    async def test_handler_not_initialized_returns_error(self) -> None:
+        """Test execute before initialize returns error."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.handlers")
+        from omnibase_core.models.events import ModelIntentQueryRequestedEvent
+
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery()
+        request = ModelIntentQueryRequestedEvent.create_distribution_query(
+            time_range_hours=1,
+        )
+
+        response = await handler.execute(request)
+
+        assert response.status == "error"
+        assert "not initialized" in (response.error_message or "").lower()
+
+    def test_handler_config_defaults(self) -> None:
+        """Test handler uses default config when none provided."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.handlers")
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery()
+
+        assert handler.config.timeout_seconds == 10.0
+        assert handler.config.default_time_range_hours == 24
+        assert handler.config.default_limit == 100
+
+    def test_handler_config_custom(self) -> None:
+        """Test handler accepts custom config."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.models")
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+        from omnimemory.nodes.intent_query_effect.models import (
+            ModelHandlerIntentQueryConfig,
+        )
+
+        config = ModelHandlerIntentQueryConfig(
+            timeout_seconds=30.0,
+            default_time_range_hours=48,
+            default_limit=50,
+        )
+        handler = HandlerIntentQuery(config)
+
+        assert handler.config.timeout_seconds == 30.0
+        assert handler.config.default_time_range_hours == 48
+        assert handler.config.default_limit == 50
+
+    def test_handler_not_initialized_by_default(self) -> None:
+        """Test handler is not initialized by default."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.handlers")
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery()
+
+        assert not handler.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_handler_initialize_requires_adapter(self) -> None:
+        """Test initialize requires valid adapter."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.handlers")
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery()
+
+        # Should not raise, but sets adapter
+        # We can't call initialize with None, so we test the state
+        assert handler.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_handler_shutdown_idempotent(self) -> None:
+        """Test shutdown can be called multiple times safely."""
+        pytest.importorskip("omnimemory.nodes.intent_query_effect.handlers")
+        from omnimemory.nodes.intent_query_effect.handlers import HandlerIntentQuery
+
+        handler = HandlerIntentQuery()
+
+        # Should not raise
+        await handler.shutdown()
+        await handler.shutdown()
+
+        assert not handler.is_initialized
+
+
+# Remove integration markers for unit tests
+TestHandlerIntentQueryUnit.pytestmark = []  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Implements ONEX effect node that handles intent query requests via Kafka, enabling OmniDash to query intent data without direct database access.

- Add `get_recent_intents()` to AdapterIntentGraph for time-based queries across all sessions
- Add `session_ref` field to ModelIntentRecord for IntentRecordPayload mapping
- Create `intent_query_effect` node with contract.yaml, handler, registry
- Support 3 query types: distribution, session, recent
- Add integration and unit tests
- Update omnibase dependencies (core 0.9.4, spi 0.6.0, infra 0.2.3)

## Architecture

```
OmniDash
    → Kafka: dev.omnimemory.intent.query.requested.v1
        → HandlerIntentQuery
            → AdapterIntentGraph (Memgraph)
    ← Kafka: dev.omnimemory.intent.query.response.v1
```

## Files Changed

**New Node** (`src/omnimemory/nodes/intent_query_effect/`):
- `contract.yaml` - ONEX contract definition
- `handlers/handler_intent_query.py` - Main handler with query routing
- `models/model_handler_intent_query_config.py` - Configuration model
- `utils/util_intent_mapping.py` - ModelIntentRecord → IntentRecordPayload mapping
- `registry/registry_intent_query_effect.py` - DI registry

**Modified**:
- `adapter_intent_graph.py` - Added `get_recent_intents()` method
- `model_intent_domain.py` - Added `session_ref` field to ModelIntentRecord
- `pyproject.toml` - Updated omnibase dependencies

## Test plan

- [x] Unit tests pass (6 tests, no Memgraph required)
- [ ] Integration tests with Memgraph (requires running instance)
- [ ] Verify Kafka event flow end-to-end with OmniDash

## Linear

Closes OMN-1504