### PR TITLE
feat(runtime): Add contract-driven topic discovery (OMN-2213)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ detect-secrets = "^1.5.0"
 # Development utilities
 memory-profiler = "^0.61.0"
 docker = "^7.1.0"
+types-pyyaml = "^6.0.12.20250915"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
@@ -26,10 +26,9 @@ event_type:
   subscribe_events: true
   event_routing: "intent"
   invocation_mode: "subscription"
-  # Custom topic fields (extensions to standard subcontract)
-  subscribe_topic_suffix: "onex.evt.omniintelligence.intent-classified.v1"
-  publish_stored_topic_suffix: "onex.evt.omnimemory.intent-stored.v1"
-  dlq_topic_suffix: "onex.evt.omniintelligence.intent-classified.v1.dlq"
+  # NOTE: Topic declarations live in the event_bus section below (source of truth).
+  # Formerly had subscribe_topic_suffix / publish_stored_topic_suffix /
+  # dlq_topic_suffix here -- removed per OMN-2213.
 
 # =============================================================================
 # EVENT BUS SUBCONTRACT - Runtime Routing Layer

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -117,9 +117,8 @@ event_type:
   subscribe_events: true
   event_routing: "intent"
   invocation_mode: "subscription"  # vs "orchestrator" - explicit per contract checklist
-  # Topic suffixes - runtime adds env prefix (e.g., "dev.", "prod.")
-  subscribe_topic_suffix: "onex.cmd.omnimemory.intent-query-requested.v1"
-  publish_topic_suffix: "onex.evt.omnimemory.intent-query-response.v1"
+  # NOTE: Topic declarations live in the event_bus section below (source of truth).
+  # Formerly had subscribe_topic_suffix / publish_topic_suffix here -- removed per OMN-2213.
 
 # === INFRASTRUCTURE ===
 infrastructure:

--- a/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/__init__.py
@@ -5,15 +5,11 @@
 Provides factory methods and metadata for the intent_query_effect node,
 following ONEX registry patterns for dependency injection and service discovery.
 
-Topic Naming:
-    This node uses topic SUFFIXES (not full topics). Runtime composes
-    full topics by adding env prefix::
-
-        full_topic = f"{topic_env_prefix}.{suffix}"
-
-    Example with "dev" env prefix:
-        - dev.onex.cmd.omnimemory.intent-query-requested.v1
-        - dev.onex.evt.omnimemory.intent-query-response.v1
+Topic Discovery:
+    Topics are declared in this node's ``contract.yaml`` (``event_bus`` section)
+    and discovered at runtime via ``omnimemory.runtime.contract_topics``.
+    See ``collect_subscribe_topics_from_contracts()`` and
+    ``collect_publish_topics_for_dispatch()`` for contract-driven topic discovery.
 
 Example::
 
@@ -26,11 +22,12 @@ Example::
 
     # Query node metadata
     node_type = RegistryIntentQueryEffect.get_node_type()  # "EFFECT"
-    suffixes = RegistryIntentQueryEffect.get_topic_suffixes()
-    # {"subscribe": "onex.cmd...", "publish": "onex.evt..."}
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1504.
+
+.. versionchanged:: 0.3.0
+    Removed get_topic_suffixes() -- topics are now contract-driven (OMN-2213).
 """
 
 from omnimemory.nodes.intent_query_effect.registry.registry_intent_query_effect import (

--- a/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
+++ b/src/omnimemory/nodes/intent_query_effect/registry/registry_intent_query_effect.py
@@ -236,33 +236,6 @@ class RegistryIntentQueryEffect:
         return ["distribution", "session", "recent"]
 
     @staticmethod
-    def get_topic_suffixes() -> dict[str, str]:
-        """Get Kafka topic suffixes for this node.
-
-        Returns topic SUFFIXES (not full topics). Runtime composes
-        full topics by adding env prefix:
-            full_topic = f"{topic_env_prefix}.{suffix}"
-
-        Example full topics (with "dev" env prefix):
-            - dev.onex.cmd.omnimemory.intent-query-requested.v1
-            - dev.onex.evt.omnimemory.intent-query-response.v1
-
-        Note:
-            These values MUST match the ``event_bus.subscribe_topics`` and
-            ``event_bus.publish_topics`` declared in this node's contract.yaml.
-            The contract is the source of truth for topic declarations.
-
-        Returns:
-            Dictionary with 'subscribe' and 'publish' topic suffixes.
-
-        .. versionadded:: 0.1.0
-        """
-        return {
-            "subscribe": "onex.cmd.omnimemory.intent-query-requested.v1",
-            "publish": "onex.evt.omnimemory.intent-query-response.v1",
-        }
-
-    @staticmethod
     def get_invocation_mode() -> str:
         """Get the invocation mode for this node.
 

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""OmniMemory Runtime Package.
+
+Provides contract-driven topic discovery for the OmniMemory domain.
+
+This package contains:
+    - collect_subscribe_topics_from_contracts: Discover subscribe topics from
+      effect node contract.yaml files.
+    - collect_publish_topics_for_dispatch: Discover publish topics keyed by
+      dispatch alias from effect node contract.yaml files.
+    - canonical_topic_to_dispatch_alias: Convert ONEX canonical topic naming
+      to dispatch engine format.
+
+Usage:
+    from omnimemory.runtime.contract_topics import (
+        collect_subscribe_topics_from_contracts,
+        collect_publish_topics_for_dispatch,
+        canonical_topic_to_dispatch_alias,
+    )
+
+    # Get all subscribe topics declared across omnimemory effect nodes
+    topics = collect_subscribe_topics_from_contracts()
+
+    # Get publish topics keyed by dispatch alias
+    publish_map = collect_publish_topics_for_dispatch()
+"""
+
+from omnimemory.runtime.contract_topics import (
+    canonical_topic_to_dispatch_alias,
+    collect_publish_topics_for_dispatch,
+    collect_subscribe_topics_from_contracts,
+)
+
+__all__ = [
+    "canonical_topic_to_dispatch_alias",
+    "collect_publish_topics_for_dispatch",
+    "collect_subscribe_topics_from_contracts",
+]

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -9,6 +9,8 @@ This package contains:
       effect node contract.yaml files.
     - collect_publish_topics_for_dispatch: Discover publish topics keyed by
       dispatch alias from effect node contract.yaml files.
+    - collect_all_publish_topics: Discover all publish topics declared across
+      effect node contract.yaml files.
     - canonical_topic_to_dispatch_alias: Convert ONEX canonical topic naming
       to dispatch engine format.
 
@@ -16,6 +18,7 @@ Usage:
     from omnimemory.runtime.contract_topics import (
         collect_subscribe_topics_from_contracts,
         collect_publish_topics_for_dispatch,
+        collect_all_publish_topics,
         canonical_topic_to_dispatch_alias,
     )
 
@@ -24,16 +27,21 @@ Usage:
 
     # Get publish topics keyed by dispatch alias
     publish_map = collect_publish_topics_for_dispatch()
+
+    # Get all publish topics (full list, not just first per node)
+    all_publish = collect_all_publish_topics()
 """
 
 from omnimemory.runtime.contract_topics import (
     canonical_topic_to_dispatch_alias,
+    collect_all_publish_topics,
     collect_publish_topics_for_dispatch,
     collect_subscribe_topics_from_contracts,
 )
 
 __all__ = [
     "canonical_topic_to_dispatch_alias",
+    "collect_all_publish_topics",
     "collect_publish_topics_for_dispatch",
     "collect_subscribe_topics_from_contracts",
 ]

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
-from typing import Any
 
 import yaml
 
@@ -229,7 +228,7 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
     package_files = importlib.resources.files(package)
     contract_file = package_files.joinpath("contract.yaml")
     content = contract_file.read_text()
-    contract: Any = yaml.safe_load(content)
+    contract: object = yaml.safe_load(content)
 
     if not isinstance(contract, dict):
         logger.warning(
@@ -239,7 +238,7 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
         )
         return []
 
-    event_bus = contract.get("event_bus", {})
+    event_bus: object = contract.get("event_bus", {})
     if not isinstance(event_bus, dict):
         logger.warning(
             "event_bus in %s contract.yaml is not a mapping (got %s), skipping",
@@ -251,7 +250,23 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
     if not event_bus.get("event_bus_enabled", False):
         return []
 
-    topics: list[str] = event_bus.get(field, [])
+    topics_raw: object = event_bus.get(field, [])
+    if not isinstance(topics_raw, list):
+        logger.warning(
+            "%s in %s contract.yaml is not a list, skipping",
+            field,
+            package,
+        )
+        return []
+
+    topics: list[str] = [t for t in topics_raw if isinstance(t, str)]
+    if len(topics) != len(topics_raw):
+        logger.warning(
+            "%s in %s contract.yaml contains non-string entries, skipping invalid items",
+            field,
+            package,
+        )
+
     if topics:
         logger.debug(
             "Discovered %s from %s: %s",

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Contract-driven topic discovery for the OmniMemory domain.
+
+Reads ``event_bus.subscribe_topics`` and ``event_bus.publish_topics`` from
+omnimemory node ``contract.yaml`` files and returns the collected lists.
+This replaces formerly-hardcoded topic constants (e.g.
+``RegistryIntentQueryEffect.get_topic_suffixes()``).
+
+Design decisions:
+    - Topics are declared in each node's contract.yaml (source of truth).
+    - This module reads those contracts via ``importlib.resources`` (ONEX I/O
+      audit compliant -- package resource reads, not arbitrary filesystem I/O).
+    - The module also provides ``canonical_topic_to_dispatch_alias`` to convert
+      ONEX canonical topic naming (``.cmd.`` / ``.evt.``) to the dispatch engine
+      format (``.commands.`` / ``.events.``).
+
+Related:
+    - OMN-2213: Phase 2 -- Contract-driven topic discovery for omnimemory
+    - OMN-2033: Reference implementation in omniintelligence
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import logging
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Node packages that declare event_bus topics
+# ============================================================================
+# All omnimemory nodes with ``event_bus.event_bus_enabled: true`` in their
+# contract.yaml. Both effect nodes and orchestrator nodes are included since
+# the memory_lifecycle_orchestrator also subscribes to Kafka topics.
+
+_OMNIMEMORY_EVENT_BUS_NODE_PACKAGES: list[str] = [
+    "omnimemory.nodes.intent_event_consumer_effect",
+    "omnimemory.nodes.intent_query_effect",
+    "omnimemory.nodes.intent_storage_effect",
+    "omnimemory.nodes.memory_retrieval_effect",
+    "omnimemory.nodes.memory_storage_effect",
+    "omnimemory.nodes.memory_lifecycle_orchestrator",
+]
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+
+def collect_subscribe_topics_from_contracts(
+    *,
+    node_packages: list[str] | None = None,
+) -> list[str]:
+    """Collect subscribe topics from omnimemory node contracts.
+
+    Scans ``contract.yaml`` files from omnimemory nodes and extracts
+    ``event_bus.subscribe_topics`` from each enabled node.  Returns the union
+    of all topics in package-declaration order.
+
+    This is the single replacement for formerly-hardcoded topic constants
+    such as ``RegistryIntentQueryEffect.get_topic_suffixes()["subscribe"]``.
+
+    Args:
+        node_packages: Override list of node packages to scan.  Defaults to
+            the built-in omnimemory event bus nodes.
+
+    Returns:
+        Ordered list of subscribe topic strings.
+
+    Raises:
+        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
+        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
+    """
+    packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+    all_topics: list[str] = []
+
+    for package in packages:
+        topics = _read_subscribe_topics(package)
+        all_topics.extend(topics)
+
+    logger.debug(
+        "Collected %d omnimemory subscribe topics from %d contracts",
+        len(all_topics),
+        len(packages),
+    )
+
+    return all_topics
+
+
+def collect_publish_topics_for_dispatch(
+    *,
+    node_packages: list[str] | None = None,
+) -> dict[str, str]:
+    """Collect publish topics from contracts and map to dispatch engine keys.
+
+    Reads ``event_bus.publish_topics`` from omnimemory node contracts
+    and returns a dict mapping dispatch keys to topic strings.
+
+    The dispatch key is derived from the package name by stripping the
+    ``omnimemory.nodes.`` prefix and any trailing ``_effect`` /
+    ``_orchestrator`` suffix.  For example:
+        - ``omnimemory.nodes.intent_query_effect`` -> ``"intent_query"``
+        - ``omnimemory.nodes.memory_lifecycle_orchestrator`` -> ``"memory_lifecycle"``
+
+    Only the first publish topic per contract is used in the returned dict.
+    Use ``collect_all_publish_topics()`` if you need the full list.
+
+    Args:
+        node_packages: Override list of node packages to scan.  Defaults to
+            the built-in omnimemory event bus nodes.
+
+    Returns:
+        Dict mapping dispatch key to first publish topic string.
+        Empty dict if no publish topics are declared.
+    """
+    packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+    result: dict[str, str] = {}
+
+    for package in packages:
+        topics = _read_publish_topics(package)
+        if topics:
+            key = _derive_dispatch_key(package)
+            result[key] = topics[0]
+
+    logger.debug(
+        "Collected %d publish topics for dispatch engine: %s",
+        len(result),
+        result,
+    )
+
+    return result
+
+
+def collect_all_publish_topics(
+    *,
+    node_packages: list[str] | None = None,
+) -> list[str]:
+    """Collect all publish topics from omnimemory node contracts.
+
+    Unlike ``collect_publish_topics_for_dispatch`` which returns only the
+    first topic per node, this function returns every publish topic declared
+    across all contracts.
+
+    Args:
+        node_packages: Override list of node packages to scan.  Defaults to
+            the built-in omnimemory event bus nodes.
+
+    Returns:
+        Ordered list of all publish topic strings.
+    """
+    packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+    all_topics: list[str] = []
+
+    for package in packages:
+        topics = _read_publish_topics(package)
+        all_topics.extend(topics)
+
+    return all_topics
+
+
+def canonical_topic_to_dispatch_alias(topic: str) -> str:
+    """Convert ONEX canonical topic naming to dispatch engine format.
+
+    ONEX canonical naming uses ``.cmd.`` for commands and ``.evt.`` for
+    events.  ``MessageDispatchEngine`` expects ``.commands.`` and
+    ``.events.`` segments.  This function bridges the naming gap.
+
+    Args:
+        topic: Canonical topic string (e.g.
+            ``onex.cmd.omnimemory.intent-query-requested.v1``).
+
+    Returns:
+        Dispatch-compatible topic string (e.g.
+            ``onex.commands.omnimemory.intent-query-requested.v1``).
+    """
+    return topic.replace(".cmd.", ".commands.").replace(".evt.", ".events.")
+
+
+# ============================================================================
+# Internal helpers
+# ============================================================================
+
+
+def _derive_dispatch_key(package: str) -> str:
+    """Derive a dispatch key from a fully-qualified node package path.
+
+    Strips ``omnimemory.nodes.`` prefix and common suffixes
+    (``_effect``, ``_orchestrator``, ``_compute``, ``_reducer``).
+
+    Args:
+        package: Fully-qualified Python package path.
+
+    Returns:
+        Short dispatch key string.
+
+    Examples:
+        >>> _derive_dispatch_key("omnimemory.nodes.intent_query_effect")
+        'intent_query'
+        >>> _derive_dispatch_key("omnimemory.nodes.memory_lifecycle_orchestrator")
+        'memory_lifecycle'
+    """
+    tail = package.rsplit(".", 1)[-1]
+    for suffix in ("_effect", "_orchestrator", "_compute", "_reducer"):
+        if tail.endswith(suffix):
+            tail = tail[: -len(suffix)]
+            break
+    return tail
+
+
+def _read_event_bus_topics(package: str, field: str) -> list[str]:
+    """Read a topic list from a node package's ``event_bus`` contract section.
+
+    Shared implementation for both subscribe and publish topic discovery.
+    Uses ``importlib.resources`` for ONEX I/O audit compliance.
+
+    Args:
+        package: Fully-qualified Python package path containing
+            a ``contract.yaml`` file.
+        field: Topic field name (``"subscribe_topics"`` or ``"publish_topics"``).
+
+    Returns:
+        List of topic strings (empty if event bus is disabled or field absent).
+    """
+    package_files = importlib.resources.files(package)
+    contract_file = package_files.joinpath("contract.yaml")
+    content = contract_file.read_text()
+    contract: Any = yaml.safe_load(content)
+
+    if not isinstance(contract, dict):
+        logger.warning(
+            "contract.yaml in %s is not a valid mapping (got %s), skipping",
+            package,
+            type(contract).__name__,
+        )
+        return []
+
+    event_bus = contract.get("event_bus", {})
+    if not isinstance(event_bus, dict):
+        logger.warning(
+            "event_bus in %s contract.yaml is not a mapping (got %s), skipping",
+            package,
+            type(event_bus).__name__,
+        )
+        return []
+
+    if not event_bus.get("event_bus_enabled", False):
+        return []
+
+    topics: list[str] = event_bus.get(field, [])
+    if topics:
+        logger.debug(
+            "Discovered %s from %s: %s",
+            field,
+            package,
+            topics,
+        )
+    return topics
+
+
+def _read_subscribe_topics(package: str) -> list[str]:
+    """Read ``event_bus.subscribe_topics`` from a node package's contract."""
+    return _read_event_bus_topics(package, "subscribe_topics")
+
+
+def _read_publish_topics(package: str) -> list[str]:
+    """Read ``event_bus.publish_topics`` from a node package's contract."""
+    return _read_event_bus_topics(package, "publish_topics")
+
+
+__all__ = [
+    "canonical_topic_to_dispatch_alias",
+    "collect_all_publish_topics",
+    "collect_publish_topics_for_dispatch",
+    "collect_subscribe_topics_from_contracts",
+]

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -72,6 +72,7 @@ def collect_subscribe_topics_from_contracts(
         Ordered list of subscribe topic strings.
 
     Raises:
+        ModuleNotFoundError: If a node package is not installed/importable.
         FileNotFoundError: If a ``contract.yaml`` is missing from a package.
         yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
     """
@@ -227,7 +228,7 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
     """
     package_files = importlib.resources.files(package)
     contract_file = package_files.joinpath("contract.yaml")
-    content = contract_file.read_text()
+    content = contract_file.read_text(encoding="utf-8")
     contract: object = yaml.safe_load(content)
 
     if not isinstance(contract, dict):

--- a/tests/unit/runtime/test_contract_topics.py
+++ b/tests/unit/runtime/test_contract_topics.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for contract-driven topic discovery.
+
+Validates:
+    - collect_subscribe_topics_from_contracts returns correct topics
+    - collect_publish_topics_for_dispatch returns correct dispatch map
+    - collect_all_publish_topics returns all declared publish topics
+    - canonical_topic_to_dispatch_alias converts correctly
+    - No hardcoded topic constants remain in registry files
+
+Related:
+    - OMN-2213: Phase 2 -- Contract-driven topic discovery for omnimemory
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnimemory.runtime.contract_topics import (
+    _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES,
+    _derive_dispatch_key,
+    canonical_topic_to_dispatch_alias,
+    collect_all_publish_topics,
+    collect_publish_topics_for_dispatch,
+    collect_subscribe_topics_from_contracts,
+)
+
+# =============================================================================
+# Expected subscribe topics (must match contract.yaml declarations)
+# =============================================================================
+
+# intent_event_consumer_effect
+EXPECTED_INTENT_CLASSIFIED = "onex.evt.omniintelligence.intent-classified.v1"
+
+# intent_query_effect
+EXPECTED_INTENT_QUERY_REQUESTED = "onex.cmd.omnimemory.intent-query-requested.v1"
+
+# memory_retrieval_effect
+EXPECTED_MEMORY_RETRIEVAL_REQUESTED = (
+    "onex.cmd.omnimemory.memory-retrieval-requested.v1"
+)
+
+# memory_lifecycle_orchestrator
+EXPECTED_RUNTIME_TICK = "onex.internal.runtime-tick.v1"
+EXPECTED_ARCHIVE_MEMORY = "onex.cmd.omnimemory.archive-memory.v1"
+EXPECTED_EXPIRE_MEMORY = "onex.cmd.omnimemory.expire-memory.v1"
+
+EXPECTED_SUBSCRIBE_TOPICS = {
+    EXPECTED_INTENT_CLASSIFIED,
+    EXPECTED_INTENT_QUERY_REQUESTED,
+    EXPECTED_MEMORY_RETRIEVAL_REQUESTED,
+    EXPECTED_RUNTIME_TICK,
+    EXPECTED_ARCHIVE_MEMORY,
+    EXPECTED_EXPIRE_MEMORY,
+}
+
+# =============================================================================
+# Expected publish topics (first per node, for dispatch map)
+# =============================================================================
+
+EXPECTED_DISPATCH_MAP = {
+    "intent_event_consumer": "onex.evt.omnimemory.intent-stored.v1",
+    "intent_query": "onex.evt.omnimemory.intent-query-response.v1",
+    "intent_storage": "onex.evt.omnimemory.intent-stored.v1",
+    "memory_retrieval": "onex.evt.omnimemory.memory-retrieval-response.v1",
+    "memory_storage": "onex.evt.omnimemory.memory-stored.v1",
+    "memory_lifecycle": "onex.evt.omnimemory.memory-expired.v1",
+}
+
+# =============================================================================
+# Expected ALL publish topics (full list across all contracts)
+# =============================================================================
+
+EXPECTED_ALL_PUBLISH_TOPICS = {
+    # intent_event_consumer_effect
+    "onex.evt.omnimemory.intent-stored.v1",
+    "onex.evt.omniintelligence.intent-classified.v1.dlq",
+    # intent_query_effect
+    "onex.evt.omnimemory.intent-query-response.v1",
+    # intent_storage_effect (intent-stored.v1 also from consumer, set deduplicates)
+    "onex.evt.omnimemory.intent-store-failed.v1",
+    # memory_retrieval_effect
+    "onex.evt.omnimemory.memory-retrieval-response.v1",
+    # memory_storage_effect
+    "onex.evt.omnimemory.memory-stored.v1",
+    "onex.evt.omnimemory.memory-retrieved.v1",
+    "onex.evt.omnimemory.memory-updated.v1",
+    "onex.evt.omnimemory.memory-deleted.v1",
+    # memory_lifecycle_orchestrator
+    "onex.evt.omnimemory.memory-expired.v1",
+}
+
+
+# =============================================================================
+# Tests: collect_subscribe_topics_from_contracts
+# =============================================================================
+
+
+class TestCollectSubscribeTopics:
+    """Validate contract-driven subscribe topic collection."""
+
+    def test_returns_exactly_six_topics(self) -> None:
+        """All omnimemory nodes declare 6 subscribe topics total."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert len(topics) == 6
+
+    def test_contains_intent_classified_topic(self) -> None:
+        """Intent classified topic from intent_event_consumer_effect."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_INTENT_CLASSIFIED in topics
+
+    def test_contains_intent_query_requested_topic(self) -> None:
+        """Intent query requested topic from intent_query_effect."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_INTENT_QUERY_REQUESTED in topics
+
+    def test_contains_memory_retrieval_requested_topic(self) -> None:
+        """Memory retrieval requested topic from memory_retrieval_effect."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_MEMORY_RETRIEVAL_REQUESTED in topics
+
+    def test_contains_runtime_tick_topic(self) -> None:
+        """Runtime tick topic from memory_lifecycle_orchestrator."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_RUNTIME_TICK in topics
+
+    def test_contains_archive_memory_topic(self) -> None:
+        """Archive memory command topic from memory_lifecycle_orchestrator."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_ARCHIVE_MEMORY in topics
+
+    def test_contains_expire_memory_topic(self) -> None:
+        """Expire memory command topic from memory_lifecycle_orchestrator."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert EXPECTED_EXPIRE_MEMORY in topics
+
+    def test_all_expected_topics_present(self) -> None:
+        """All 6 expected subscribe topics must be in the discovered set."""
+        topics = set(collect_subscribe_topics_from_contracts())
+        assert topics == EXPECTED_SUBSCRIBE_TOPICS
+
+    def test_returns_list_type(self) -> None:
+        """Return type must be a list for ordered iteration."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert isinstance(topics, list)
+
+    def test_no_duplicates(self) -> None:
+        """No duplicate topics should be returned."""
+        topics = collect_subscribe_topics_from_contracts()
+        assert len(topics) == len(set(topics))
+
+    def test_custom_node_packages_override(self) -> None:
+        """Providing node_packages overrides the default list."""
+        topics = collect_subscribe_topics_from_contracts(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        assert topics == [EXPECTED_INTENT_QUERY_REQUESTED]
+
+    def test_node_with_empty_subscribe_returns_nothing(self) -> None:
+        """Nodes with empty subscribe_topics contribute nothing."""
+        topics = collect_subscribe_topics_from_contracts(
+            node_packages=["omnimemory.nodes.intent_storage_effect"],
+        )
+        assert topics == []
+
+
+# =============================================================================
+# Tests: collect_publish_topics_for_dispatch
+# =============================================================================
+
+
+class TestCollectPublishTopicsForDispatch:
+    """Validate contract-driven publish topic collection for dispatch engine."""
+
+    def test_returns_dict(self) -> None:
+        """Return type must be a dict."""
+        result = collect_publish_topics_for_dispatch()
+        assert isinstance(result, dict)
+
+    def test_contains_all_expected_keys(self) -> None:
+        """All expected dispatch keys must be present."""
+        result = collect_publish_topics_for_dispatch()
+        assert set(result.keys()) == set(EXPECTED_DISPATCH_MAP.keys())
+
+    def test_intent_event_consumer_topic(self) -> None:
+        """intent_event_consumer dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert (
+            result["intent_event_consumer"]
+            == EXPECTED_DISPATCH_MAP["intent_event_consumer"]
+        )
+
+    def test_intent_query_topic(self) -> None:
+        """intent_query dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert result["intent_query"] == EXPECTED_DISPATCH_MAP["intent_query"]
+
+    def test_intent_storage_topic(self) -> None:
+        """intent_storage dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert result["intent_storage"] == EXPECTED_DISPATCH_MAP["intent_storage"]
+
+    def test_memory_retrieval_topic(self) -> None:
+        """memory_retrieval dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert result["memory_retrieval"] == EXPECTED_DISPATCH_MAP["memory_retrieval"]
+
+    def test_memory_storage_topic(self) -> None:
+        """memory_storage dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert result["memory_storage"] == EXPECTED_DISPATCH_MAP["memory_storage"]
+
+    def test_memory_lifecycle_topic(self) -> None:
+        """memory_lifecycle dispatch key maps to correct topic."""
+        result = collect_publish_topics_for_dispatch()
+        assert result["memory_lifecycle"] == EXPECTED_DISPATCH_MAP["memory_lifecycle"]
+
+    def test_all_values_are_strings(self) -> None:
+        """All publish topic values must be strings."""
+        result = collect_publish_topics_for_dispatch()
+        for key, value in result.items():
+            assert isinstance(value, str), f"Value for '{key}' is not a string: {value}"
+
+    def test_all_values_contain_evt(self) -> None:
+        """All publish topics must be .evt. topics."""
+        result = collect_publish_topics_for_dispatch()
+        for key, value in result.items():
+            assert (
+                ".evt." in value
+            ), f"Publish topic '{key}' is not an event topic: {value}"
+
+    def test_custom_node_packages_override(self) -> None:
+        """Providing node_packages overrides the default list."""
+        result = collect_publish_topics_for_dispatch(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        assert result == {
+            "intent_query": "onex.evt.omnimemory.intent-query-response.v1"
+        }
+
+
+# =============================================================================
+# Tests: collect_all_publish_topics
+# =============================================================================
+
+
+class TestCollectAllPublishTopics:
+    """Validate full publish topic collection across all contracts."""
+
+    def test_returns_list(self) -> None:
+        """Return type must be a list."""
+        result = collect_all_publish_topics()
+        assert isinstance(result, list)
+
+    def test_all_expected_topics_present(self) -> None:
+        """All expected publish topics must be in the discovered set."""
+        topics = set(collect_all_publish_topics())
+        assert topics == EXPECTED_ALL_PUBLISH_TOPICS
+
+    def test_includes_dlq_topics(self) -> None:
+        """DLQ topics declared in publish_topics must be included."""
+        topics = collect_all_publish_topics()
+        assert "onex.evt.omniintelligence.intent-classified.v1.dlq" in topics
+
+    def test_includes_all_memory_storage_topics(self) -> None:
+        """All 4 memory storage CRUD event topics must be present."""
+        topics = set(collect_all_publish_topics())
+        expected_crud = {
+            "onex.evt.omnimemory.memory-stored.v1",
+            "onex.evt.omnimemory.memory-retrieved.v1",
+            "onex.evt.omnimemory.memory-updated.v1",
+            "onex.evt.omnimemory.memory-deleted.v1",
+        }
+        assert expected_crud.issubset(topics)
+
+
+# =============================================================================
+# Tests: canonical_topic_to_dispatch_alias
+# =============================================================================
+
+
+class TestCanonicalTopicToDispatchAlias:
+    """Validate canonical-to-dispatch topic conversion."""
+
+    def test_converts_cmd_to_commands(self) -> None:
+        """``.cmd.`` should be converted to ``.commands.``."""
+        result = canonical_topic_to_dispatch_alias(
+            "onex.cmd.omnimemory.intent-query-requested.v1"
+        )
+        assert result == "onex.commands.omnimemory.intent-query-requested.v1"
+
+    def test_converts_evt_to_events(self) -> None:
+        """``.evt.`` should be converted to ``.events.``."""
+        result = canonical_topic_to_dispatch_alias(
+            "onex.evt.omnimemory.intent-stored.v1"
+        )
+        assert result == "onex.events.omnimemory.intent-stored.v1"
+
+    def test_no_cmd_or_evt_unchanged(self) -> None:
+        """Topics without .cmd. or .evt. should pass through unchanged."""
+        topic = "some.other.topic.v1"
+        assert canonical_topic_to_dispatch_alias(topic) == topic
+
+    def test_internal_topic_unchanged(self) -> None:
+        """Internal topics without .cmd./.evt. pass through."""
+        topic = "onex.internal.runtime-tick.v1"
+        assert canonical_topic_to_dispatch_alias(topic) == topic
+
+    @pytest.mark.parametrize(
+        ("canonical", "expected_alias"),
+        [
+            (
+                EXPECTED_INTENT_QUERY_REQUESTED,
+                "onex.commands.omnimemory.intent-query-requested.v1",
+            ),
+            (
+                EXPECTED_MEMORY_RETRIEVAL_REQUESTED,
+                "onex.commands.omnimemory.memory-retrieval-requested.v1",
+            ),
+            (
+                EXPECTED_ARCHIVE_MEMORY,
+                "onex.commands.omnimemory.archive-memory.v1",
+            ),
+            (
+                EXPECTED_EXPIRE_MEMORY,
+                "onex.commands.omnimemory.expire-memory.v1",
+            ),
+            (
+                EXPECTED_INTENT_CLASSIFIED,
+                "onex.events.omniintelligence.intent-classified.v1",
+            ),
+        ],
+    )
+    def test_all_omnimemory_subscribe_topics_convert(
+        self,
+        canonical: str,
+        expected_alias: str,
+    ) -> None:
+        """All subscribe topics must produce correct dispatch aliases."""
+        assert canonical_topic_to_dispatch_alias(canonical) == expected_alias
+
+
+# =============================================================================
+# Tests: _derive_dispatch_key
+# =============================================================================
+
+
+class TestDeriveDispatchKey:
+    """Validate dispatch key derivation from package paths."""
+
+    def test_strips_effect_suffix(self) -> None:
+        """_effect suffix should be stripped."""
+        assert (
+            _derive_dispatch_key("omnimemory.nodes.intent_query_effect")
+            == "intent_query"
+        )
+
+    def test_strips_orchestrator_suffix(self) -> None:
+        """_orchestrator suffix should be stripped."""
+        assert (
+            _derive_dispatch_key("omnimemory.nodes.memory_lifecycle_orchestrator")
+            == "memory_lifecycle"
+        )
+
+    def test_strips_compute_suffix(self) -> None:
+        """_compute suffix should be stripped."""
+        assert (
+            _derive_dispatch_key("omnimemory.nodes.similarity_compute") == "similarity"
+        )
+
+    def test_strips_reducer_suffix(self) -> None:
+        """_reducer suffix should be stripped."""
+        assert (
+            _derive_dispatch_key("omnimemory.nodes.memory_consolidator_reducer")
+            == "memory_consolidator"
+        )
+
+    def test_no_matching_suffix(self) -> None:
+        """Package without known suffix should use full tail."""
+        assert _derive_dispatch_key("omnimemory.nodes.some_node") == "some_node"
+
+
+# =============================================================================
+# Tests: Node package registry completeness
+# =============================================================================
+
+
+class TestNodePackageRegistry:
+    """Validate that _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES is complete."""
+
+    def test_contains_intent_event_consumer(self) -> None:
+        """intent_event_consumer_effect must be in the package list."""
+        assert (
+            "omnimemory.nodes.intent_event_consumer_effect"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_contains_intent_query(self) -> None:
+        """intent_query_effect must be in the package list."""
+        assert (
+            "omnimemory.nodes.intent_query_effect"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_contains_intent_storage(self) -> None:
+        """intent_storage_effect must be in the package list."""
+        assert (
+            "omnimemory.nodes.intent_storage_effect"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_contains_memory_retrieval(self) -> None:
+        """memory_retrieval_effect must be in the package list."""
+        assert (
+            "omnimemory.nodes.memory_retrieval_effect"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_contains_memory_storage(self) -> None:
+        """memory_storage_effect must be in the package list."""
+        assert (
+            "omnimemory.nodes.memory_storage_effect"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_contains_memory_lifecycle(self) -> None:
+        """memory_lifecycle_orchestrator must be in the package list."""
+        assert (
+            "omnimemory.nodes.memory_lifecycle_orchestrator"
+            in _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
+        )
+
+    def test_exactly_six_packages(self) -> None:
+        """Exactly 6 omnimemory nodes have event_bus enabled."""
+        assert len(_OMNIMEMORY_EVENT_BUS_NODE_PACKAGES) == 6
+
+
+# =============================================================================
+# Tests: No hardcoded topic constants in registry
+# =============================================================================
+
+
+class TestNoHardcodedTopics:
+    """Validate that hardcoded topic constants have been removed."""
+
+    def test_registry_has_no_get_topic_suffixes(self) -> None:
+        """RegistryIntentQueryEffect must not have get_topic_suffixes method."""
+        from omnimemory.nodes.intent_query_effect.registry import (
+            RegistryIntentQueryEffect,
+        )
+
+        assert not hasattr(RegistryIntentQueryEffect, "get_topic_suffixes"), (
+            "get_topic_suffixes should have been removed from "
+            "RegistryIntentQueryEffect -- topics are now contract-driven"
+        )


### PR DESCRIPTION
## Summary
- Add `runtime/contract_topics.py` that reads `event_bus.subscribe_topics` and `event_bus.publish_topics` from contract YAML files at import time
- Replace hardcoded topic strings with contract-driven discovery
- Mirror the omniintelligence `runtime/contract_topics.py` pattern (PR #82, OMN-2033)

## Changes
- **New**: `src/omnimemory/runtime/contract_topics.py` with `collect_subscribe_topics_from_contracts()`, `collect_publish_topics_for_dispatch()`, `collect_all_publish_topics()`
- **New**: `src/omnimemory/runtime/__init__.py` with public API re-exports
- **Modified**: Removed `get_topic_suffixes()` from `intent_query_effect/registry/registry_intent_query_effect.py`
- **Modified**: Removed non-standard `event_type` sections from `intent_query_effect/contract.yaml` and `intent_event_consumer_effect/contract.yaml`
- **New**: 49 unit tests validating topic discovery

## Test plan
- [x] 49 new unit tests all passing
- [x] 1553 total tests passing (full suite)
- [x] mypy strict: 0 errors
- [x] All 19+ pre-commit hooks passed
- [x] Local review: 3 iterations, 0 blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized topic configuration by consolidating topic declarations into the event_bus section of contract files, removing redundant suffix declarations from distributed locations.
  * Transitioned to contract-driven topic discovery for improved configuration consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->