### PR TITLE
feat(contracts): Add event_bus topic declarations to all effect nodes (OMN-2212)

### DIFF
--- a/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
@@ -66,10 +66,12 @@ event_bus:
     - "onex.evt.omniintelligence.intent-classified.v1"
 
   # Topics this node publishes to (sends events to)
+  # NOTE: DLQ topic included here for publish_topic_metadata consistency
   publish_topics:
     - "onex.evt.omnimemory.intent-stored.v1"
+    - "onex.evt.omniintelligence.intent-classified.v1.dlq"
 
-  # Dead letter queue topics
+  # Dead letter queue topics (documentation; also listed in publish_topics)
   dlq_topics:
     - "onex.evt.omniintelligence.intent-classified.v1.dlq"
 
@@ -79,7 +81,6 @@ event_bus:
       schema_ref: "omnimemory.models.events.model_intent_classified_event.ModelIntentClassifiedEvent"
       description: "Intent classification events from omniintelligence. Contains classified intent data
         with confidence scores, session references, and classification metadata."
-      content_type: "application/json"
 
   # Metadata for published topics
   publish_topic_metadata:
@@ -87,12 +88,10 @@ event_bus:
       schema_ref: "omnibase_core.models.events.ModelIntentStoredEvent"
       description: "Intent storage confirmation events. Emitted after successfully persisting a classified
         intent to Memgraph. Uses status field to indicate success or error."
-      content_type: "application/json"
     "onex.evt.omniintelligence.intent-classified.v1.dlq":
       schema_ref: "omnimemory.models.events.model_intent_classified_event.ModelIntentClassifiedEvent"
       description: "Dead letter queue for intent-classified events that failed processing after max retries.
         Contains the original event plus error metadata."
-      content_type: "application/json"
 
 # === HANDLER CONFIGURATION ===
 handler_config:

--- a/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
@@ -31,6 +31,69 @@ event_type:
   publish_stored_topic_suffix: "onex.evt.omnimemory.intent-stored.v1"
   dlq_topic_suffix: "onex.evt.omniintelligence.intent-classified.v1.dlq"
 
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This is intentionally separate from event_type (above) which
+# documents WHAT events this node produces. Both are needed for Effect nodes:
+#   - event_type = documentation layer (WHAT)
+#   - event_bus = runtime routing layer (WHERE)
+#
+# Topic naming: onex.{kind}[.{producer}].{event-name}.v{n}
+#   - kind=cmd for commands/inputs
+#   - kind=evt for events/outputs
+#   - {producer} segment: REQUIRED for internal single-producer topics
+#   - {producer} segment: OMITTED for multi-producer business events
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives events from)
+  subscribe_topics:
+    - "onex.evt.omniintelligence.intent-classified.v1"
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.intent-stored.v1"
+
+  # Dead letter queue topics
+  dlq_topics:
+    - "onex.evt.omniintelligence.intent-classified.v1.dlq"
+
+  # Metadata for subscribed topics
+  subscribe_topic_metadata:
+    "onex.evt.omniintelligence.intent-classified.v1":
+      schema_ref: "omnimemory.models.events.model_intent_classified_event.ModelIntentClassifiedEvent"
+      description: "Intent classification events from omniintelligence. Contains classified intent data
+        with confidence scores, session references, and classification metadata."
+      content_type: "application/json"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.intent-stored.v1":
+      schema_ref: "omnibase_core.models.events.ModelIntentStoredEvent"
+      description: "Intent storage confirmation events. Emitted after successfully persisting a classified
+        intent to Memgraph. Uses status field to indicate success or error."
+      content_type: "application/json"
+    "onex.evt.omniintelligence.intent-classified.v1.dlq":
+      schema_ref: "omnimemory.models.events.model_intent_classified_event.ModelIntentClassifiedEvent"
+      description: "Dead letter queue for intent-classified events that failed processing after max retries.
+        Contains the original event plus error metadata."
+      content_type: "application/json"
+
 # === HANDLER CONFIGURATION ===
 handler_config:
   handler_class: "HandlerIntentEventConsumer"

--- a/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
@@ -49,10 +49,10 @@ event_type:
 #   - event_bus = runtime routing layer (WHERE)
 #
 # Topic naming: onex.{kind}[.{producer}].{event-name}.v{n}
-#   - kind=cmd for commands/inputs
-#   - kind=evt for events/outputs
-#   - {producer} segment: REQUIRED for internal single-producer topics
-#   - {producer} segment: OMITTED for multi-producer business events
+#   - kind=cmd for commands/inputs, kind=evt for events/outputs
+#   - producer=omnimemory for this node's topics
+#   - DLQ topics may use different producer segments (e.g., omniintelligence)
+#   - Internal runtime events use onex.internal.* namespace
 # =============================================================================
 event_bus:
   version:

--- a/src/omnimemory/nodes/intent_event_consumer_effect/models/model_consumer_config.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/models/model_consumer_config.py
@@ -9,6 +9,11 @@ class ModelIntentEventConsumerConfig(BaseModel):
 
     Note: consumer_group is NOT configured here. It is derived from
     ModelNodeIdentity via compute_consumer_group_id() per ADR.
+
+    Note: Topic suffix defaults MUST match the ``event_bus.subscribe_topics``,
+    ``event_bus.publish_topics``, and ``event_bus.dlq_topics`` declared in this
+    node's contract.yaml. The contract is the source of truth for topic
+    declarations.
     """
 
     model_config = ConfigDict(extra="forbid", strict=True)

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -172,6 +172,58 @@ handler_routing:
       output_events: []
   default_handler: null
 
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This is intentionally separate from event_type (above) which
+# documents WHAT events this node produces. Both are needed for Effect nodes:
+#   - event_type = documentation layer (WHAT)
+#   - event_bus = runtime routing layer (WHERE)
+#
+# Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=cmd for commands/inputs
+#   - kind=evt for events/outputs
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives events from)
+  subscribe_topics:
+    - "onex.cmd.omnimemory.intent-query-requested.v1"
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.intent-query-response.v1"
+
+  # Metadata for subscribed topics
+  subscribe_topic_metadata:
+    "onex.cmd.omnimemory.intent-query-requested.v1":
+      schema_ref: "omnibase_core.models.events.ModelIntentQueryRequestedEvent"
+      description: "Intent query request events containing query type, session reference, and filtering
+        parameters. Runtime dispatches inbound events to this node."
+      content_type: "application/json"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.intent-query-response.v1":
+      schema_ref: "omnibase_core.models.events.ModelIntentQueryResponseEvent"
+      description: "Intent query response events containing distribution data, intent records, or error
+        details based on the query type."
+      content_type: "application/json"
+
 # === TAGS ===
 tags:
   - intent

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -214,7 +214,6 @@ event_bus:
       schema_ref: "omnibase_core.models.events.ModelIntentQueryRequestedEvent"
       description: "Intent query request events containing query type, session reference, and filtering
         parameters. Runtime dispatches inbound events to this node."
-      content_type: "application/json"
 
   # Metadata for published topics
   publish_topic_metadata:
@@ -222,7 +221,6 @@ event_bus:
       schema_ref: "omnibase_core.models.events.ModelIntentQueryResponseEvent"
       description: "Intent query response events containing distribution data, intent records, or error
         details based on the query type."
-      content_type: "application/json"
 
 # === TAGS ===
 tags:

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -192,6 +192,7 @@ handler_routing:
 # Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
 #   - kind=cmd for commands/inputs
 #   - kind=evt for events/outputs
+#   - Internal runtime events use onex.internal.* namespace
 # =============================================================================
 event_bus:
   version:

--- a/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
@@ -247,6 +247,11 @@ class RegistryIntentQueryEffect:
             - dev.onex.cmd.omnimemory.intent-query-requested.v1
             - dev.onex.evt.omnimemory.intent-query-response.v1
 
+        Note:
+            These values MUST match the ``event_bus.subscribe_topics`` and
+            ``event_bus.publish_topics`` declared in this node's contract.yaml.
+            The contract is the source of truth for topic declarations.
+
         Returns:
             Dictionary with 'subscribe' and 'publish' topic suffixes.
 

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -157,6 +157,52 @@ handler_routing:
       output_events: []
   default_handler: null
 
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This node is orchestrator-invoked (not subscription-driven).
+# It publishes storage confirmation events but does not subscribe to topics.
+#
+# Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=evt for events/outputs
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # This node does not subscribe to topics (orchestrator-invoked)
+  subscribe_topics: []
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.intent-stored.v1"
+    - "onex.evt.omnimemory.intent-store-failed.v1"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.intent-stored.v1":
+      schema_ref: "omnimemory.nodes.intent_storage_effect.models.model_intent_storage_response.ModelIntentStorageResponse"
+      description: "Intent storage confirmation event. Emitted when an intent is successfully stored in
+        Memgraph with session linkage."
+      content_type: "application/json"
+    "onex.evt.omnimemory.intent-store-failed.v1":
+      schema_ref: "omnimemory.nodes.intent_storage_effect.models.model_intent_storage_response.ModelIntentStorageResponse"
+      description: "Intent storage failure event. Emitted when an intent storage operation fails with
+        error details."
+      content_type: "application/json"
+
 # === TAGS ===
 tags:
   - intent

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -196,12 +196,10 @@ event_bus:
       schema_ref: "omnimemory.nodes.intent_storage_effect.models.model_intent_storage_response.ModelIntentStorageResponse"
       description: "Intent storage confirmation event. Emitted when an intent is successfully stored in
         Memgraph with session linkage."
-      content_type: "application/json"
     "onex.evt.omnimemory.intent-store-failed.v1":
       schema_ref: "omnimemory.nodes.intent_storage_effect.models.model_intent_storage_response.ModelIntentStorageResponse"
       description: "Intent storage failure event. Emitted when an intent storage operation fails with
         error details."
-      content_type: "application/json"
 
 # === TAGS ===
 tags:

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -173,7 +173,9 @@ handler_routing:
 # It publishes storage confirmation events but does not subscribe to topics.
 #
 # Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=cmd for commands/inputs
 #   - kind=evt for events/outputs
+#   - Internal runtime events use onex.internal.* namespace
 # =============================================================================
 event_bus:
   version:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -39,13 +39,12 @@
 #   - ModelRestoreMemoryCommand -> HandlerRestoreMemory (ARCHIVED -> ACTIVE)
 #   - ModelMemoryAccessedEvent -> HandlerMemoryAccessed (TTL extension tracking)
 #
-# Published Event Topics:
-#   - {env}.{namespace}.memory.evt.memory-expired.v1
-#   - {env}.{namespace}.memory.evt.memory-archived.v1
-#   - {env}.{namespace}.memory.evt.memory-archive-initiated.v1
-#   - {env}.{namespace}.memory.evt.memory-restored.v1
-#   - {env}.{namespace}.memory.evt.memory-consolidated.v1
-#   - {env}.{namespace}.memory.evt.lifecycle-transition-failed.v1
+# Published Event Topics (ONEX canonical naming):
+#   - {env}.onex.evt.omnimemory.memory-expired.v1
+#   - {env}.onex.evt.omnimemory.memory-archived.v1
+#   - {env}.onex.evt.omnimemory.memory-archive-initiated.v1
+#   - {env}.onex.evt.omnimemory.memory-restored.v1
+#   - {env}.onex.evt.omnimemory.lifecycle-transition-failed.v1
 # =============================================================================
 
 contract_version:
@@ -103,23 +102,24 @@ tags:
 author: "OmniNode Team"
 
 # Consumed events - follows ModelEventSubscription schema
+# Topic names follow ONEX canonical naming: onex.{cmd/evt}.omnimemory.{action}.v{N}
 consumed_events:
   # RuntimeTick - Periodic lifecycle evaluation trigger
   - event_pattern: "onex.internal.runtime-tick.v1"
     handler_function: "handle_runtime_tick"
 
   # Memory lifecycle command events
-  - event_pattern: "memory.cmd.archive-memory.v1"
+  - event_pattern: "onex.cmd.omnimemory.archive-memory.v1"
     handler_function: "handle_archive_memory"
 
-  - event_pattern: "memory.cmd.expire-memory.v1"
+  - event_pattern: "onex.cmd.omnimemory.expire-memory.v1"
     handler_function: "handle_expire_memory"
 
-  - event_pattern: "memory.cmd.restore-memory.v1"
+  - event_pattern: "onex.cmd.omnimemory.restore-memory.v1"
     handler_function: "handle_restore_memory"
 
   # Memory access events for lifecycle tracking
-  - event_pattern: "memory.evt.memory-accessed.v1"
+  - event_pattern: "onex.evt.omnimemory.memory-accessed.v1"
     handler_function: "handle_memory_accessed"
 
 # Published events - empty list since ModelEventDescriptor requires complex
@@ -162,6 +162,104 @@ handler_routing:
       output_events: []
   # Future handlers (OMN-1453): restore, memory-accessed
   default_handler: null
+
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This is intentionally separate from consumed_events/published_events
+# (above) which documents WHAT events this node handles. Both are needed:
+#   - consumed_events/published_events = documentation layer (WHAT)
+#   - event_bus = runtime routing layer (WHERE)
+#
+# Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=cmd for commands/inputs
+#   - kind=evt for events/outputs
+#   - Internal runtime events use onex.internal.* namespace
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives events from)
+  subscribe_topics:
+    - "onex.internal.runtime-tick.v1"
+    - "onex.cmd.omnimemory.archive-memory.v1"
+    - "onex.cmd.omnimemory.expire-memory.v1"
+    - "onex.cmd.omnimemory.restore-memory.v1"
+    - "onex.evt.omnimemory.memory-accessed.v1"
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.memory-expired.v1"
+    - "onex.evt.omnimemory.memory-archived.v1"
+    - "onex.evt.omnimemory.memory-archive-initiated.v1"
+    - "onex.evt.omnimemory.memory-restored.v1"
+    - "onex.evt.omnimemory.lifecycle-transition-failed.v1"
+
+  # Metadata for subscribed topics
+  subscribe_topic_metadata:
+    "onex.internal.runtime-tick.v1":
+      schema_ref: "omnibase_core.models.runtime.ModelRuntimeTick"
+      description: "Periodic runtime tick for TTL expiration evaluation. Injected timestamp enables deterministic
+        lifecycle checks."
+      content_type: "application/json"
+    "onex.cmd.omnimemory.archive-memory.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelArchiveMemoryCommand"
+      description: "Command to transition an EXPIRED memory to ARCHIVED state in cold storage."
+      content_type: "application/json"
+    "onex.cmd.omnimemory.expire-memory.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelExpireMemoryCommand"
+      description: "Command to explicitly transition an ACTIVE memory to EXPIRED state."
+      content_type: "application/json"
+    "onex.cmd.omnimemory.restore-memory.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelRestoreMemoryCommand"
+      description: "Command to restore an ARCHIVED memory back to ACTIVE state."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-accessed.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryAccessedEvent"
+      description: "Memory access event for TTL extension tracking. Resets or extends memory TTL based
+        on access patterns."
+      content_type: "application/json"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.memory-expired.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick.ModelMemoryExpiredEvent"
+      description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
+        from ACTIVE to EXPIRED state."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-archived.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
+      description: "Memory archival confirmation event. Emitted when a memory is successfully moved from
+        EXPIRED to ARCHIVED state in cold storage."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-archive-initiated.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
+      description: "Memory archive initiation event. Emitted when an archive operation begins for an expired
+        memory entity."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-restored.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryRestoredEvent"
+      description: "Memory restoration confirmation event. Emitted when a memory is successfully restored
+        from ARCHIVED to ACTIVE state."
+      content_type: "application/json"
+    "onex.evt.omnimemory.lifecycle-transition-failed.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
+      description: "Lifecycle transition failure event. Emitted when a lifecycle state transition fails
+        with error details and the attempted transition."
+      content_type: "application/json"
 
 # Orchestration configuration - use defaults
 load_balancing_enabled: true

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -45,6 +45,9 @@
 #   - {env}.onex.evt.omnimemory.memory-archive-initiated.v1
 #   - {env}.onex.evt.omnimemory.memory-restored.v1
 #   - {env}.onex.evt.omnimemory.lifecycle-transition-failed.v1
+#
+# NOTE: memory-consolidated.v1 removed — consolidation is not a lifecycle
+# state transition. If needed, it belongs in a separate consolidation node.
 # =============================================================================
 
 contract_version:
@@ -215,15 +218,17 @@ event_bus:
       description: "Periodic runtime tick for TTL expiration evaluation. Injected timestamp enables deterministic
         lifecycle checks."
     "onex.cmd.omnimemory.archive-memory.v1":
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelArchiveMemoryCommand"
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_archive.ModelArchiveMemoryCommand"
       description: "Command to transition an EXPIRED memory to ARCHIVED state in cold storage."
     "onex.cmd.omnimemory.expire-memory.v1":
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelExpireMemoryCommand"
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire.ModelExpireMemoryCommand"
       description: "Command to explicitly transition an ACTIVE memory to EXPIRED state."
     "onex.cmd.omnimemory.restore-memory.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelRestoreMemoryCommand"
       description: "Command to restore an ARCHIVED memory back to ACTIVE state."
     "onex.evt.omnimemory.memory-accessed.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryAccessedEvent"
       description: "Memory access event for TTL extension tracking. Resets or extends memory TTL based
         on access patterns."
@@ -235,18 +240,22 @@ event_bus:
       description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
         from ACTIVE to EXPIRED state."
     "onex.evt.omnimemory.memory-archived.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
       description: "Memory archival confirmation event. Emitted when a memory is successfully moved from
         EXPIRED to ARCHIVED state in cold storage."
     "onex.evt.omnimemory.memory-archive-initiated.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
       description: "Memory archive initiation event. Emitted when an archive operation begins for an expired
         memory entity."
     "onex.evt.omnimemory.memory-restored.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryRestoredEvent"
       description: "Memory restoration confirmation event. Emitted when a memory is successfully restored
         from ARCHIVED to ACTIVE state."
     "onex.evt.omnimemory.lifecycle-transition-failed.v1":
+      # TODO(OMN-1453): Forward-declared — model not yet implemented
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
       description: "Lifecycle transition failure event. Emitted when a lifecycle state transition fails
         with error details and the attempted transition."

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -214,24 +214,19 @@ event_bus:
       schema_ref: "omnibase_core.models.runtime.ModelRuntimeTick"
       description: "Periodic runtime tick for TTL expiration evaluation. Injected timestamp enables deterministic
         lifecycle checks."
-      content_type: "application/json"
     "onex.cmd.omnimemory.archive-memory.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelArchiveMemoryCommand"
       description: "Command to transition an EXPIRED memory to ARCHIVED state in cold storage."
-      content_type: "application/json"
     "onex.cmd.omnimemory.expire-memory.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelExpireMemoryCommand"
       description: "Command to explicitly transition an ACTIVE memory to EXPIRED state."
-      content_type: "application/json"
     "onex.cmd.omnimemory.restore-memory.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelRestoreMemoryCommand"
       description: "Command to restore an ARCHIVED memory back to ACTIVE state."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-accessed.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryAccessedEvent"
       description: "Memory access event for TTL extension tracking. Resets or extends memory TTL based
         on access patterns."
-      content_type: "application/json"
 
   # Metadata for published topics
   publish_topic_metadata:
@@ -239,27 +234,22 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick.ModelMemoryExpiredEvent"
       description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
         from ACTIVE to EXPIRED state."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-archived.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
       description: "Memory archival confirmation event. Emitted when a memory is successfully moved from
         EXPIRED to ARCHIVED state in cold storage."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-archive-initiated.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
       description: "Memory archive initiation event. Emitted when an archive operation begins for an expired
         memory entity."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-restored.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryRestoredEvent"
       description: "Memory restoration confirmation event. Emitted when a memory is successfully restored
         from ARCHIVED to ACTIVE state."
-      content_type: "application/json"
     "onex.evt.omnimemory.lifecycle-transition-failed.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
       description: "Lifecycle transition failure event. Emitted when a lifecycle state transition fails
         with error details and the attempted transition."
-      content_type: "application/json"
 
 # Orchestration configuration - use defaults
 load_balancing_enabled: true

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -163,7 +163,8 @@ handler_routing:
       handler_key: "HandlerMemoryArchive"
       priority: 0
       output_events: []
-  # Future handlers (OMN-1453): restore, memory-accessed
+  # NOTE: restore and memory-accessed handlers planned for OMN-1453
+  # Their event_bus topics will be added when handlers are implemented
   default_handler: null
 
 # =============================================================================
@@ -200,16 +201,10 @@ event_bus:
     - "onex.internal.runtime-tick.v1"
     - "onex.cmd.omnimemory.archive-memory.v1"
     - "onex.cmd.omnimemory.expire-memory.v1"
-    - "onex.cmd.omnimemory.restore-memory.v1"
-    - "onex.evt.omnimemory.memory-accessed.v1"
 
   # Topics this node publishes to (sends events to)
   publish_topics:
     - "onex.evt.omnimemory.memory-expired.v1"
-    - "onex.evt.omnimemory.memory-archived.v1"
-    - "onex.evt.omnimemory.memory-archive-initiated.v1"
-    - "onex.evt.omnimemory.memory-restored.v1"
-    - "onex.evt.omnimemory.lifecycle-transition-failed.v1"
 
   # Metadata for subscribed topics
   subscribe_topic_metadata:
@@ -223,15 +218,6 @@ event_bus:
     "onex.cmd.omnimemory.expire-memory.v1":
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire.ModelExpireMemoryCommand"
       description: "Command to explicitly transition an ACTIVE memory to EXPIRED state."
-    "onex.cmd.omnimemory.restore-memory.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelRestoreMemoryCommand"
-      description: "Command to restore an ARCHIVED memory back to ACTIVE state."
-    "onex.evt.omnimemory.memory-accessed.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryAccessedEvent"
-      description: "Memory access event for TTL extension tracking. Resets or extends memory TTL based
-        on access patterns."
 
   # Metadata for published topics
   publish_topic_metadata:
@@ -239,26 +225,6 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick.ModelMemoryExpiredEvent"
       description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
         from ACTIVE to EXPIRED state."
-    "onex.evt.omnimemory.memory-archived.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
-      description: "Memory archival confirmation event. Emitted when a memory is successfully moved from
-        EXPIRED to ARCHIVED state in cold storage."
-    "onex.evt.omnimemory.memory-archive-initiated.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"  # TODO(OMN-1453): Needs its own model (e.g., ModelMemoryArchiveInitiatedEvent)
-      description: "Memory archive initiation event. Emitted when an archive operation begins for an expired
-        memory entity."
-    "onex.evt.omnimemory.memory-restored.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryRestoredEvent"
-      description: "Memory restoration confirmation event. Emitted when a memory is successfully restored
-        from ARCHIVED to ACTIVE state."
-    "onex.evt.omnimemory.lifecycle-transition-failed.v1":
-      # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
-      description: "Lifecycle transition failure event. Emitted when a lifecycle state transition fails
-        with error details and the attempted transition."
 
 # Orchestration configuration - use defaults
 load_balancing_enabled: true

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -64,7 +64,7 @@ name: "memory_lifecycle_orchestrator"
 node_type: "ORCHESTRATOR_GENERIC"
 description: >-
   Memory lifecycle orchestrator that manages expiration, archival, and cleanup of memory entities based
-  on configurable TTL and retention policies. #magic___^_^___line
+  on configurable TTL and retention policies.
 # Model specifications - fully qualified class names
 input_model: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleOrchestratorInput"
 output_model: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleOrchestratorOutput"
@@ -214,7 +214,7 @@ event_bus:
   # Metadata for subscribed topics
   subscribe_topic_metadata:
     "onex.internal.runtime-tick.v1":
-      schema_ref: "omnibase_core.models.runtime.ModelRuntimeTick"
+      schema_ref: "omnibase_infra.runtime.models.model_runtime_tick.ModelRuntimeTick"
       description: "Periodic runtime tick for TTL expiration evaluation. Injected timestamp enables deterministic
         lifecycle checks."
     "onex.cmd.omnimemory.archive-memory.v1":
@@ -246,7 +246,7 @@ event_bus:
         EXPIRED to ARCHIVED state in cold storage."
     "onex.evt.omnimemory.memory-archive-initiated.v1":
       # TODO(OMN-1453): Forward-declared — model not yet implemented
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"  # TODO(OMN-1453): Needs its own model (e.g., ModelMemoryArchiveInitiatedEvent)
       description: "Memory archive initiation event. Emitted when an archive operation begins for an expired
         memory entity."
     "onex.evt.omnimemory.memory-restored.v1":

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -120,6 +120,7 @@ event_type:
   event_categories: ["memory", "effect", "retrieval", "search"]
   publish_events: true
   subscribe_events: true
+  invocation_mode: "subscription"
   event_routing: "memory"
 
 # === INFRASTRUCTURE ===

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -173,6 +173,57 @@ handler_routing:
       output_events: []
   default_handler: "HandlerMemoryRetrieval"
 
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This node supports both orchestrator invocation and subscription mode.
+# When subscription-driven, it listens for retrieval request commands and
+# publishes response events.
+#
+# Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=cmd for commands/inputs
+#   - kind=evt for events/outputs
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives events from)
+  subscribe_topics:
+    - "onex.cmd.omnimemory.memory-retrieval-requested.v1"
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.memory-retrieval-response.v1"
+
+  # Metadata for subscribed topics
+  subscribe_topic_metadata:
+    "onex.cmd.omnimemory.memory-retrieval-requested.v1":
+      schema_ref: "omnimemory.nodes.memory_retrieval_effect.models.model_memory_retrieval_request.ModelMemoryRetrievalRequest"
+      description: "Memory retrieval request events containing search parameters including query text,
+        embeddings, similarity thresholds, and backend selection."
+      content_type: "application/json"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.memory-retrieval-response.v1":
+      schema_ref: "omnimemory.nodes.memory_retrieval_effect.models.model_memory_retrieval_response.ModelMemoryRetrievalResponse"
+      description: "Memory retrieval response events containing search results with similarity scores,
+        total counts, and metadata from the queried backends."
+      content_type: "application/json"
+
 # === TAGS ===
 tags:
   - memory

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -192,6 +192,7 @@ handler_routing:
 # Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
 #   - kind=cmd for commands/inputs
 #   - kind=evt for events/outputs
+#   - Internal runtime events use onex.internal.* namespace
 # =============================================================================
 event_bus:
   version:

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -119,7 +119,7 @@ event_type:
   primary_events: ["memory_searched", "memory_retrieved", "graph_traversed"]
   event_categories: ["memory", "effect", "retrieval", "search"]
   publish_events: true
-  subscribe_events: false
+  subscribe_events: true
   event_routing: "memory"
 
 # === INFRASTRUCTURE ===
@@ -214,7 +214,6 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_retrieval_effect.models.model_memory_retrieval_request.ModelMemoryRetrievalRequest"
       description: "Memory retrieval request events containing search parameters including query text,
         embeddings, similarity thresholds, and backend selection."
-      content_type: "application/json"
 
   # Metadata for published topics
   publish_topic_metadata:
@@ -222,7 +221,6 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_retrieval_effect.models.model_memory_retrieval_response.ModelMemoryRetrievalResponse"
       description: "Memory retrieval response events containing search results with similarity scores,
         total counts, and metadata from the queried backends."
-      content_type: "application/json"
 
 # === TAGS ===
 tags:

--- a/src/omnimemory/nodes/memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_storage_effect/contract.yaml
@@ -214,22 +214,18 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
       description: "Memory storage confirmation event. Emitted when a memory snapshot is successfully
         persisted to the storage backend."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-retrieved.v1":
       schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
       description: "Memory retrieval confirmation event. Emitted when a memory snapshot is successfully
         retrieved from the storage backend."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-updated.v1":
       schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
       description: "Memory update confirmation event. Emitted when a memory snapshot is successfully updated
         in the storage backend."
-      content_type: "application/json"
     "onex.evt.omnimemory.memory-deleted.v1":
       schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
       description: "Memory deletion confirmation event. Emitted when a memory snapshot is successfully
         soft-deleted from the storage backend."
-      content_type: "application/json"
 
 # === TAGS ===
 tags:

--- a/src/omnimemory/nodes/memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_storage_effect/contract.yaml
@@ -189,7 +189,9 @@ validation_rules:
 # It publishes CRUD operation events but does not subscribe to topics.
 #
 # Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=cmd for commands/inputs
 #   - kind=evt for events/outputs
+#   - Internal runtime events use onex.internal.* namespace
 # =============================================================================
 event_bus:
   version:

--- a/src/omnimemory/nodes/memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_storage_effect/contract.yaml
@@ -173,6 +173,64 @@ validation_rules:
     metadata: "dict type for additional operation metadata"
     tags: "list of strings for filtering operations"
 
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# Contains: topic suffixes (simple strings) + optional schema references.
+#
+# NOTE: This node is orchestrator-invoked (not subscription-driven).
+# It publishes CRUD operation events but does not subscribe to topics.
+#
+# Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
+#   - kind=evt for events/outputs
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # This node does not subscribe to topics (orchestrator-invoked)
+  subscribe_topics: []
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.memory-stored.v1"
+    - "onex.evt.omnimemory.memory-retrieved.v1"
+    - "onex.evt.omnimemory.memory-updated.v1"
+    - "onex.evt.omnimemory.memory-deleted.v1"
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.memory-stored.v1":
+      schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
+      description: "Memory storage confirmation event. Emitted when a memory snapshot is successfully
+        persisted to the storage backend."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-retrieved.v1":
+      schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
+      description: "Memory retrieval confirmation event. Emitted when a memory snapshot is successfully
+        retrieved from the storage backend."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-updated.v1":
+      schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
+      description: "Memory update confirmation event. Emitted when a memory snapshot is successfully updated
+        in the storage backend."
+      content_type: "application/json"
+    "onex.evt.omnimemory.memory-deleted.v1":
+      schema_ref: "omnimemory.nodes.memory_storage_effect.models.model_memory_storage_response.ModelMemoryStorageResponse"
+      description: "Memory deletion confirmation event. Emitted when a memory snapshot is successfully
+        soft-deleted from the storage backend."
+      content_type: "application/json"
+
 # === TAGS ===
 tags:
   - memory


### PR DESCRIPTION
## Summary

- Add `event_bus` section (subscribe_topics, publish_topics, topic metadata) to all 6 omnimemory effect/orchestrator node contracts
- Use ONEX canonical topic naming: `onex.{cmd/evt}.omnimemory.{action}.v1`
- Include schema refs in topic metadata and DLQ declaration for intent_event_consumer_effect
- Add cross-reference docstrings in 2 Python files linking runtime topic suffixes to contract declarations

## Contracts Updated

| Node | Subscribe | Publish |
|------|-----------|---------|
| intent_storage_effect | — | 2 topics |
| intent_query_effect | 1 topic | 1 topic |
| intent_event_consumer_effect | 1 topic | 1 topic + 1 DLQ |
| memory_storage_effect | — | 4 topics |
| memory_retrieval_effect | 1 topic | 1 topic |
| memory_lifecycle_orchestrator | 5 topics | 5 topics |

## Test plan

- [x] All 1529 tests pass (157 skipped, 0 failures)
- [x] All pre-commit hooks pass (yamlfmt, ruff, ONEX validators)
- [x] YAML syntax validated
- [x] Topic names validated against ONEX canonical naming convention
- [x] Cross-contract consistency verified (metadata keys match topic lists)

Closes OMN-2212
Subsumes OMN-1538, OMN-1746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a runtime "event bus" routing configuration across multiple nodes.
  * Added explicit handler dependency declarations for required runtime integrations.

* **Chores**
  * Standardized canonical topic naming and expanded publish/subscribe coverage across memory components.
  * Added monitoring, metrics, load‑balancing and failure‑isolation toggles for routing.

* **Documentation**
  * Clarified contract-based topic declarations as the source of truth and updated docstrings/notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->