### PR TITLE
feat(ci): Add migration freeze enforcement (OMN-2074)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
   # =============================================================================
   #
   # Phase 1 - Quick Validation (parallel, ~2-5 min):
+  #   - migration-freeze: Block new DB migrations during schema freeze (OMN-2055)
   #   - lint: Code quality (ruff format, ruff check, mypy strict)
   #   - pyright: Type checking (complementary to mypy)
   #   - onex-validation: ONEX pattern validation (pydantic, naming, enums, etc.)
@@ -51,6 +52,7 @@ jobs:
   # CI-TO-HOOK SYNCHRONIZATION MAP:
   # CI Job          | Pre-commit Hook                   | Command
   # ----------------|-----------------------------------|----------------------------------
+  # migration-freeze| migration-freeze-check (pre-commit)| ./scripts/check_migration_freeze.sh [--ci]
   # lint            | ruff-format (pre-commit)          | ruff format --check src/ tests/
   # lint            | ruff (pre-commit)                 | ruff check src/ tests/
   # lint            | mypy (pre-push)                   | mypy --show-error-codes --no-error-summary src/omnimemory
@@ -67,6 +69,23 @@ jobs:
   #
   # POETRY VERSION: Must match POETRY_VERSION env var (currently 2.2.1)
   # =============================================================================
+
+  # Phase 1 - Migration Freeze Enforcement
+  # Blocks new migrations when .migration_freeze exists (DB-per-repo refactor OMN-2055)
+  # SYNC: Pre-commit hook 'migration-freeze-check' at pre-commit stage
+  migration-freeze:
+    name: Migration Freeze Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for git diff
+
+      - name: Check migration freeze
+        run: ./scripts/check_migration_freeze.sh --ci
 
   # Phase 1 - Code Quality
   lint:
@@ -402,24 +421,27 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [lint, pyright, onex-validation, check-handshake, test]
+    needs: [migration-freeze, lint, pyright, onex-validation, check-handshake, test]
     if: always()
 
     steps:
       - name: Check test results
         run: |
+          migration_freeze="${{ needs.migration-freeze.result }}"
           lint="${{ needs.lint.result }}"
           pyright="${{ needs.pyright.result }}"
           onex="${{ needs.onex-validation.result }}"
           handshake="${{ needs.check-handshake.result }}"
           test="${{ needs.test.result }}"
 
-          if [[ "$lint" == "success" ]] && \
+          if [[ "$migration_freeze" == "success" ]] && \
+             [[ "$lint" == "success" ]] && \
              [[ "$pyright" == "success" ]] && \
              [[ "$onex" == "success" ]] && \
              [[ "$handshake" == "success" || "$handshake" == "skipped" ]] && \
              [[ "$test" == "success" ]]; then
             echo "All tests passed successfully"
+            echo "Migration Freeze: Passed"
             echo "Code Quality: Passed"
             echo "Pyright Type Checking: Passed"
             echo "ONEX Validation: Passed"
@@ -428,6 +450,7 @@ jobs:
             exit 0
           else
             echo "Tests failed"
+            echo "Migration Freeze: $migration_freeze"
             echo "Lint: $lint"
             echo "Pyright: $pyright"
             echo "ONEX Validation: $onex"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,10 +82,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history for git diff
+          fetch-depth: 0  # Needed for three-dot diff (merge-base with origin/main)
 
       - name: Check migration freeze
         run: ./scripts/check_migration_freeze.sh --ci
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
   # Phase 1 - Code Quality
   lint:

--- a/.migration_freeze
+++ b/.migration_freeze
@@ -1,0 +1,16 @@
+# Migration Freeze
+#
+# This file enforces a schema freeze during the DB-per-repo refactor (OMN-2055).
+# While this file exists, no new migrations may be added to deployment/database/migrations/.
+#
+# Allowed during freeze:
+#   - Migration moves (reorg between repos)
+#   - Ownership fixes (table transfers)
+#   - Rollback bug fixes (DB-SPLIT-01 refactor phase)
+#
+# To lift the freeze: remove this file once DB boundary work for omnimemory is complete.
+#
+# Enforcement: CI job (migration-freeze) + pre-commit hook (migration-freeze-check)
+# Tracking: OMN-2074
+# Parent:   OMN-2055
+# Created:  2026-02-10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@
 # ====================================
 # Pre-commit Hook                   | CI Workflow Job          | Command
 # ----------------------------------|--------------------------|----------------------------------
+# migration-freeze-check (pre-commit)| migration-freeze        | ./scripts/check_migration_freeze.sh [--ci]
 # ruff-format (pre-commit)          | lint                     | ruff format --check src/ tests/
 # ruff (pre-commit)                 | lint                     | ruff check src/ tests/
 # mypy (pre-push)                   | lint                     | mypy --show-error-codes --no-error-summary src/omnimemory
@@ -157,10 +158,30 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-  # Local hooks for cleanup and ONEX validation
+  # Local hooks for cleanup, migration freeze, and ONEX validation
   # These use language: python or language: system with no Poetry dependency
   - repo: local
     hooks:
+      # --------------------------------------------------------------------------
+      # Migration Freeze Check - Block new migrations during DB-per-repo refactor
+      # Validates: No new .sql files added to deployment/database/migrations/
+      # Scope: Only triggers when migration files or .migration_freeze change
+      # Purpose: Enforces schema freeze (OMN-2055) while .migration_freeze exists
+      # --------------------------------------------------------------------------
+      - id: migration-freeze-check
+        name: migration freeze check
+        entry: ./scripts/check_migration_freeze.sh
+        language: system
+        pass_filenames: false
+        # Trigger when migration files or the freeze file itself change.
+        # Note: pre-commit sees deletions in the changeset, so deleting
+        # .migration_freeze will trigger this hook. The script then checks
+        # [ ! -f .migration_freeze ] at runtime and exits 0, which means
+        # removing the freeze file + adding a migration in the same commit
+        # is intentionally allowed (freeze is lifted).
+        files: ^(deployment/database/migrations/|\.migration_freeze)
+        stages: [pre-commit]
+
       # Cleanup: Clear tmp/ directory before commits
       - id: clean-tmp-directory
         name: Clean tmp directory

--- a/scripts/check_migration_freeze.sh
+++ b/scripts/check_migration_freeze.sh
@@ -26,19 +26,25 @@ MODE="${1:-precommit}"
 
 if [ "$MODE" = "--ci" ]; then
     # CI mode: compare against base branch
-    BASE_BRANCH="${GITHUB_BASE_REF:-main}"
+    # GITHUB_BASE_REF is set automatically for pull_request events.
+    # DEFAULT_BRANCH can be passed from the workflow for push events.
+    BASE_BRANCH="${GITHUB_BASE_REF:-${DEFAULT_BRANCH:-main}}"
     # Defensive fetch: ensure origin/<base> ref is up-to-date even if
     # the CI runner's checkout didn't fully resolve it.
-    git fetch origin "${BASE_BRANCH}" --quiet 2>/dev/null || true
+    if ! git fetch origin "${BASE_BRANCH}" --quiet 2>/dev/null; then
+        echo "Warning: git fetch origin ${BASE_BRANCH} failed; using existing refs." >&2
+    fi
     # Detect added (A) or renamed (R) files in the migrations directory.
     # Modified (M) files are intentionally allowed — fixing existing
     # migrations (rollback bug fixes, comment tweaks) is safe during freeze.
+    # Uses awk (not grep|awk) to avoid grep exit-code 1 on no-match with pipefail.
     NEW_MIGRATIONS=$(git diff --name-status "origin/${BASE_BRANCH}...HEAD" -- "$MIGRATIONS_DIR" \
-        | grep -E '^[AR]' | awk '{print $NF}' || true)
+        | awk '/^[AR]/ {print $NF}')
 else
     # Pre-commit mode: check staged files
+    # Uses awk (not grep|awk) to avoid grep exit-code 1 on no-match with pipefail.
     NEW_MIGRATIONS=$(git diff --cached --name-status -- "$MIGRATIONS_DIR" \
-        | grep -E '^[AR]' | awk '{print $NF}' || true)
+        | awk '/^[AR]/ {print $NF}')
 fi
 
 if [ -n "$NEW_MIGRATIONS" ]; then

--- a/scripts/check_migration_freeze.sh
+++ b/scripts/check_migration_freeze.sh
@@ -12,6 +12,8 @@
 set -euo pipefail
 
 FREEZE_FILE=".migration_freeze"
+# Path to migrations directory. git diff returns empty (not error) if this path
+# does not exist yet, which is correct — no migrations means no violations.
 MIGRATIONS_DIR="deployment/database/migrations"
 
 # If no freeze file, nothing to enforce.
@@ -37,6 +39,8 @@ if [ "$MODE" = "--ci" ]; then
     # Detect added (A) or renamed (R) files in the migrations directory.
     # Modified (M) files are intentionally allowed — fixing existing
     # migrations (rollback bug fixes, comment tweaks) is safe during freeze.
+    # Three-dot diff finds the merge-base automatically. If no common ancestor
+    # exists (orphan branch), git diff falls back to two-dot behavior — safe.
     # Uses awk (not grep|awk) to avoid grep exit-code 1 on no-match with pipefail.
     NEW_MIGRATIONS=$(git diff --name-status "origin/${BASE_BRANCH}...HEAD" -- "$MIGRATIONS_DIR" \
         | awk '/^[AR]/ {print $NF}')

--- a/scripts/check_migration_freeze.sh
+++ b/scripts/check_migration_freeze.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# check_migration_freeze.sh — Block new migrations while .migration_freeze exists.
+#
+# Usage:
+#   Pre-commit: ./scripts/check_migration_freeze.sh           (checks staged files)
+#   CI:         ./scripts/check_migration_freeze.sh --ci       (checks diff vs base branch)
+#
+# Exit codes:
+#   0 — No freeze active, or no new migrations detected
+#   1 — Freeze violation: new migration files added
+
+set -euo pipefail
+
+FREEZE_FILE=".migration_freeze"
+MIGRATIONS_DIR="deployment/database/migrations"
+
+# If no freeze file, nothing to enforce.
+if [ ! -f "$FREEZE_FILE" ]; then
+    echo "No migration freeze active — skipping check."
+    exit 0
+fi
+
+echo "Migration freeze is ACTIVE ($FREEZE_FILE exists)"
+
+MODE="${1:-precommit}"
+
+if [ "$MODE" = "--ci" ]; then
+    # CI mode: compare against base branch
+    BASE_BRANCH="${GITHUB_BASE_REF:-main}"
+    # Defensive fetch: ensure origin/<base> ref is up-to-date even if
+    # the CI runner's checkout didn't fully resolve it.
+    git fetch origin "${BASE_BRANCH}" --quiet 2>/dev/null || true
+    # Detect added (A) or renamed (R) files in the migrations directory.
+    # Modified (M) files are intentionally allowed — fixing existing
+    # migrations (rollback bug fixes, comment tweaks) is safe during freeze.
+    NEW_MIGRATIONS=$(git diff --name-status "origin/${BASE_BRANCH}...HEAD" -- "$MIGRATIONS_DIR" \
+        | grep -E '^[AR]' | awk '{print $NF}' || true)
+else
+    # Pre-commit mode: check staged files
+    NEW_MIGRATIONS=$(git diff --cached --name-status -- "$MIGRATIONS_DIR" \
+        | grep -E '^[AR]' | awk '{print $NF}' || true)
+fi
+
+if [ -n "$NEW_MIGRATIONS" ]; then
+    echo ""
+    echo "ERROR: Migration freeze violation!"
+    echo "Blocked: new migration files (A=added) or renames (R) while $FREEZE_FILE exists."
+    echo "Allowed: modifications (M) to existing migrations (bug fixes, comments)."
+    echo ""
+    echo "Violating files:"
+    echo "$NEW_MIGRATIONS" | sed 's/^/  /'
+    echo ""
+    echo "See $FREEZE_FILE for details on the active freeze."
+    exit 1
+fi
+
+echo "No new migrations detected — freeze check passed."
+exit 0


### PR DESCRIPTION
## Summary

- Adds migration freeze CI checks matching omniintelligence's implementation for the DB-per-repo refactor (OMN-2055)
- Dual enforcement: pre-commit hook blocks locally, CI job blocks in GitHub Actions
- Zero overhead when inactive — script exits immediately if `.migration_freeze` marker is absent

## Components

| File | Purpose |
|------|---------|
| `.migration_freeze` | Marker file — presence activates the freeze |
| `scripts/check_migration_freeze.sh` | Enforcement script with pre-commit + CI modes |
| `.pre-commit-config.yaml` | `migration-freeze-check` hook (triggers on migration dir changes) |
| `.github/workflows/test.yml` | `migration-freeze` CI job (Phase 1, parallel with lint/pyright) |

## Behavior

- **Blocks**: New migration files (Added/Renamed) in `deployment/database/migrations/`
- **Allows**: Modifications to existing migrations (bug fixes, comments)
- **Lift freeze**: Delete `.migration_freeze` — same commit can add migrations

## Test plan

- [x] `./scripts/check_migration_freeze.sh` passes locally (no new migrations)
- [x] All 1529 tests pass, 0 failures
- [x] Pre-commit hooks pass (migration freeze check: Passed)
- [x] YAML validation passes for both workflow and pre-commit config
- [ ] CI pipeline runs successfully on GitHub