### PR TITLE
feat(handlers): Add HandlerIntent for direct intent operations [OMN-1…

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Example modules for OmniMemory."""

--- a/src/omnimemory/handlers/__init__.py
+++ b/src/omnimemory/handlers/__init__.py
@@ -7,6 +7,7 @@ Handlers interface with infrastructure services (databases, graph stores, vector
 while adapters translate between memory-domain concepts and handler-level operations.
 
 Available Handlers:
+    - HandlerIntent: Direct protocol handler for intent storage and query operations
     - HandlerSubscription: Agent subscription and notification delivery management
     - HandlerSemanticCompute: Semantic analysis with policy hooks
 
@@ -16,6 +17,8 @@ Subpackages:
 Example::
 
     from omnimemory.handlers import (
+        HandlerIntent,
+        ModelHandlerIntentMetadata,
         HandlerSubscription,
         ModelHandlerSubscriptionConfig,
         HandlerSemanticCompute,
@@ -29,6 +32,7 @@ Example::
 .. versionadded:: 0.1.0
     HandlerSubscription added for OMN-1393.
     HandlerSemanticCompute added for OMN-1390.
+    HandlerIntent added for OMN-1536.
 """
 
 from omnimemory.handlers.adapters import (
@@ -43,6 +47,10 @@ from omnimemory.handlers.adapters import (
     ModelRelatedMemoryResult,
     ModelValkeyHealth,
 )
+from omnimemory.handlers.handler_intent import (
+    HandlerIntent,
+    ModelHandlerIntentMetadata,
+)
 from omnimemory.handlers.handler_semantic_compute import (
     HandlerSemanticCompute,
     HandlerSemanticComputePolicy,
@@ -54,8 +62,13 @@ from omnimemory.handlers.handler_subscription import (
     ModelSubscriptionHealth,
     ModelSubscriptionMetrics,
 )
+from omnimemory.handlers.models import ModelHandlerIntentConfig
 
 __all__ = [
+    # Intent Handler
+    "HandlerIntent",
+    "ModelHandlerIntentConfig",
+    "ModelHandlerIntentMetadata",
     # Semantic Compute Handler
     "HandlerSemanticCompute",
     "HandlerSemanticComputePolicy",

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -6,11 +6,23 @@ Wraps AdapterIntentGraph following the omnibase_infra container-driven pattern.
 Unlike event-driven handlers, this handler provides synchronous direct method
 calls for API layer integration.
 
+Protocol Compliance:
+    Implements :class:`~omnimemory.protocols.ProtocolHandlerIntent` protocol
+    for contract-driven development and type-safe dependency injection.
+
+Resilience:
+    Includes circuit breaker pattern for fault tolerance. The circuit breaker
+    protects against cascading failures when the graph database is unavailable
+    or experiencing issues. Configuration via initialize() options:
+    - circuit_breaker_threshold: Failures before opening (default: 5)
+    - circuit_breaker_reset_timeout: Seconds before half-open (default: 60.0)
+
 Architecture:
     - Container-driven initialization (receives ModelONEXContainer)
     - Handler owns adapter lifecycle (creates on init, closes on shutdown)
     - Delegates all operations to AdapterIntentGraph
     - Uses structured logging with correlation IDs
+    - Circuit breaker wraps all adapter operations
 
 Operations:
     - store_intent(): Store an intent classification linked to a session
@@ -53,6 +65,9 @@ Example::
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1536.
+
+.. versionchanged:: 0.2.0
+    Added ProtocolHandlerIntent compliance and circuit breaker resilience.
 """
 
 from __future__ import annotations
@@ -75,11 +90,17 @@ from omnimemory.handlers.adapters.models import (
     ModelIntentQueryResult,
     ModelIntentStorageResult,
 )
+from omnimemory.utils.concurrency import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitBreakerState,
+)
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
 
 __all__ = [
+    "CircuitBreakerOpenError",
     "HandlerIntent",
     "ModelHandlerIntentMetadata",
 ]
@@ -90,9 +111,9 @@ logger = logging.getLogger(__name__)
 HANDLER_ID_INTENT: str = "intent-handler"
 
 
-class ModelHandlerIntentMetadata(
+class ModelHandlerIntentMetadata(  # omnimemory-model-exempt: handler-local metadata
     BaseModel
-):  # omnimemory-model-exempt: handler-local metadata
+):
     """Metadata describing the intent handler capabilities.
 
     Returned by HandlerIntent.describe() to provide information about
@@ -131,6 +152,8 @@ class ModelHandlerIntentMetadata(
 class HandlerIntent:
     """Direct protocol handler for intent storage and query operations.
 
+    Implements: :class:`~omnimemory.protocols.ProtocolHandlerIntent`
+
     Wraps AdapterIntentGraph following the omnibase_infra container-driven pattern.
     Unlike HandlerIntentQuery (event-driven), this handler provides synchronous
     direct method calls for API layer integration.
@@ -140,11 +163,23 @@ class HandlerIntent:
     - Closes adapter during shutdown()
 
     Protocol Compliance:
-        Implements standard handler interface:
+        Implements :class:`~omnimemory.protocols.ProtocolHandlerIntent` protocol:
         - handler_type property returning "intent"
         - is_initialized property for state checking
         - initialize(), shutdown() lifecycle methods
+        - store_intent(), query_session(), query_distribution() operations
         - health_check(), describe() introspection methods
+
+    Circuit Breaker:
+        All adapter operations are protected by a circuit breaker pattern to
+        prevent cascading failures. The circuit breaker:
+        - Opens after consecutive failures (configurable threshold)
+        - Automatically attempts recovery after reset timeout
+        - Raises CircuitBreakerOpenError when open (fail-fast behavior)
+
+        Configuration via initialize() options:
+        - circuit_breaker_threshold: Failures before opening (default: 5)
+        - circuit_breaker_reset_timeout: Seconds before half-open (default: 60.0)
 
     Thread Safety:
         Uses asyncio.Lock for initialization to prevent race conditions
@@ -154,6 +189,9 @@ class HandlerIntent:
         All business operation methods return error status in response
         models rather than raising exceptions. This allows API layers
         to handle errors gracefully without try/except blocks.
+
+        Exception: CircuitBreakerOpenError is raised when the circuit is
+        open to provide immediate feedback that the service is unavailable.
 
     Attributes:
         handler_type: Returns "intent" as handler type identifier.
@@ -193,6 +231,8 @@ class HandlerIntent:
             The container is stored for interface compliance with the standard
             ONEX handler pattern and to enable future DI-based service resolution.
             The adapter is NOT created here; it is created during initialize().
+            The circuit breaker is also created during initialize() with
+            configuration from the options parameter.
         """
         self._container = container
         self._adapter: AdapterIntentGraph | None = None
@@ -200,6 +240,8 @@ class HandlerIntent:
         self._initialized: bool = False
         self._init_lock = asyncio.Lock()
         self._connection_uri: str = ""
+        # Circuit breaker for adapter operations (initialized in initialize())
+        self._circuit_breaker: CircuitBreaker | None = None
 
     @property
     def handler_type(self) -> str:
@@ -299,6 +341,38 @@ class HandlerIntent:
 
                 auto_indexes_raw = opts.get("auto_create_indexes", True)
                 auto_create_indexes = bool(auto_indexes_raw)
+
+                # Circuit breaker configuration
+                cb_threshold_raw = opts.get("circuit_breaker_threshold", 5)
+                circuit_breaker_threshold = (
+                    int(cb_threshold_raw)
+                    if isinstance(cb_threshold_raw, int | float | str)
+                    else 5
+                )
+
+                cb_reset_raw = opts.get("circuit_breaker_reset_timeout", 60.0)
+                circuit_breaker_reset_timeout = (
+                    float(cb_reset_raw)
+                    if isinstance(cb_reset_raw, int | float | str)
+                    else 60.0
+                )
+
+                # Create circuit breaker for adapter protection
+                self._circuit_breaker = CircuitBreaker(
+                    failure_threshold=circuit_breaker_threshold,
+                    recovery_timeout=circuit_breaker_reset_timeout,
+                    success_threshold=1,  # Close after 1 success in half-open
+                )
+
+                logger.debug(
+                    "Circuit breaker configured",
+                    extra={
+                        "handler": HANDLER_ID_INTENT,
+                        "correlation_id": str(init_correlation_id),
+                        "failure_threshold": circuit_breaker_threshold,
+                        "recovery_timeout": circuit_breaker_reset_timeout,
+                    },
+                )
 
                 self._adapter_config = ModelAdapterIntentGraphConfig(
                     timeout_seconds=timeout_seconds,
@@ -418,6 +492,7 @@ class HandlerIntent:
 
             self._initialized = False
             self._adapter_config = None
+            self._circuit_breaker = None
 
             logger.info(
                 "%s shutdown complete",
@@ -428,20 +503,24 @@ class HandlerIntent:
                 },
             )
 
-    def _ensure_initialized(self) -> AdapterIntentGraph:
-        """Ensure handler is initialized and return adapter.
+    def _ensure_initialized(self) -> tuple[AdapterIntentGraph, CircuitBreaker]:
+        """Ensure handler is initialized and return adapter with circuit breaker.
 
         Returns:
-            The initialized AdapterIntentGraph.
+            Tuple of (AdapterIntentGraph, CircuitBreaker) for protected operations.
 
         Raises:
             RuntimeError: If handler is not initialized.
         """
-        if not self._initialized or self._adapter is None:
+        if (
+            not self._initialized
+            or self._adapter is None
+            or self._circuit_breaker is None
+        ):
             raise RuntimeError(
                 "HandlerIntent not initialized. Call initialize() first."
             )
-        return self._adapter
+        return self._adapter, self._circuit_breaker
 
     # =========================================================================
     # Core Operations
@@ -470,12 +549,17 @@ class HandlerIntent:
             On success, includes the intent_id and whether a new
             intent was created vs merged.
 
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is open.
+
         Note:
             This method never raises on business errors - it returns
-            an error status in the result model instead.
+            an error status in the result model instead. However,
+            CircuitBreakerOpenError is raised for immediate fail-fast
+            behavior when the service is unavailable.
         """
         try:
-            adapter = self._ensure_initialized()
+            adapter, circuit_breaker = self._ensure_initialized()
         except RuntimeError as e:
             logger.error(
                 "store_intent called on uninitialized handler",
@@ -491,6 +575,21 @@ class HandlerIntent:
                 error_message=str(e),
             )
 
+        # Check circuit breaker before attempting operation
+        if not circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker is open, failing fast",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(correlation_id),
+                    "session_id": session_id,
+                    "circuit_state": circuit_breaker.state.value,
+                },
+            )
+            raise CircuitBreakerOpenError(
+                f"Circuit breaker is {circuit_breaker.state.value}"
+            )
+
         logger.debug(
             "Storing intent for session %s",
             session_id,
@@ -502,12 +601,34 @@ class HandlerIntent:
             },
         )
 
-        return await adapter.store_intent(
-            session_id=session_id,
-            intent_data=intent_data,
-            correlation_id=correlation_id,
-            user_context=user_context,
-        )
+        try:
+            result = await adapter.store_intent(
+                session_id=session_id,
+                intent_data=intent_data,
+                correlation_id=correlation_id,
+                user_context=user_context,
+            )
+            # Record success if operation completed without exception
+            if result.status == "success":
+                circuit_breaker.record_success()
+            else:
+                # Business errors (e.g., validation) are not circuit breaker failures
+                pass
+            return result
+        except Exception as e:
+            circuit_breaker.record_failure()
+            logger.error(
+                "store_intent failed, recorded circuit breaker failure",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(correlation_id),
+                    "session_id": session_id,
+                    "error": str(e),
+                    "circuit_state": circuit_breaker.state.value,
+                    "failure_count": circuit_breaker.failure_count,
+                },
+            )
+            raise
 
     async def query_session(
         self,
@@ -530,14 +651,19 @@ class HandlerIntent:
         Returns:
             ModelIntentQueryResult with the list of intents or error status.
 
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is open.
+
         Note:
             This method never raises on business errors - it returns
-            an error status in the result model instead.
+            an error status in the result model instead. However,
+            CircuitBreakerOpenError is raised for immediate fail-fast
+            behavior when the service is unavailable.
         """
         query_correlation_id = uuid4()
 
         try:
-            adapter = self._ensure_initialized()
+            adapter, circuit_breaker = self._ensure_initialized()
         except RuntimeError as e:
             logger.error(
                 "query_session called on uninitialized handler",
@@ -552,6 +678,21 @@ class HandlerIntent:
                 error_message=str(e),
             )
 
+        # Check circuit breaker before attempting operation
+        if not circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker is open, failing fast",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "session_id": session_id,
+                    "circuit_state": circuit_breaker.state.value,
+                },
+            )
+            raise CircuitBreakerOpenError(
+                f"Circuit breaker is {circuit_breaker.state.value}"
+            )
+
         logger.debug(
             "Querying intents for session %s",
             session_id,
@@ -564,11 +705,30 @@ class HandlerIntent:
             },
         )
 
-        return await adapter.get_session_intents(
-            session_id=session_id,
-            min_confidence=min_confidence,
-            limit=limit,
-        )
+        try:
+            result = await adapter.get_session_intents(
+                session_id=session_id,
+                min_confidence=min_confidence,
+                limit=limit,
+            )
+            # Record success if operation completed without exception
+            if result.status == "success":
+                circuit_breaker.record_success()
+            return result
+        except Exception as e:
+            circuit_breaker.record_failure()
+            logger.error(
+                "query_session failed, recorded circuit breaker failure",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "session_id": session_id,
+                    "error": str(e),
+                    "circuit_state": circuit_breaker.state.value,
+                    "failure_count": circuit_breaker.failure_count,
+                },
+            )
+            raise
 
     async def query_distribution(
         self,
@@ -586,14 +746,19 @@ class HandlerIntent:
         Returns:
             ModelIntentDistributionResult with distribution data or error status.
 
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is open.
+
         Note:
             This method never raises on business errors - it returns
-            an error status in the result model instead.
+            an error status in the result model instead. However,
+            CircuitBreakerOpenError is raised for immediate fail-fast
+            behavior when the service is unavailable.
         """
         query_correlation_id = uuid4()
 
         try:
-            adapter = self._ensure_initialized()
+            adapter, circuit_breaker = self._ensure_initialized()
         except RuntimeError as e:
             logger.error(
                 "query_distribution called on uninitialized handler",
@@ -609,6 +774,21 @@ class HandlerIntent:
                 error_message=str(e),
             )
 
+        # Check circuit breaker before attempting operation
+        if not circuit_breaker.should_allow_request():
+            logger.warning(
+                "Circuit breaker is open, failing fast",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "time_range_hours": time_range_hours,
+                    "circuit_state": circuit_breaker.state.value,
+                },
+            )
+            raise CircuitBreakerOpenError(
+                f"Circuit breaker is {circuit_breaker.state.value}"
+            )
+
         logger.debug(
             "Querying intent distribution for last %d hours",
             time_range_hours,
@@ -619,9 +799,28 @@ class HandlerIntent:
             },
         )
 
-        return await adapter.get_intent_distribution(
-            time_range_hours=time_range_hours,
-        )
+        try:
+            result = await adapter.get_intent_distribution(
+                time_range_hours=time_range_hours,
+            )
+            # Record success if operation completed without exception
+            if result.status == "success":
+                circuit_breaker.record_success()
+            return result
+        except Exception as e:
+            circuit_breaker.record_failure()
+            logger.error(
+                "query_distribution failed, recorded circuit breaker failure",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "time_range_hours": time_range_hours,
+                    "error": str(e),
+                    "circuit_state": circuit_breaker.state.value,
+                    "failure_count": circuit_breaker.failure_count,
+                },
+            )
+            raise
 
     # =========================================================================
     # Introspection
@@ -631,12 +830,13 @@ class HandlerIntent:
         """Check if the handler and adapter are healthy.
 
         Delegates to AdapterIntentGraph.health_check() to verify
-        connectivity and gather graph statistics.
+        connectivity and gather graph statistics. Also includes
+        circuit breaker status in the response.
 
         Returns:
-            ModelIntentGraphHealth with detailed health status.
-            This method never raises - errors are captured in the
-            result model.
+            ModelIntentGraphHealth with detailed health status including
+            circuit breaker state. This method never raises - errors are
+            captured in the result model.
         """
         timestamp = datetime.now(UTC)
 
@@ -649,19 +849,52 @@ class HandlerIntent:
                 last_check_timestamp=timestamp,
             )
 
+        # Include circuit breaker status in health check
+        circuit_breaker_info = ""
+        if self._circuit_breaker is not None:
+            cb = self._circuit_breaker
+            circuit_breaker_info = (
+                f"circuit_breaker={cb.state.value}, "
+                f"failures={cb.failure_count}/{cb.failure_threshold}"
+            )
+            # If circuit breaker is open, mark as degraded but not unhealthy
+            if cb.state == CircuitBreakerState.OPEN:
+                return ModelIntentGraphHealth(
+                    is_healthy=False,
+                    initialized=True,
+                    handler_healthy=True,  # Handler itself is healthy
+                    error_message=f"Circuit breaker is open ({circuit_breaker_info})",
+                    last_check_timestamp=timestamp,
+                )
+
         try:
-            return await self._adapter.health_check()
+            health = await self._adapter.health_check()
+            # Append circuit breaker info to any existing error message
+            if circuit_breaker_info and health.error_message:
+                health = ModelIntentGraphHealth(
+                    is_healthy=health.is_healthy,
+                    initialized=health.initialized,
+                    handler_healthy=health.handler_healthy,
+                    error_message=f"{health.error_message} ({circuit_breaker_info})",
+                    last_check_timestamp=health.last_check_timestamp,
+                    session_count=health.session_count,
+                    intent_count=health.intent_count,
+                )
+            return health
         except Exception as e:
             logger.warning(
                 "Health check failed: %s",
                 e,
                 extra={"handler": HANDLER_ID_INTENT},
             )
+            error_msg = f"Health check failed: {e}"
+            if circuit_breaker_info:
+                error_msg = f"{error_msg} ({circuit_breaker_info})"
             return ModelIntentGraphHealth(
                 is_healthy=False,
                 initialized=True,
                 handler_healthy=None,
-                error_message=f"Health check failed: {e}",
+                error_message=error_msg,
                 last_check_timestamp=timestamp,
             )
 

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -1,0 +1,690 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Direct protocol handler for intent storage and query operations.
+
+Wraps AdapterIntentGraph following the omnibase_infra container-driven pattern.
+Unlike event-driven handlers, this handler provides synchronous direct method
+calls for API layer integration.
+
+Architecture:
+    - Container-driven initialization (receives ModelONEXContainer)
+    - Handler owns adapter lifecycle (creates on init, closes on shutdown)
+    - Delegates all operations to AdapterIntentGraph
+    - Uses structured logging with correlation IDs
+
+Operations:
+    - store_intent(): Store an intent classification linked to a session
+    - query_session(): Retrieve intents for a specific session
+    - query_distribution(): Get intent category statistics
+
+Example::
+
+    from omnibase_core.container import ModelONEXContainer
+    from omnimemory.handlers import HandlerIntent
+
+    container = ModelONEXContainer()
+    handler = HandlerIntent(container)
+
+    await handler.initialize(
+        connection_uri="bolt://localhost:7687",
+    )
+
+    # Store an intent
+    from uuid import uuid4
+    from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
+
+    result = await handler.store_intent(
+        session_id="session_123",
+        intent_data=ModelIntentClassificationOutput(
+            intent_category="debugging",
+            confidence=0.92,
+            keywords=["error", "traceback"],
+        ),
+        correlation_id=uuid4(),
+    )
+
+    # Query session intents
+    query_result = await handler.query_session(
+        session_id="session_123",
+        min_confidence=0.5,
+    )
+
+    await handler.shutdown()
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1536.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.handlers.adapters.adapter_intent_graph import AdapterIntentGraph
+from omnimemory.handlers.adapters.models import (
+    ModelAdapterIntentGraphConfig,
+    ModelIntentClassificationOutput,
+    ModelIntentDistributionResult,
+    ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentStorageResult,
+)
+
+if TYPE_CHECKING:
+    from omnibase_core.container import ModelONEXContainer
+
+__all__ = [
+    "HandlerIntent",
+    "ModelHandlerIntentMetadata",
+]
+
+logger = logging.getLogger(__name__)
+
+# Handler identifier for logging and registration
+HANDLER_ID_INTENT: str = "intent-handler"
+
+
+class ModelHandlerIntentMetadata(
+    BaseModel
+):  # omnimemory-model-exempt: handler-local metadata
+    """Metadata describing the intent handler capabilities.
+
+    Returned by HandlerIntent.describe() to provide information about
+    handler type, capabilities, and configuration.
+
+    Attributes:
+        handler_type: The handler type identifier ("intent").
+        capabilities: List of supported operations.
+        adapter_type: Type of adapter being wrapped.
+        initialized: Whether the handler is currently initialized.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+    )
+
+    handler_type: str = Field(
+        ...,
+        description="Handler type identifier",
+    )
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="List of supported operations",
+    )
+    adapter_type: str = Field(
+        default="AdapterIntentGraph",
+        description="Type of adapter being wrapped",
+    )
+    initialized: bool = Field(
+        default=False,
+        description="Whether the handler is currently initialized",
+    )
+
+
+class HandlerIntent:
+    """Direct protocol handler for intent storage and query operations.
+
+    Wraps AdapterIntentGraph following the omnibase_infra container-driven pattern.
+    Unlike HandlerIntentQuery (event-driven), this handler provides synchronous
+    direct method calls for API layer integration.
+
+    The handler owns the adapter lifecycle:
+    - Creates adapter during initialize()
+    - Closes adapter during shutdown()
+
+    Protocol Compliance:
+        Implements standard handler interface:
+        - handler_type property returning "intent"
+        - is_initialized property for state checking
+        - initialize(), shutdown() lifecycle methods
+        - health_check(), describe() introspection methods
+
+    Thread Safety:
+        Uses asyncio.Lock for initialization to prevent race conditions
+        when multiple coroutines call initialize() concurrently.
+
+    Error Handling:
+        All business operation methods return error status in response
+        models rather than raising exceptions. This allows API layers
+        to handle errors gracefully without try/except blocks.
+
+    Attributes:
+        handler_type: Returns "intent" as handler type identifier.
+        is_initialized: Returns True if handler is ready for operations.
+
+    Example::
+
+        from omnibase_core.container import ModelONEXContainer
+        from omnimemory.handlers import HandlerIntent
+
+        container = ModelONEXContainer()
+        handler = HandlerIntent(container)
+
+        await handler.initialize(connection_uri="bolt://localhost:7687")
+
+        result = await handler.store_intent(
+            session_id="sess_123",
+            intent_data=ModelIntentClassificationOutput(
+                intent_category="code_generation",
+                confidence=0.95,
+                keywords=["python", "function"],
+            ),
+            correlation_id=uuid4(),
+        )
+
+        await handler.shutdown()
+    """
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        """Initialize HandlerIntent with ONEX container for dependency injection.
+
+        Args:
+            container: ONEX container providing dependency injection for
+                services, configuration, and runtime context.
+
+        Note:
+            The container is stored for interface compliance with the standard
+            ONEX handler pattern and to enable future DI-based service resolution.
+            The adapter is NOT created here; it is created during initialize().
+        """
+        self._container = container
+        self._adapter: AdapterIntentGraph | None = None
+        self._adapter_config: ModelAdapterIntentGraphConfig | None = None
+        self._initialized: bool = False
+        self._init_lock = asyncio.Lock()
+        self._connection_uri: str = ""
+
+    @property
+    def handler_type(self) -> str:
+        """Return the handler type identifier.
+
+        Returns:
+            String "intent" identifying this handler type.
+        """
+        return "intent"
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the handler has been initialized.
+
+        Returns:
+            True if handler is initialized and ready for operations.
+        """
+        return self._initialized
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging."""
+        return f"HandlerIntent(initialized={self._initialized})"
+
+    async def initialize(
+        self,
+        connection_uri: str,
+        auth: tuple[str, str] | None = None,
+        *,
+        options: Mapping[str, object] | None = None,
+    ) -> None:
+        """Initialize handler and create adapter.
+
+        Establishes connection to the graph database by creating and
+        initializing the underlying AdapterIntentGraph. This method
+        is idempotent - calling it multiple times after successful
+        initialization is a no-op.
+
+        Args:
+            connection_uri: Graph database URI (e.g., "bolt://localhost:7687").
+            auth: Optional (username, password) tuple for authentication.
+            options: Additional configuration options:
+                - timeout_seconds: Operation timeout (default: 30.0)
+                - max_intents_per_session: Max intents per query (default: 100)
+                - default_confidence_threshold: Min confidence filter (default: 0.0)
+                - auto_create_indexes: Create indexes on init (default: True)
+
+        Raises:
+            RuntimeError: If initialization fails or times out.
+            ValueError: If connection_uri is malformed.
+        """
+        init_correlation_id = uuid4()
+
+        async with self._init_lock:
+            if self._initialized:
+                logger.debug(
+                    "Handler already initialized, skipping",
+                    extra={
+                        "handler": HANDLER_ID_INTENT,
+                        "correlation_id": str(init_correlation_id),
+                    },
+                )
+                return
+
+            logger.info(
+                "Initializing %s",
+                self.__class__.__name__,
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(init_correlation_id),
+                },
+            )
+
+            try:
+                # Build adapter config from options
+                opts = dict(options) if options else {}
+
+                timeout_raw = opts.get("timeout_seconds", 30.0)
+                timeout_seconds = (
+                    float(timeout_raw)
+                    if isinstance(timeout_raw, int | float | str)
+                    else 30.0
+                )
+
+                max_intents_raw = opts.get("max_intents_per_session", 100)
+                max_intents_per_session = (
+                    int(max_intents_raw)
+                    if isinstance(max_intents_raw, int | float | str)
+                    else 100
+                )
+
+                threshold_raw = opts.get("default_confidence_threshold", 0.0)
+                default_confidence_threshold = (
+                    float(threshold_raw)
+                    if isinstance(threshold_raw, int | float | str)
+                    else 0.0
+                )
+
+                auto_indexes_raw = opts.get("auto_create_indexes", True)
+                auto_create_indexes = bool(auto_indexes_raw)
+
+                self._adapter_config = ModelAdapterIntentGraphConfig(
+                    timeout_seconds=timeout_seconds,
+                    max_intents_per_session=max_intents_per_session,
+                    default_confidence_threshold=default_confidence_threshold,
+                    auto_create_indexes=auto_create_indexes,
+                )
+
+                # Create adapter with config and container
+                self._adapter = AdapterIntentGraph(
+                    config=self._adapter_config,
+                    container=self._container,
+                )
+
+                # Initialize adapter
+                await self._adapter.initialize(
+                    connection_uri=connection_uri,
+                    auth=auth,
+                    options=options,
+                )
+
+                self._connection_uri = connection_uri
+                self._initialized = True
+
+                logger.info(
+                    "%s initialized successfully",
+                    self.__class__.__name__,
+                    extra={
+                        "handler": HANDLER_ID_INTENT,
+                        "correlation_id": str(init_correlation_id),
+                    },
+                )
+
+            except Exception as e:
+                logger.error(
+                    "Failed to initialize %s: %s",
+                    self.__class__.__name__,
+                    e,
+                    extra={
+                        "handler": HANDLER_ID_INTENT,
+                        "correlation_id": str(init_correlation_id),
+                    },
+                )
+                # Cleanup partial initialization
+                if self._adapter is not None:
+                    try:
+                        await self._adapter.shutdown()
+                    except Exception as cleanup_error:
+                        logger.warning(
+                            "Error during adapter cleanup: %s",
+                            cleanup_error,
+                            extra={
+                                "handler": HANDLER_ID_INTENT,
+                                "correlation_id": str(init_correlation_id),
+                            },
+                        )
+                    self._adapter = None
+                raise RuntimeError(f"Initialization failed: {e}") from e
+
+    async def shutdown(self, timeout_seconds: float = 30.0) -> None:
+        """Shutdown handler and close adapter.
+
+        Gracefully shuts down the handler by closing the underlying
+        adapter and releasing resources. Safe to call multiple times.
+
+        Args:
+            timeout_seconds: Maximum time to wait for shutdown. Defaults to 30.0.
+        """
+        shutdown_correlation_id = uuid4()
+
+        async with self._init_lock:
+            if not self._initialized:
+                logger.debug(
+                    "Handler not initialized, skipping shutdown",
+                    extra={
+                        "handler": HANDLER_ID_INTENT,
+                        "correlation_id": str(shutdown_correlation_id),
+                    },
+                )
+                return
+
+            logger.info(
+                "Shutting down %s",
+                self.__class__.__name__,
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(shutdown_correlation_id),
+                    "timeout_seconds": timeout_seconds,
+                },
+            )
+
+            if self._adapter is not None:
+                try:
+                    await asyncio.wait_for(
+                        self._adapter.shutdown(),
+                        timeout=timeout_seconds,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "Adapter shutdown timed out after %ss",
+                        timeout_seconds,
+                        extra={
+                            "handler": HANDLER_ID_INTENT,
+                            "correlation_id": str(shutdown_correlation_id),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Error during adapter shutdown: %s",
+                        e,
+                        extra={
+                            "handler": HANDLER_ID_INTENT,
+                            "correlation_id": str(shutdown_correlation_id),
+                        },
+                    )
+                self._adapter = None
+
+            self._initialized = False
+            self._adapter_config = None
+
+            logger.info(
+                "%s shutdown complete",
+                self.__class__.__name__,
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(shutdown_correlation_id),
+                },
+            )
+
+    def _ensure_initialized(self) -> AdapterIntentGraph:
+        """Ensure handler is initialized and return adapter.
+
+        Returns:
+            The initialized AdapterIntentGraph.
+
+        Raises:
+            RuntimeError: If handler is not initialized.
+        """
+        if not self._initialized or self._adapter is None:
+            raise RuntimeError(
+                "HandlerIntent not initialized. Call initialize() first."
+            )
+        return self._adapter
+
+    # =========================================================================
+    # Core Operations
+    # =========================================================================
+
+    async def store_intent(
+        self,
+        session_id: str,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+        user_context: str = "",
+    ) -> ModelIntentStorageResult:
+        """Store an intent classification linked to a session.
+
+        Delegates to AdapterIntentGraph.store_intent() using MERGE semantics
+        to create or update the session and intent nodes.
+
+        Args:
+            session_id: Unique identifier for the session.
+            intent_data: The intent classification output to store.
+            correlation_id: Correlation ID for request tracing.
+            user_context: Optional user context string for the session.
+
+        Returns:
+            ModelIntentStorageResult indicating success or failure.
+            On success, includes the intent_id and whether a new
+            intent was created vs merged.
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        try:
+            adapter = self._ensure_initialized()
+        except RuntimeError as e:
+            logger.error(
+                "store_intent called on uninitialized handler",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(correlation_id),
+                    "session_id": session_id,
+                },
+            )
+            return ModelIntentStorageResult(
+                status="error",
+                session_id=session_id,
+                error_message=str(e),
+            )
+
+        logger.debug(
+            "Storing intent for session %s",
+            session_id,
+            extra={
+                "handler": HANDLER_ID_INTENT,
+                "correlation_id": str(correlation_id),
+                "session_id": session_id,
+                "intent_category": intent_data.intent_category,
+            },
+        )
+
+        return await adapter.store_intent(
+            session_id=session_id,
+            intent_data=intent_data,
+            correlation_id=correlation_id,
+            user_context=user_context,
+        )
+
+    async def query_session(
+        self,
+        session_id: str,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        """Retrieve intents for a specific session.
+
+        Delegates to AdapterIntentGraph.get_session_intents() with optional
+        filtering by confidence threshold and result limit.
+
+        Args:
+            session_id: The session identifier to query.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+                Defaults to config.default_confidence_threshold.
+            limit: Maximum number of results to return.
+                Defaults to config.max_intents_per_session.
+
+        Returns:
+            ModelIntentQueryResult with the list of intents or error status.
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        query_correlation_id = uuid4()
+
+        try:
+            adapter = self._ensure_initialized()
+        except RuntimeError as e:
+            logger.error(
+                "query_session called on uninitialized handler",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "session_id": session_id,
+                },
+            )
+            return ModelIntentQueryResult(
+                status="error",
+                error_message=str(e),
+            )
+
+        logger.debug(
+            "Querying intents for session %s",
+            session_id,
+            extra={
+                "handler": HANDLER_ID_INTENT,
+                "correlation_id": str(query_correlation_id),
+                "session_id": session_id,
+                "min_confidence": min_confidence,
+                "limit": limit,
+            },
+        )
+
+        return await adapter.get_session_intents(
+            session_id=session_id,
+            min_confidence=min_confidence,
+            limit=limit,
+        )
+
+    async def query_distribution(
+        self,
+        time_range_hours: int = 24,
+    ) -> ModelIntentDistributionResult:
+        """Get intent category distribution for analytics.
+
+        Delegates to AdapterIntentGraph.get_intent_distribution() to return
+        the count of intents per category within the specified time range.
+
+        Args:
+            time_range_hours: Number of hours to look back from now.
+                Defaults to 24 hours.
+
+        Returns:
+            ModelIntentDistributionResult with distribution data or error status.
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        query_correlation_id = uuid4()
+
+        try:
+            adapter = self._ensure_initialized()
+        except RuntimeError as e:
+            logger.error(
+                "query_distribution called on uninitialized handler",
+                extra={
+                    "handler": HANDLER_ID_INTENT,
+                    "correlation_id": str(query_correlation_id),
+                    "time_range_hours": time_range_hours,
+                },
+            )
+            return ModelIntentDistributionResult(
+                status="error",
+                time_range_hours=time_range_hours,
+                error_message=str(e),
+            )
+
+        logger.debug(
+            "Querying intent distribution for last %d hours",
+            time_range_hours,
+            extra={
+                "handler": HANDLER_ID_INTENT,
+                "correlation_id": str(query_correlation_id),
+                "time_range_hours": time_range_hours,
+            },
+        )
+
+        return await adapter.get_intent_distribution(
+            time_range_hours=time_range_hours,
+        )
+
+    # =========================================================================
+    # Introspection
+    # =========================================================================
+
+    async def health_check(self) -> ModelIntentGraphHealth:
+        """Check if the handler and adapter are healthy.
+
+        Delegates to AdapterIntentGraph.health_check() to verify
+        connectivity and gather graph statistics.
+
+        Returns:
+            ModelIntentGraphHealth with detailed health status.
+            This method never raises - errors are captured in the
+            result model.
+        """
+        timestamp = datetime.now(UTC)
+
+        if not self._initialized or self._adapter is None:
+            return ModelIntentGraphHealth(
+                is_healthy=False,
+                initialized=False,
+                handler_healthy=None,
+                error_message="Handler not initialized",
+                last_check_timestamp=timestamp,
+            )
+
+        try:
+            return await self._adapter.health_check()
+        except Exception as e:
+            logger.warning(
+                "Health check failed: %s",
+                e,
+                extra={"handler": HANDLER_ID_INTENT},
+            )
+            return ModelIntentGraphHealth(
+                is_healthy=False,
+                initialized=True,
+                handler_healthy=None,
+                error_message=f"Health check failed: {e}",
+                last_check_timestamp=timestamp,
+            )
+
+    async def describe(self) -> ModelHandlerIntentMetadata:
+        """Return handler metadata and capabilities.
+
+        Provides information about the handler type, supported operations,
+        and current initialization state.
+
+        Returns:
+            ModelHandlerIntentMetadata with handler information.
+        """
+        capabilities = [
+            "store_intent",
+            "query_session",
+            "query_distribution",
+            "health_check",
+            "describe",
+        ]
+
+        return ModelHandlerIntentMetadata(
+            handler_type=self.handler_type,
+            capabilities=capabilities,
+            adapter_type="AdapterIntentGraph",
+            initialized=self._initialized,
+        )

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -609,11 +609,9 @@ class HandlerIntent:
                 user_context=user_context,
             )
             # Record success if operation completed without exception
+            # Business errors (e.g., validation) are not circuit breaker failures
             if result.status == "success":
                 circuit_breaker.record_success()
-            else:
-                # Business errors (e.g., validation) are not circuit breaker failures
-                pass
             return result
         except Exception as e:
             circuit_breaker.record_failure()

--- a/src/omnimemory/handlers/handler_semantic_compute.py
+++ b/src/omnimemory/handlers/handler_semantic_compute.py
@@ -62,6 +62,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ..enums import EnumEntityExtractionMode, EnumSemanticEntityType
 from ..models.config import ModelSemanticComputePolicyConfig
+from ..models.foundation.model_semver import ModelSemVer
 from ..models.intelligence import (
     ModelSemanticAnalysisResult,
     ModelSemanticEntity,
@@ -761,7 +762,7 @@ class HandlerSemanticCompute:
             relevance_score=None,  # Relevance analysis not implemented
             confidence_score=0.9 if embedding else 0.7,
             model_name=self._embedding_provider.model_name,
-            model_version=self._config.handler_version,
+            model_version=ModelSemVer.parse(self._config.handler_version),
             processing_time_ms=processing_time_ms,
         )
 

--- a/src/omnimemory/handlers/handler_semantic_compute.py
+++ b/src/omnimemory/handlers/handler_semantic_compute.py
@@ -97,7 +97,9 @@ _T = TypeVar("_T")
 # =============================================================================
 
 
-class ModelHandlerSemanticComputeConfig(BaseModel):
+class ModelHandlerSemanticComputeConfig(  # omnimemory-model-exempt: handler-local config
+    BaseModel
+):
     """Configuration for the semantic compute handler.
 
     This model configures the handler's behavior and wraps the policy config.

--- a/src/omnimemory/handlers/models/__init__.py
+++ b/src/omnimemory/handlers/models/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Handler models for omnimemory.
+
+This module exports configuration and data models used by handlers
+in the omnimemory package.
+
+Exports:
+    ModelHandlerIntentConfig: Configuration for HandlerIntent.
+"""
+
+from omnimemory.handlers.models.model_handler_intent_config import (
+    ModelHandlerIntentConfig,
+)
+
+__all__ = [
+    "ModelHandlerIntentConfig",
+]

--- a/src/omnimemory/handlers/models/model_handler_intent_config.py
+++ b/src/omnimemory/handlers/models/model_handler_intent_config.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Configuration model for HandlerIntent.
+
+This module provides the configuration model for HandlerIntent, which manages
+intent storage and query operations against a graph database. The configuration
+controls connection settings, circuit breaker behavior, and query limits.
+
+Example:
+    >>> config = ModelHandlerIntentConfig(
+    ...     connection_uri="bolt://localhost:7687",
+    ...     timeout_seconds=60.0,
+    ...     circuit_breaker_threshold=3,
+    ... )
+    >>> config.timeout_seconds
+    60.0
+
+    >>> # Load from environment variables
+    >>> config = ModelHandlerIntentConfig.from_env()
+"""
+
+from __future__ import annotations
+
+import os
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelHandlerIntentConfig"]
+
+
+class ModelHandlerIntentConfig(BaseModel):  # omnimemory-model-exempt: handler config
+    """Configuration for the HandlerIntent handler.
+
+    Controls connection settings, authentication, circuit breaker behavior,
+    and query limits for intent storage and retrieval operations.
+
+    Attributes:
+        connection_uri: Graph database connection URI (e.g., "bolt://localhost:7687").
+        auth_username: Optional username for database authentication.
+        auth_password: Optional password for database authentication.
+        timeout_seconds: Connection and operation timeout in seconds.
+            Bounded to prevent both overly aggressive timeouts and
+            indefinite hangs. Defaults to 30.0.
+        circuit_breaker_threshold: Number of consecutive failures before
+            the circuit breaker opens. Once open, operations fail fast
+            without attempting the actual operation. Defaults to 5.
+        circuit_breaker_reset_timeout: Seconds to wait before attempting
+            to close the circuit breaker after it opens. Defaults to 60.0.
+        max_intents_per_session: Maximum number of intents to return per
+            session in queries. Prevents unbounded result sets. Defaults to 100.
+        default_confidence_threshold: Minimum confidence score for intent
+            queries. Intents below this threshold are filtered out.
+            Defaults to 0.0 (no filtering).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+        json_schema_extra={
+            "examples": [
+                {
+                    "connection_uri": "bolt://localhost:7687",
+                    "auth_username": "neo4j",
+                    "auth_password": "<secret>",
+                    "timeout_seconds": 30.0,
+                    "circuit_breaker_threshold": 5,
+                    "circuit_breaker_reset_timeout": 60.0,
+                    "max_intents_per_session": 100,
+                    "default_confidence_threshold": 0.5,
+                },
+                {
+                    "connection_uri": "bolt://memgraph:7687",
+                    "timeout_seconds": 60.0,
+                    "circuit_breaker_threshold": 3,
+                    "max_intents_per_session": 50,
+                },
+            ]
+        },
+    )
+
+    connection_uri: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Graph database connection URI. "
+            "Example: 'bolt://localhost:7687' or 'bolt://memgraph:7687'."
+        ),
+    )
+    auth_username: str | None = Field(
+        default=None,
+        description=(
+            "Optional username for database authentication. "
+            "If provided, auth_password should also be set."
+        ),
+    )
+    auth_password: str | None = Field(
+        default=None,
+        description=(
+            "Optional password for database authentication. "
+            "If provided, auth_username should also be set."
+        ),
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        ge=0.1,
+        le=300.0,
+        description=(
+            "Connection and operation timeout in seconds. " "Range: 0.1-300.0 seconds."
+        ),
+    )
+    circuit_breaker_threshold: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Number of consecutive failures before the circuit breaker opens. "
+            "Once open, operations fail fast without attempting the actual operation."
+        ),
+    )
+    circuit_breaker_reset_timeout: float = Field(
+        default=60.0,
+        ge=1.0,
+        le=3600.0,
+        description=(
+            "Seconds to wait before attempting to close the circuit breaker "
+            "after it opens. Range: 1.0-3600.0 seconds."
+        ),
+    )
+    max_intents_per_session: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description=(
+            "Maximum number of intents to return per session in queries. "
+            "Prevents unbounded result sets. Range: 1-1000."
+        ),
+    )
+    default_confidence_threshold: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum confidence score for intent queries. "
+            "Intents below this threshold are filtered out. "
+            "Range: 0.0-1.0 where 0.0 means no filtering."
+        ),
+    )
+
+    @classmethod
+    def from_env(
+        cls,
+        prefix: str = "HANDLER_INTENT_",
+    ) -> ModelHandlerIntentConfig:
+        """Create configuration from environment variables.
+
+        Reads configuration values from environment variables with an optional
+        prefix. This factory method provides a convenient way to configure
+        the handler without hardcoding values.
+
+        Environment Variables (with default prefix HANDLER_INTENT_):
+            - HANDLER_INTENT_CONNECTION_URI: Required. Database connection URI.
+            - HANDLER_INTENT_AUTH_USERNAME: Optional. Authentication username.
+            - HANDLER_INTENT_AUTH_PASSWORD: Optional. Authentication password.
+            - HANDLER_INTENT_TIMEOUT_SECONDS: Optional. Timeout in seconds.
+            - HANDLER_INTENT_CIRCUIT_BREAKER_THRESHOLD: Optional. Failure threshold.
+            - HANDLER_INTENT_CIRCUIT_BREAKER_RESET_TIMEOUT: Optional. Reset timeout.
+            - HANDLER_INTENT_MAX_INTENTS_PER_SESSION: Optional. Max intents per query.
+            - HANDLER_INTENT_DEFAULT_CONFIDENCE_THRESHOLD: Optional. Min confidence.
+
+        Args:
+            prefix: Environment variable prefix. Defaults to "HANDLER_INTENT_".
+
+        Returns:
+            ModelHandlerIntentConfig instance populated from environment.
+
+        Raises:
+            ValueError: If required environment variables are missing or invalid.
+
+        Example:
+            >>> import os
+            >>> os.environ["HANDLER_INTENT_CONNECTION_URI"] = "bolt://localhost:7687"
+            >>> os.environ["HANDLER_INTENT_TIMEOUT_SECONDS"] = "45.0"
+            >>> config = ModelHandlerIntentConfig.from_env()
+            >>> config.connection_uri
+            'bolt://localhost:7687'
+            >>> config.timeout_seconds
+            45.0
+        """
+        connection_uri = os.environ.get(f"{prefix}CONNECTION_URI")
+        if not connection_uri:
+            msg = f"Required environment variable {prefix}CONNECTION_URI is not set"
+            raise ValueError(msg)
+
+        auth_username = os.environ.get(f"{prefix}AUTH_USERNAME")
+        auth_password = os.environ.get(f"{prefix}AUTH_PASSWORD")
+
+        timeout_str = os.environ.get(f"{prefix}TIMEOUT_SECONDS")
+        timeout_seconds = float(timeout_str) if timeout_str else 30.0
+
+        cb_threshold_str = os.environ.get(f"{prefix}CIRCUIT_BREAKER_THRESHOLD")
+        circuit_breaker_threshold = int(cb_threshold_str) if cb_threshold_str else 5
+
+        cb_reset_str = os.environ.get(f"{prefix}CIRCUIT_BREAKER_RESET_TIMEOUT")
+        circuit_breaker_reset_timeout = float(cb_reset_str) if cb_reset_str else 60.0
+
+        max_intents_str = os.environ.get(f"{prefix}MAX_INTENTS_PER_SESSION")
+        max_intents_per_session = int(max_intents_str) if max_intents_str else 100
+
+        threshold_str = os.environ.get(f"{prefix}DEFAULT_CONFIDENCE_THRESHOLD")
+        default_confidence_threshold = float(threshold_str) if threshold_str else 0.0
+
+        return cls(
+            connection_uri=connection_uri,
+            auth_username=auth_username,
+            auth_password=auth_password,
+            timeout_seconds=timeout_seconds,
+            circuit_breaker_threshold=circuit_breaker_threshold,
+            circuit_breaker_reset_timeout=circuit_breaker_reset_timeout,
+            max_intents_per_session=max_intents_per_session,
+            default_confidence_threshold=default_confidence_threshold,
+        )
+
+    def get_auth_tuple(self) -> tuple[str, str] | None:
+        """Get authentication credentials as a tuple.
+
+        Returns:
+            Tuple of (username, password) if both are set, None otherwise.
+
+        Example:
+            >>> config = ModelHandlerIntentConfig(
+            ...     connection_uri="bolt://localhost:7687",
+            ...     auth_username="neo4j",
+            ...     auth_password="<secret>",  # noqa: S106
+            ... )
+            >>> config.get_auth_tuple()
+            ('neo4j', '<secret>')
+        """
+        if self.auth_username is not None and self.auth_password is not None:
+            return (self.auth_username, self.auth_password)
+        return None

--- a/src/omnimemory/models/intelligence/model_semantic_analysis_result.py
+++ b/src/omnimemory/models/intelligence/model_semantic_analysis_result.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from omnimemory.models.foundation.model_semver import ModelSemVer
+from omnimemory.models.foundation.model_semver import ModelSemVer  # noqa: TC001
 
 from .model_semantic_entity_list import ModelSemanticEntityList  # noqa: TC001
 

--- a/src/omnimemory/nodes/semantic_analyzer_compute/contract.yaml
+++ b/src/omnimemory/nodes/semantic_analyzer_compute/contract.yaml
@@ -8,7 +8,8 @@
 
 # === REQUIRED ROOT FIELDS ===
 name: "semantic_analyzer_compute"
-version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
 description: >
   Compute node for semantic analysis including embedding generation, entity extraction, and topic modeling.
   Delegates I/O to provider protocols (ProtocolEmbeddingProvider, ProtocolLLMProvider) to maintain compute

--- a/src/omnimemory/protocols/__init__.py
+++ b/src/omnimemory/protocols/__init__.py
@@ -59,6 +59,8 @@ from .error_models import (  # Error handling; Error codes
 )
 from .protocol_embedding import ProtocolEmbeddingClient, ProtocolRateLimiter
 from .protocol_embedding_provider import ProtocolEmbeddingProvider, ProtocolLLMProvider
+from .protocol_handler_intent import ProtocolHandlerIntent
+from .protocol_intent_graph_adapter import ProtocolIntentGraphAdapter
 from .protocol_secrets_provider import ProtocolSecretsProvider
 
 __all__ = [
@@ -120,4 +122,8 @@ __all__ = [
     # Provider protocols (for handler dependencies)
     "ProtocolEmbeddingProvider",
     "ProtocolLLMProvider",
+    # Handler protocols (for contract-driven handler interfaces)
+    "ProtocolHandlerIntent",
+    # Adapter protocols (for contract-driven dependency injection)
+    "ProtocolIntentGraphAdapter",
 ]

--- a/src/omnimemory/protocols/protocol_handler_intent.py
+++ b/src/omnimemory/protocols/protocol_handler_intent.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Protocol definition for intent handler operations.
+
+This module defines the ProtocolHandlerIntent interface that establishes the
+contract for intent storage and query operations. Following the omnibase_infra
+container-driven pattern, this protocol enables contract-driven development
+and allows for multiple implementations.
+
+The protocol defines:
+    - Lifecycle management (initialize, shutdown)
+    - Intent storage operations (store_intent)
+    - Intent query operations (query_session, query_distribution)
+    - Introspection capabilities (health_check, describe)
+
+Example::
+
+    from omnimemory.protocols import ProtocolHandlerIntent
+
+    async def process_intents(handler: ProtocolHandlerIntent) -> None:
+        '''Process intents using any conforming handler implementation.'''
+        # Verify handler is ready
+        if not handler.is_initialized:
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+            )
+
+        # Store an intent
+        from uuid import uuid4
+        from omnimemory.handlers.adapters.models import ModelIntentClassificationOutput
+
+        result = await handler.store_intent(
+            session_id="session_123",
+            intent_data=ModelIntentClassificationOutput(
+                intent_category="debugging",
+                confidence=0.92,
+                keywords=["error", "traceback"],
+            ),
+            correlation_id=uuid4(),
+        )
+
+        # Query session intents
+        query_result = await handler.query_session(
+            session_id="session_123",
+            min_confidence=0.5,
+        )
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1536.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from omnimemory.handlers.adapters.models import (
+        ModelIntentClassificationOutput,
+        ModelIntentDistributionResult,
+        ModelIntentGraphHealth,
+        ModelIntentQueryResult,
+        ModelIntentStorageResult,
+    )
+    from omnimemory.handlers.handler_intent import ModelHandlerIntentMetadata
+
+__all__ = [
+    "ProtocolHandlerIntent",
+]
+
+
+@runtime_checkable
+class ProtocolHandlerIntent(Protocol):
+    """Protocol defining the contract for intent handler operations.
+
+    This protocol establishes the interface for handlers that manage intent
+    classification storage and retrieval in a graph database. It follows
+    the omnibase_infra container-driven pattern for ONEX compliance.
+
+    Implementations must provide:
+        - handler_type: Property returning a string identifier for the handler type.
+        - is_initialized: Property indicating whether the handler is ready for operations.
+        - initialize(): Async method to establish connections and prepare the handler.
+        - shutdown(): Async method to gracefully close connections and release resources.
+        - store_intent(): Async method to store an intent classification for a session.
+        - query_session(): Async method to retrieve intents for a specific session.
+        - query_distribution(): Async method to get intent category statistics.
+        - health_check(): Async method to verify handler and adapter health.
+        - describe(): Async method to return handler metadata and capabilities.
+
+    Thread Safety:
+        Implementations should use appropriate synchronization (e.g., asyncio.Lock)
+        for initialization to prevent race conditions when multiple coroutines
+        call initialize() concurrently.
+
+    Error Handling:
+        Business operation methods (store_intent, query_session, query_distribution)
+        should return error status in response models rather than raising exceptions.
+        This allows API layers to handle errors gracefully without try/except blocks.
+
+    Example::
+
+        class CustomIntentHandler:
+            '''Custom implementation of ProtocolHandlerIntent.'''
+
+            @property
+            def handler_type(self) -> str:
+                return "custom-intent"
+
+            @property
+            def is_initialized(self) -> bool:
+                return self._initialized
+
+            async def initialize(
+                self,
+                connection_uri: str,
+                auth: tuple[str, str] | None = None,
+                *,
+                options: Mapping[str, object] | None = None,
+            ) -> None:
+                # Implementation details...
+                pass
+
+            # ... other required methods
+
+        # Verify conformance at runtime
+        handler = CustomIntentHandler()
+        assert isinstance(handler, ProtocolHandlerIntent)
+    """
+
+    @property
+    def handler_type(self) -> str:
+        """Return the handler type identifier.
+
+        Returns:
+            String identifying this handler type (e.g., "intent").
+            Used for logging, registration, and handler discovery.
+        """
+        ...
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the handler has been initialized.
+
+        Returns:
+            True if handler is initialized and ready for operations,
+            False otherwise.
+        """
+        ...
+
+    async def initialize(
+        self,
+        connection_uri: str,
+        auth: tuple[str, str] | None = None,
+        *,
+        options: Mapping[str, object] | None = None,
+    ) -> None:
+        """Initialize handler and establish connections.
+
+        Establishes connection to the graph database by creating and
+        initializing the underlying adapter. This method should be
+        idempotent - calling it multiple times after successful
+        initialization should be a no-op.
+
+        Args:
+            connection_uri: Graph database URI (e.g., "bolt://localhost:7687").
+            auth: Optional (username, password) tuple for authentication.
+            options: Additional configuration options. Common options include:
+                - timeout_seconds: Operation timeout (default: 30.0)
+                - max_intents_per_session: Max intents per query (default: 100)
+                - default_confidence_threshold: Min confidence filter (default: 0.0)
+                - auto_create_indexes: Create indexes on init (default: True)
+
+        Raises:
+            RuntimeError: If initialization fails or times out.
+            ValueError: If connection_uri is malformed.
+        """
+        ...
+
+    async def shutdown(self, timeout_seconds: float = 30.0) -> None:
+        """Shutdown handler and close connections.
+
+        Gracefully shuts down the handler by closing the underlying
+        adapter and releasing resources. Safe to call multiple times.
+
+        Args:
+            timeout_seconds: Maximum time to wait for shutdown. Defaults to 30.0.
+        """
+        ...
+
+    async def store_intent(
+        self,
+        session_id: str,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+        user_context: str = "",
+    ) -> ModelIntentStorageResult:
+        """Store an intent classification linked to a session.
+
+        Creates or updates an intent node in the graph database and links
+        it to the specified session using MERGE semantics.
+
+        Args:
+            session_id: Unique identifier for the session.
+            intent_data: The intent classification output to store.
+            correlation_id: Correlation ID for request tracing.
+            user_context: Optional user context string for the session.
+
+        Returns:
+            ModelIntentStorageResult indicating success or failure.
+            On success, includes the intent_id and whether a new
+            intent was created vs merged.
+
+        Note:
+            This method should not raise on business errors - it should
+            return an error status in the result model instead.
+        """
+        ...
+
+    async def query_session(
+        self,
+        session_id: str,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        """Retrieve intents for a specific session.
+
+        Queries the graph database for intents associated with the
+        specified session, with optional filtering by confidence
+        threshold and result limit.
+
+        Args:
+            session_id: The session identifier to query.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+                If None, uses the handler's default threshold.
+            limit: Maximum number of results to return.
+                If None, uses the handler's default limit.
+
+        Returns:
+            ModelIntentQueryResult with the list of intents or error status.
+
+        Note:
+            This method should not raise on business errors - it should
+            return an error status in the result model instead.
+        """
+        ...
+
+    async def query_distribution(
+        self,
+        time_range_hours: int = 24,
+    ) -> ModelIntentDistributionResult:
+        """Get intent category distribution for analytics.
+
+        Returns the count of intents per category within the specified
+        time range, useful for analytics and reporting.
+
+        Args:
+            time_range_hours: Number of hours to look back from now.
+                Defaults to 24 hours.
+
+        Returns:
+            ModelIntentDistributionResult with distribution data or error status.
+
+        Note:
+            This method should not raise on business errors - it should
+            return an error status in the result model instead.
+        """
+        ...
+
+    async def health_check(self) -> ModelIntentGraphHealth:
+        """Check if the handler and adapter are healthy.
+
+        Verifies connectivity to the graph database and gathers
+        statistics about stored data.
+
+        Returns:
+            ModelIntentGraphHealth with detailed health status.
+            This method should not raise - errors should be captured
+            in the result model.
+        """
+        ...
+
+    async def describe(self) -> ModelHandlerIntentMetadata:
+        """Return handler metadata and capabilities.
+
+        Provides information about the handler type, supported operations,
+        and current initialization state.
+
+        Returns:
+            ModelHandlerIntentMetadata with handler information including:
+            - handler_type: The handler type identifier
+            - capabilities: List of supported operations
+            - adapter_type: Type of adapter being wrapped
+            - initialized: Whether the handler is currently initialized
+        """
+        ...

--- a/src/omnimemory/protocols/protocol_intent_graph_adapter.py
+++ b/src/omnimemory/protocols/protocol_intent_graph_adapter.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Protocol definition for intent graph adapter implementations.
+
+This module defines the contract boundary protocol for intent graph storage
+operations. All intent graph adapter implementations must conform to this
+protocol for proper contract-driven design and testability.
+
+IMPORTANT: This protocol enables HandlerIntent to depend on an abstraction
+rather than a concrete AdapterIntentGraph implementation. This supports:
+- Mock implementations for unit testing
+- Alternative graph backends (Neo4j, Memgraph, etc.)
+- Dependency injection via ONEX container
+
+Example::
+
+    from omnimemory.protocols import ProtocolIntentGraphAdapter
+
+    class MockIntentGraphAdapter:
+        '''Test double conforming to ProtocolIntentGraphAdapter.'''
+
+        async def initialize(
+            self,
+            connection_uri: str,
+            auth: tuple[str, str] | None = None,
+            *,
+            options: Mapping[str, object] | None = None,
+        ) -> None:
+            pass  # No-op for tests
+
+        async def shutdown(self) -> None:
+            pass
+
+        async def store_intent(
+            self,
+            session_id: str,
+            intent_data: ModelIntentClassificationOutput,
+            correlation_id: UUID,
+            *,
+            user_context: str = "",
+        ) -> ModelIntentStorageResult:
+            return ModelIntentStorageResult(
+                status="success",
+                session_id=session_id,
+                intent_id=uuid4(),
+                created=True,
+            )
+
+        # ... other method implementations
+
+.. versionadded:: 0.2.0
+    Initial implementation for OMN-1536.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from omnimemory.handlers.adapters.models import (
+        ModelIntentClassificationOutput,
+        ModelIntentDistributionResult,
+        ModelIntentGraphHealth,
+        ModelIntentQueryResult,
+        ModelIntentStorageResult,
+    )
+
+__all__ = [
+    "ProtocolIntentGraphAdapter",
+]
+
+
+@runtime_checkable
+class ProtocolIntentGraphAdapter(Protocol):
+    """Protocol for intent graph adapter implementations.
+
+    Defines the contract for all intent graph storage adapters in OmniMemory.
+    Implementations wrap a graph database (Memgraph, Neo4j, etc.) and provide
+    intent-specific operations:
+
+    - store_intent(): Store an intent classification linked to a session
+    - get_session_intents(): Retrieve intents for a given session
+    - get_recent_intents(): Query recent intents across all sessions
+    - get_intent_distribution(): Get aggregate intent statistics
+
+    Implementations are expected to:
+    - Handle session and intent node creation/merging
+    - Track relationships between sessions and intents
+    - Support confidence-based filtering
+    - Provide temporal queries for analytics
+
+    Lifecycle:
+        1. Create instance with configuration
+        2. Call initialize() with connection parameters
+        3. Use store/query methods
+        4. Call shutdown() to release resources
+
+    The adapter supports async context manager protocol for automatic
+    cleanup via ``async with``.
+    """
+
+    @property
+    def is_initialized(self) -> bool:
+        """Check if the adapter has been initialized.
+
+        Returns:
+            True if initialize() has been called successfully and
+            shutdown() has not been called, False otherwise.
+        """
+        ...
+
+    async def initialize(
+        self,
+        connection_uri: str,
+        auth: tuple[str, str] | None = None,
+        *,
+        options: Mapping[str, object] | None = None,
+    ) -> None:
+        """Initialize the adapter and establish graph database connection.
+
+        Establishes connection to the graph database and prepares
+        the adapter for intent storage operations. Creates indexes
+        for optimal query performance.
+
+        This method is idempotent - calling it multiple times after
+        successful initialization is a no-op.
+
+        Args:
+            connection_uri: Graph database URI (e.g., "bolt://localhost:7687").
+            auth: Optional (username, password) tuple for authentication.
+            options: Additional connection options passed to the underlying
+                graph handler.
+
+        Raises:
+            RuntimeError: If initialization fails or times out.
+            ValueError: If connection_uri is malformed.
+        """
+        ...
+
+    async def shutdown(self) -> None:
+        """Shutdown the adapter and release resources.
+
+        Closes the connection to the graph database and cleans up
+        internal state. Safe to call multiple times - subsequent
+        calls are no-ops.
+        """
+        ...
+
+    async def store_intent(
+        self,
+        session_id: str,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+        *,
+        user_context: str = "",
+    ) -> ModelIntentStorageResult:
+        """Store an intent classification linked to a session.
+
+        Uses MERGE semantics to create or update the session and intent
+        nodes. If an intent with the same category already exists for
+        the session, its confidence and keywords are updated.
+
+        Args:
+            session_id: Unique identifier for the session.
+            intent_data: The intent classification output to store.
+            correlation_id: Correlation ID for request tracing.
+            user_context: Optional user context string for the session.
+
+        Returns:
+            ModelIntentStorageResult indicating success or failure.
+            On success, includes the intent_id and whether a new
+            intent was created vs merged.
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        ...
+
+    async def get_session_intents(
+        self,
+        session_id: str,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        """Get intents for a session with optional filtering.
+
+        Retrieves intent classifications associated with the specified
+        session, ordered by creation time (most recent first).
+
+        Args:
+            session_id: The session identifier to query.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+                Defaults to implementation-specific threshold.
+            limit: Maximum number of results to return.
+                Defaults to implementation-specific maximum.
+
+        Returns:
+            ModelIntentQueryResult with the list of intents or error status.
+            Possible status values:
+            - "success": Query completed with results
+            - "no_results": Session exists but has no intents matching criteria
+            - "not_found": Session not found (reserved for future use)
+            - "error": Query failed
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        ...
+
+    async def get_recent_intents(
+        self,
+        time_range_hours: int = 24,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        """Get recent intents across all sessions within a time range.
+
+        Retrieves intent classifications created within the specified time
+        range, optionally filtered by confidence threshold. Results are
+        ordered by creation time (most recent first) and include the
+        associated session reference.
+
+        Args:
+            time_range_hours: Number of hours to look back from now.
+                Defaults to 24 hours. Values less than 1 may be clamped
+                to a minimum by implementations.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+                If None, no confidence filtering is applied.
+            limit: Maximum number of results to return.
+                Defaults to implementation-specific maximum.
+
+        Returns:
+            ModelIntentQueryResult with the list of intents or error status.
+            Each intent record includes session_ref populated with the
+            session_id it belongs to.
+
+            Possible status values:
+            - "success": Query completed with results
+            - "no_results": No intents found matching criteria
+            - "error": Query failed
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        ...
+
+    async def get_intent_distribution(
+        self,
+        time_range_hours: int = 24,
+    ) -> ModelIntentDistributionResult:
+        """Get intent category distribution for analytics.
+
+        Returns the count of intents per category within the specified
+        time range. Useful for dashboards and understanding user intent
+        patterns.
+
+        Args:
+            time_range_hours: Number of hours to look back from now.
+                Defaults to 24 hours. Values less than 1 may be clamped
+                to a minimum by implementations.
+
+        Returns:
+            ModelIntentDistributionResult with distribution data or error status.
+            On success, includes the distribution dictionary and total count.
+
+        Example::
+
+            result = await adapter.get_intent_distribution(time_range_hours=48)
+            if result.status == "success":
+                print(result.distribution)
+                # {"debugging": 150, "code_generation": 89, "explanation": 45}
+
+        Note:
+            This method never raises on business errors - it returns
+            an error status in the result model instead.
+        """
+        ...
+
+    async def health_check(self) -> ModelIntentGraphHealth:
+        """Check if the graph connection is healthy.
+
+        Performs connectivity check and optionally gathers graph
+        statistics (session and intent counts).
+
+        Returns:
+            ModelIntentGraphHealth with detailed health status.
+            This method never raises - errors are captured in the
+            result model.
+        """
+        ...

--- a/tests/handlers/test_handler_intent.py
+++ b/tests/handlers/test_handler_intent.py
@@ -1,0 +1,1068 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerIntent with mocked adapter.
+
+This module provides comprehensive testing for the HandlerIntent handler,
+using mock implementations to test the handler logic in isolation without
+requiring real database connections.
+
+Test Categories:
+    1. TestLifecycle: Handler initialization and shutdown
+    2. TestCircuitBreaker: Circuit breaker state transitions
+    3. TestOperations: Core operation delegation tests
+    4. TestIntrospection: Health check and describe tests
+    5. TestProperties: Handler property tests
+
+Usage:
+    pytest tests/handlers/test_handler_intent.py -v
+    pytest tests/handlers/test_handler_intent.py -v -k "lifecycle"
+    pytest tests/handlers/test_handler_intent.py -v -k "circuit"
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1536.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnimemory.handlers.adapters.models import (
+    ModelIntentClassificationOutput,
+    ModelIntentDistributionResult,
+    ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentRecord,
+    ModelIntentStorageResult,
+)
+from omnimemory.handlers.handler_intent import (
+    CircuitBreakerOpenError,
+    HandlerIntent,
+    ModelHandlerIntentMetadata,
+)
+from omnimemory.utils.concurrency import CircuitBreakerState
+
+# =============================================================================
+# Mock Container
+# =============================================================================
+
+
+def create_mock_container() -> MagicMock:
+    """Create a mock ModelONEXContainer for testing."""
+    return MagicMock(spec=["__class__"])
+
+
+# =============================================================================
+# Mock Adapter
+# =============================================================================
+
+
+class MockAdapterIntentGraph:
+    """Mock adapter for testing HandlerIntent without real database connections.
+
+    Provides controllable behavior for testing handler logic.
+    """
+
+    def __init__(
+        self,
+        *,
+        store_result: ModelIntentStorageResult | None = None,
+        query_result: ModelIntentQueryResult | None = None,
+        distribution_result: ModelIntentDistributionResult | None = None,
+        health_result: ModelIntentGraphHealth | None = None,
+        fail_on_store: bool = False,
+        fail_on_query: bool = False,
+        fail_on_distribution: bool = False,
+        fail_on_health: bool = False,
+    ) -> None:
+        self._initialized = False
+        self._store_result = store_result
+        self._query_result = query_result
+        self._distribution_result = distribution_result
+        self._health_result = health_result
+        self._fail_on_store = fail_on_store
+        self._fail_on_query = fail_on_query
+        self._fail_on_distribution = fail_on_distribution
+        self._fail_on_health = fail_on_health
+        self.store_intent_calls: list[dict[str, object]] = []
+        self.get_session_intents_calls: list[dict[str, object]] = []
+        self.get_intent_distribution_calls: list[dict[str, object]] = []
+        self.health_check_calls: int = 0
+        self.shutdown_calls: int = 0
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    async def initialize(
+        self,
+        connection_uri: str,
+        auth: tuple[str, str] | None = None,
+        *,
+        options: dict[str, object] | None = None,
+    ) -> None:
+        self._initialized = True
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self._initialized = False
+
+    async def store_intent(
+        self,
+        session_id: str,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+        user_context: str = "",
+    ) -> ModelIntentStorageResult:
+        self.store_intent_calls.append(
+            {
+                "session_id": session_id,
+                "intent_data": intent_data,
+                "correlation_id": correlation_id,
+                "user_context": user_context,
+            }
+        )
+
+        if self._fail_on_store:
+            raise RuntimeError("Simulated store failure")
+
+        if self._store_result:
+            return self._store_result
+
+        return ModelIntentStorageResult(
+            status="success",
+            intent_id=uuid4(),
+            session_id=session_id,
+            created=True,
+            execution_time_ms=10.5,
+        )
+
+    async def get_session_intents(
+        self,
+        session_id: str,
+        min_confidence: float | None = None,
+        limit: int | None = None,
+    ) -> ModelIntentQueryResult:
+        self.get_session_intents_calls.append(
+            {
+                "session_id": session_id,
+                "min_confidence": min_confidence,
+                "limit": limit,
+            }
+        )
+
+        if self._fail_on_query:
+            raise RuntimeError("Simulated query failure")
+
+        if self._query_result:
+            return self._query_result
+
+        return ModelIntentQueryResult(
+            status="success",
+            intents=[],
+            total_count=0,
+            execution_time_ms=5.0,
+        )
+
+    async def get_intent_distribution(
+        self,
+        time_range_hours: int = 24,
+    ) -> ModelIntentDistributionResult:
+        self.get_intent_distribution_calls.append(
+            {"time_range_hours": time_range_hours}
+        )
+
+        if self._fail_on_distribution:
+            raise RuntimeError("Simulated distribution query failure")
+
+        if self._distribution_result:
+            return self._distribution_result
+
+        return ModelIntentDistributionResult(
+            status="success",
+            distribution={"debugging": 10, "code_generation": 5},
+            total_intents=15,
+            time_range_hours=time_range_hours,
+            execution_time_ms=8.0,
+        )
+
+    async def health_check(self) -> ModelIntentGraphHealth:
+        self.health_check_calls += 1
+
+        if self._fail_on_health:
+            raise RuntimeError("Simulated health check failure")
+
+        if self._health_result:
+            return self._health_result
+
+        return ModelIntentGraphHealth(
+            is_healthy=True,
+            initialized=True,
+            handler_healthy=True,
+            session_count=5,
+            intent_count=15,
+            last_check_timestamp=datetime.now(UTC),
+        )
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_container() -> MagicMock:
+    """Create a mock container for testing."""
+    return create_mock_container()
+
+
+@pytest.fixture
+def mock_adapter() -> MockAdapterIntentGraph:
+    """Create a mock adapter for testing."""
+    return MockAdapterIntentGraph()
+
+
+@pytest.fixture
+def handler(mock_container: MagicMock) -> HandlerIntent:
+    """Create an uninitialized handler for testing."""
+    return HandlerIntent(mock_container)
+
+
+@pytest.fixture
+def intent_data() -> ModelIntentClassificationOutput:
+    """Create sample intent classification data."""
+    return ModelIntentClassificationOutput(
+        intent_category="debugging",
+        confidence=0.92,
+        keywords=["error", "traceback"],
+    )
+
+
+@pytest.fixture
+def correlation_id() -> UUID:
+    """Create a sample correlation ID."""
+    return uuid4()
+
+
+# =============================================================================
+# Lifecycle Tests
+# =============================================================================
+
+
+class TestLifecycle:
+    """Tests for handler initialization and shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_adapter(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Initialize should create and configure the adapter."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+            )
+
+            assert handler.is_initialized is True
+            assert mock_adapter.is_initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_is_idempotent(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Multiple initialize calls should not re-initialize."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ) as mock_class:
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            # AdapterIntentGraph constructor should only be called once
+            assert mock_class.call_count == 1
+            assert handler.is_initialized is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cleans_up_adapter(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Shutdown should close adapter and release resources."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            assert handler.is_initialized is True
+
+            await handler.shutdown()
+
+            assert handler.is_initialized is False
+            assert mock_adapter.shutdown_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Multiple shutdown calls should be safe."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            await handler.shutdown()
+            await handler.shutdown()
+            await handler.shutdown()
+
+            # Only one shutdown should actually clean up (when initialized)
+            assert handler.is_initialized is False
+            assert mock_adapter.shutdown_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_on_uninitialized_handler_is_noop(
+        self, handler: HandlerIntent
+    ) -> None:
+        """Shutdown on uninitialized handler should be a no-op."""
+        # Should not raise
+        await handler.shutdown()
+        assert handler.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_options(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Initialize should pass options to adapter."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={
+                    "timeout_seconds": 60.0,
+                    "circuit_breaker_threshold": 10,
+                },
+            )
+
+            assert handler.is_initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_auth(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Initialize should pass auth credentials to adapter."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                auth=("neo4j", "password"),
+            )
+
+            assert handler.is_initialized is True
+
+
+# =============================================================================
+# Circuit Breaker Tests
+# =============================================================================
+
+
+class TestCircuitBreaker:
+    """Tests for circuit breaker behavior."""
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_opens_after_failures(
+        self, handler: HandlerIntent
+    ) -> None:
+        """Circuit breaker should open after threshold failures."""
+        # Create adapter that always fails
+        failing_adapter = MockAdapterIntentGraph(fail_on_store=True)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=failing_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={
+                    "circuit_breaker_threshold": 3,
+                    "circuit_breaker_reset_timeout": 60.0,
+                },
+            )
+
+            intent_data = ModelIntentClassificationOutput(
+                intent_category="test",
+                confidence=0.9,
+                keywords=[],
+            )
+
+            # Make enough calls to trip the circuit breaker
+            for i in range(3):
+                with pytest.raises(RuntimeError, match="Simulated store failure"):
+                    await handler.store_intent(
+                        session_id=f"session_{i}",
+                        intent_data=intent_data,
+                        correlation_id=uuid4(),
+                    )
+
+            # Next call should raise CircuitBreakerOpenError
+            with pytest.raises(CircuitBreakerOpenError):
+                await handler.store_intent(
+                    session_id="session_final",
+                    intent_data=intent_data,
+                    correlation_id=uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_raises_when_open(
+        self, handler: HandlerIntent
+    ) -> None:
+        """Operations should raise CircuitBreakerOpenError when circuit is open."""
+        mock_adapter = MockAdapterIntentGraph()
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={"circuit_breaker_threshold": 1},
+            )
+
+            # Manually set circuit breaker to open state via internal access
+            assert handler._circuit_breaker is not None
+            handler._circuit_breaker.state = CircuitBreakerState.OPEN
+            handler._circuit_breaker.last_failure_time = datetime.now(UTC)
+
+            intent_data = ModelIntentClassificationOutput(
+                intent_category="test",
+                confidence=0.9,
+                keywords=[],
+            )
+
+            # All operations should raise when circuit is open
+            with pytest.raises(CircuitBreakerOpenError):
+                await handler.store_intent(
+                    session_id="session_1",
+                    intent_data=intent_data,
+                    correlation_id=uuid4(),
+                )
+
+            with pytest.raises(CircuitBreakerOpenError):
+                await handler.query_session(session_id="session_1")
+
+            with pytest.raises(CircuitBreakerOpenError):
+                await handler.query_distribution(time_range_hours=24)
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_records_success(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """Successful operations should record success in circuit breaker."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={"circuit_breaker_threshold": 5},
+            )
+
+            intent_data = ModelIntentClassificationOutput(
+                intent_category="debugging",
+                confidence=0.9,
+                keywords=[],
+            )
+
+            # Successful operation
+            result = await handler.store_intent(
+                session_id="session_1",
+                intent_data=intent_data,
+                correlation_id=uuid4(),
+            )
+
+            assert result.status == "success"
+            assert handler._circuit_breaker is not None
+            assert handler._circuit_breaker.state == CircuitBreakerState.CLOSED
+            assert handler._circuit_breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_resets_failure_count_on_success(
+        self, handler: HandlerIntent
+    ) -> None:
+        """Success after failures should reset failure count."""
+        # Adapter that fails twice then succeeds
+        call_count = 0
+
+        class PartiallyFailingAdapter(MockAdapterIntentGraph):
+            async def store_intent(
+                self, *args: object, **kwargs: object
+            ) -> ModelIntentStorageResult:
+                nonlocal call_count
+                call_count += 1
+                if call_count <= 2:
+                    raise RuntimeError("Temporary failure")
+                return await super().store_intent(*args, **kwargs)  # type: ignore[arg-type]
+
+        adapter = PartiallyFailingAdapter()
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={"circuit_breaker_threshold": 5},
+            )
+
+            intent_data = ModelIntentClassificationOutput(
+                intent_category="test",
+                confidence=0.9,
+                keywords=[],
+            )
+
+            # Two failures
+            for _ in range(2):
+                with pytest.raises(RuntimeError):
+                    await handler.store_intent(
+                        session_id="session",
+                        intent_data=intent_data,
+                        correlation_id=uuid4(),
+                    )
+
+            assert handler._circuit_breaker is not None
+            assert handler._circuit_breaker.failure_count == 2
+
+            # Third call succeeds
+            result = await handler.store_intent(
+                session_id="session",
+                intent_data=intent_data,
+                correlation_id=uuid4(),
+            )
+
+            assert result.status == "success"
+            assert handler._circuit_breaker.failure_count == 0
+
+
+# =============================================================================
+# Operation Tests
+# =============================================================================
+
+
+class TestOperations:
+    """Tests for core handler operations."""
+
+    @pytest.mark.asyncio
+    async def test_store_intent_delegates_to_adapter(
+        self,
+        handler: HandlerIntent,
+        mock_adapter: MockAdapterIntentGraph,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+    ) -> None:
+        """store_intent should delegate to adapter correctly."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            result = await handler.store_intent(
+                session_id="session_123",
+                intent_data=intent_data,
+                correlation_id=correlation_id,
+                user_context="test context",
+            )
+
+            assert result.status == "success"
+            assert len(mock_adapter.store_intent_calls) == 1
+
+            call = mock_adapter.store_intent_calls[0]
+            assert call["session_id"] == "session_123"
+            assert call["intent_data"] == intent_data
+            assert call["correlation_id"] == correlation_id
+            assert call["user_context"] == "test context"
+
+    @pytest.mark.asyncio
+    async def test_store_intent_returns_error_when_uninitialized(
+        self,
+        handler: HandlerIntent,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+    ) -> None:
+        """store_intent on uninitialized handler should return error result."""
+        result = await handler.store_intent(
+            session_id="session_123",
+            intent_data=intent_data,
+            correlation_id=correlation_id,
+        )
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not initialized" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_session_delegates_to_adapter(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """query_session should delegate to adapter correctly."""
+        # Set up expected result
+        expected_intents = [
+            ModelIntentRecord(
+                intent_id=uuid4(),
+                intent_category="debugging",
+                confidence=0.92,
+                keywords=["error"],
+                created_at_utc=datetime.now(UTC),
+            )
+        ]
+        mock_adapter._query_result = ModelIntentQueryResult(
+            status="success",
+            intents=expected_intents,
+            total_count=1,
+            execution_time_ms=5.0,
+        )
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            result = await handler.query_session(
+                session_id="session_123",
+                min_confidence=0.5,
+                limit=10,
+            )
+
+            assert result.status == "success"
+            assert result.total_count == 1
+            assert len(mock_adapter.get_session_intents_calls) == 1
+
+            call = mock_adapter.get_session_intents_calls[0]
+            assert call["session_id"] == "session_123"
+            assert call["min_confidence"] == 0.5
+            assert call["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_query_session_returns_error_when_uninitialized(
+        self, handler: HandlerIntent
+    ) -> None:
+        """query_session on uninitialized handler should return error result."""
+        result = await handler.query_session(session_id="session_123")
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not initialized" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_distribution_delegates_to_adapter(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """query_distribution should delegate to adapter correctly."""
+        expected_distribution = {
+            "debugging": 50,
+            "code_generation": 30,
+            "explanation": 20,
+        }
+        mock_adapter._distribution_result = ModelIntentDistributionResult(
+            status="success",
+            distribution=expected_distribution,
+            total_intents=100,
+            time_range_hours=48,
+            execution_time_ms=12.0,
+        )
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            result = await handler.query_distribution(time_range_hours=48)
+
+            assert result.status == "success"
+            assert result.distribution == expected_distribution
+            assert result.total_intents == 100
+            assert len(mock_adapter.get_intent_distribution_calls) == 1
+
+            call = mock_adapter.get_intent_distribution_calls[0]
+            assert call["time_range_hours"] == 48
+
+    @pytest.mark.asyncio
+    async def test_query_distribution_returns_error_when_uninitialized(
+        self, handler: HandlerIntent
+    ) -> None:
+        """query_distribution on uninitialized handler should return error result."""
+        result = await handler.query_distribution(time_range_hours=24)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not initialized" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_query_distribution_uses_default_time_range(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """query_distribution should use default 24 hours if not specified."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            await handler.query_distribution()
+
+            call = mock_adapter.get_intent_distribution_calls[0]
+            assert call["time_range_hours"] == 24
+
+
+# =============================================================================
+# Introspection Tests
+# =============================================================================
+
+
+class TestIntrospection:
+    """Tests for health check and describe functionality."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_health_status(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """health_check should return detailed health status."""
+        mock_adapter._health_result = ModelIntentGraphHealth(
+            is_healthy=True,
+            initialized=True,
+            handler_healthy=True,
+            session_count=10,
+            intent_count=50,
+            last_check_timestamp=datetime.now(UTC),
+        )
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            health = await handler.health_check()
+
+            assert health.is_healthy is True
+            assert health.initialized is True
+            assert health.handler_healthy is True
+            assert health.session_count == 10
+            assert health.intent_count == 50
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_unhealthy_when_uninitialized(
+        self, handler: HandlerIntent
+    ) -> None:
+        """health_check on uninitialized handler should return unhealthy."""
+        health = await handler.health_check()
+
+        assert health.is_healthy is False
+        assert health.initialized is False
+        assert health.error_message is not None
+        assert "not initialized" in health.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_health_check_includes_circuit_breaker_status(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """health_check should include circuit breaker state."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(
+                connection_uri="bolt://localhost:7687",
+                options={"circuit_breaker_threshold": 5},
+            )
+
+            # Set circuit breaker to open state
+            assert handler._circuit_breaker is not None
+            handler._circuit_breaker.state = CircuitBreakerState.OPEN
+            handler._circuit_breaker.last_failure_time = datetime.now(UTC)
+
+            health = await handler.health_check()
+
+            # When circuit breaker is open, should report unhealthy
+            assert health.is_healthy is False
+            assert health.error_message is not None
+            assert "circuit breaker" in health.error_message.lower()
+            assert "open" in health.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_health_check_handles_adapter_failure(
+        self, handler: HandlerIntent
+    ) -> None:
+        """health_check should capture adapter health check failures."""
+        failing_adapter = MockAdapterIntentGraph(fail_on_health=True)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=failing_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            health = await handler.health_check()
+
+            assert health.is_healthy is False
+            assert health.error_message is not None
+            assert "health check failed" in health.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_describe_returns_metadata(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """describe should return handler metadata."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            metadata = await handler.describe()
+
+            assert isinstance(metadata, ModelHandlerIntentMetadata)
+            assert metadata.handler_type == "intent"
+            assert metadata.initialized is True
+            assert metadata.adapter_type == "AdapterIntentGraph"
+            assert "store_intent" in metadata.capabilities
+            assert "query_session" in metadata.capabilities
+            assert "query_distribution" in metadata.capabilities
+            assert "health_check" in metadata.capabilities
+            assert "describe" in metadata.capabilities
+
+    @pytest.mark.asyncio
+    async def test_describe_before_init(self, handler: HandlerIntent) -> None:
+        """describe should work even before initialization."""
+        metadata = await handler.describe()
+
+        assert isinstance(metadata, ModelHandlerIntentMetadata)
+        assert metadata.handler_type == "intent"
+        assert metadata.initialized is False
+
+
+# =============================================================================
+# Properties Tests
+# =============================================================================
+
+
+class TestProperties:
+    """Tests for handler properties."""
+
+    def test_handler_type_returns_intent(self, handler: HandlerIntent) -> None:
+        """handler_type property should return 'intent'."""
+        assert handler.handler_type == "intent"
+
+    def test_is_initialized_false_before_init(self, handler: HandlerIntent) -> None:
+        """is_initialized should be False before initialization."""
+        assert handler.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_is_initialized_true_after_init(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """is_initialized should be True after initialization."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            assert handler.is_initialized is True
+
+    @pytest.mark.asyncio
+    async def test_is_initialized_false_after_shutdown(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """is_initialized should be False after shutdown."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            await handler.shutdown()
+
+            assert handler.is_initialized is False
+
+    def test_repr_before_init(self, handler: HandlerIntent) -> None:
+        """__repr__ should work before initialization."""
+        repr_str = repr(handler)
+        assert "HandlerIntent" in repr_str
+        assert "initialized=False" in repr_str
+
+    @pytest.mark.asyncio
+    async def test_repr_after_init(
+        self, handler: HandlerIntent, mock_adapter: MockAdapterIntentGraph
+    ) -> None:
+        """__repr__ should reflect initialization state."""
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            repr_str = repr(handler)
+            assert "HandlerIntent" in repr_str
+            assert "initialized=True" in repr_str
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling behavior."""
+
+    @pytest.mark.asyncio
+    async def test_store_intent_propagates_adapter_exception(
+        self, handler: HandlerIntent, intent_data: ModelIntentClassificationOutput
+    ) -> None:
+        """store_intent should propagate adapter exceptions (and record failure)."""
+        failing_adapter = MockAdapterIntentGraph(fail_on_store=True)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=failing_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            with pytest.raises(RuntimeError, match="Simulated store failure"):
+                await handler.store_intent(
+                    session_id="session_123",
+                    intent_data=intent_data,
+                    correlation_id=uuid4(),
+                )
+
+            # Circuit breaker should record the failure
+            assert handler._circuit_breaker is not None
+            assert handler._circuit_breaker.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_query_session_propagates_adapter_exception(
+        self, handler: HandlerIntent
+    ) -> None:
+        """query_session should propagate adapter exceptions."""
+        failing_adapter = MockAdapterIntentGraph(fail_on_query=True)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=failing_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            with pytest.raises(RuntimeError, match="Simulated query failure"):
+                await handler.query_session(session_id="session_123")
+
+    @pytest.mark.asyncio
+    async def test_query_distribution_propagates_adapter_exception(
+        self, handler: HandlerIntent
+    ) -> None:
+        """query_distribution should propagate adapter exceptions."""
+        failing_adapter = MockAdapterIntentGraph(fail_on_distribution=True)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=failing_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            with pytest.raises(
+                RuntimeError, match="Simulated distribution query failure"
+            ):
+                await handler.query_distribution(time_range_hours=24)
+
+
+# =============================================================================
+# Integration-like Tests
+# =============================================================================
+
+
+class TestIntegration:
+    """Integration-style tests combining multiple operations."""
+
+    @pytest.mark.asyncio
+    async def test_full_workflow_store_and_query(
+        self,
+        handler: HandlerIntent,
+        mock_adapter: MockAdapterIntentGraph,
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: UUID,
+    ) -> None:
+        """Test storing intent then querying it back."""
+        # Set up query to return the stored intent
+        stored_intent = ModelIntentRecord(
+            intent_id=uuid4(),
+            intent_category=intent_data.intent_category,
+            confidence=intent_data.confidence,
+            keywords=intent_data.keywords,
+            created_at_utc=datetime.now(UTC),
+            correlation_id=correlation_id,
+        )
+        mock_adapter._query_result = ModelIntentQueryResult(
+            status="success",
+            intents=[stored_intent],
+            total_count=1,
+            execution_time_ms=5.0,
+        )
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            return_value=mock_adapter,
+        ):
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+
+            # Store intent
+            store_result = await handler.store_intent(
+                session_id="session_123",
+                intent_data=intent_data,
+                correlation_id=correlation_id,
+            )
+            assert store_result.status == "success"
+
+            # Query it back
+            query_result = await handler.query_session(
+                session_id="session_123",
+                min_confidence=0.5,
+            )
+            assert query_result.status == "success"
+            assert query_result.total_count == 1
+            assert query_result.intents[0].intent_category == "debugging"
+
+    @pytest.mark.asyncio
+    async def test_reinitialize_after_shutdown(self, handler: HandlerIntent) -> None:
+        """Handler should be reusable after shutdown."""
+        mock_adapter1 = MockAdapterIntentGraph()
+        mock_adapter2 = MockAdapterIntentGraph()
+        adapters = [mock_adapter1, mock_adapter2]
+        adapter_iter = iter(adapters)
+
+        def create_adapter(*args: object, **kwargs: object) -> MockAdapterIntentGraph:
+            return next(adapter_iter)
+
+        with patch(
+            "omnimemory.handlers.handler_intent.AdapterIntentGraph",
+            side_effect=create_adapter,
+        ):
+            # First initialization
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            assert handler.is_initialized is True
+
+            # Shutdown
+            await handler.shutdown()
+            assert handler.is_initialized is False
+
+            # Re-initialize with new adapter
+            await handler.initialize(connection_uri="bolt://localhost:7687")
+            assert handler.is_initialized is True
+            assert mock_adapter2.is_initialized is True

--- a/tests/handlers/test_handler_semantic_compute.py
+++ b/tests/handlers/test_handler_semantic_compute.py
@@ -875,7 +875,7 @@ class TestConfig:
         config = ModelHandlerSemanticComputeConfig()
 
         assert config.handler_name == "semantic-compute"
-        assert config.handler_version == "1.0.0"
+        assert str(config.handler_version) == "1.0.0"
         assert config.enable_caching is True
         assert config.max_cache_size == 1000
 

--- a/tests/handlers/test_handler_semantic_compute.py
+++ b/tests/handlers/test_handler_semantic_compute.py
@@ -37,6 +37,7 @@ from omnimemory.handlers import (
     ModelHandlerSemanticComputeConfig,
 )
 from omnimemory.models.config import ModelSemanticComputePolicyConfig
+from omnimemory.models.foundation import ModelSemVer
 from omnimemory.models.intelligence import (
     ModelSemanticAnalysisResult,
     ModelSemanticEntity,
@@ -635,7 +636,7 @@ class TestAnalyze:
         result = await handler.analyze("Test content.")
 
         assert result.model_name == "fake-model-v1"
-        assert result.model_version == "1.0.0"
+        assert result.model_version == ModelSemVer(major=1, minor=0, patch=0)
 
 
 # =============================================================================


### PR DESCRIPTION
…536]

Add container-driven HandlerIntent following omnibase_infra pattern:

- HandlerIntent wraps AdapterIntentGraph for direct protocol access
- Constructor takes ModelONEXContainer (container-driven DI)
- Handler owns adapter lifecycle (creates on init, closes on shutdown)
- Operations: store_intent, query_session, query_distribution
- Introspection: health_check, describe methods
- Thread-safe initialization with asyncio.Lock

Also adds:
- ModelHandlerIntentConfig with from_env() factory
- ModelHandlerIntentMetadata for describe() output
- handlers/models/ subpackage for handler configs

This is complementary to HandlerIntentQuery (event-driven):
- HandlerIntent: Direct method calls for API layer
- HandlerIntentQuery: Kafka-based for background pipelines