### PR TITLE
feat(contract): Migrate omnimemory to standard event_bus.subscribe_topics (OMN-1746)

### DIFF
--- a/src/omnimemory/handlers/adapters/__init__.py
+++ b/src/omnimemory/handlers/adapters/__init__.py
@@ -62,9 +62,6 @@ Example::
     Added AdapterValkey for OMN-1393.
 """
 
-# Contract models from omnibase_core (ProtocolIntentGraph conformance)
-from omnibase_core.models.intelligence import ModelIntentClassificationOutput
-
 from omnimemory.handlers.adapters.adapter_embedding_http import (
     EmbeddingHttpClient,
     EnumEmbeddingProviderType,
@@ -88,6 +85,7 @@ from omnimemory.handlers.adapters.adapter_valkey import (
 # Internal models for adapter-specific functionality
 from omnimemory.handlers.adapters.models import (
     ModelAdapterIntentGraphConfig,
+    ModelIntentClassificationOutput,
     ModelIntentDistributionResult,
     ModelIntentGraphHealth,
     ModelIntentQueryResult,

--- a/src/omnimemory/handlers/adapters/__init__.py
+++ b/src/omnimemory/handlers/adapters/__init__.py
@@ -63,12 +63,7 @@ Example::
 """
 
 # Contract models from omnibase_core (ProtocolIntentGraph conformance)
-from omnibase_core.models.intelligence import (
-    ModelIntentClassificationOutput,
-    ModelIntentQueryResult,
-    ModelIntentRecord,
-    ModelIntentStorageResult,
-)
+from omnibase_core.models.intelligence import ModelIntentClassificationOutput
 
 from omnimemory.handlers.adapters.adapter_embedding_http import (
     EmbeddingHttpClient,
@@ -95,6 +90,9 @@ from omnimemory.handlers.adapters.models import (
     ModelAdapterIntentGraphConfig,
     ModelIntentDistributionResult,
     ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentRecord,
+    ModelIntentStorageResult,
 )
 from omnimemory.models.adapters import (
     ModelConnectionsResult,

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -67,10 +67,11 @@ import time
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from types import TracebackType
-from typing import TYPE_CHECKING, cast
+from typing import cast
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
+from omnibase_core.container import ModelONEXContainer
 from omnibase_core.enums.intelligence import EnumIntentCategory
 from omnibase_core.models.intelligence import (
     ModelIntentClassificationOutput,
@@ -78,7 +79,6 @@ from omnibase_core.models.intelligence import (
 )
 from omnibase_core.types.type_json import JsonType
 from omnibase_infra.handlers.handler_graph import HandlerGraph
-from omnibase_spi.protocols.intelligence import ProtocolIntentGraph
 
 from omnimemory.handlers.adapters.models import (
     ModelAdapterIntentGraphConfig,
@@ -87,10 +87,6 @@ from omnimemory.handlers.adapters.models import (
     ModelIntentQueryResult,
     ModelIntentRecord,
 )
-
-if TYPE_CHECKING:
-    from omnibase_core.container import ModelONEXContainer
-
 
 __all__ = ["AdapterIntentGraph", "IntentCypherTemplates"]
 
@@ -245,11 +241,11 @@ class IntentCypherTemplates:
         """
 
 
-class AdapterIntentGraph(ProtocolIntentGraph):
+class AdapterIntentGraph:
     """Adapter that wraps HandlerGraph for intent classification storage.
 
-    Implements the ProtocolIntentGraph protocol from omnibase_spi, providing
-    a Memgraph-backed implementation for storing and retrieving intent
+    Structurally conforms to the ProtocolIntentGraph protocol from omnibase_spi,
+    providing a Memgraph-backed implementation for storing and retrieving intent
     classifications.
 
     This adapter provides an intent-domain interface on top of the generic
@@ -429,8 +425,6 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     try:
                         # Create container if not provided
                         if self._container is None:
-                            from omnibase_core.container import ModelONEXContainer
-
                             self._container = ModelONEXContainer()
 
                         # Create and initialize handler
@@ -620,6 +614,23 @@ class AdapterIntentGraph(ProtocolIntentGraph):
         intent_id = uuid4()
         timestamp_utc = datetime.now(UTC)
 
+        # Validate correlation_id as UUID
+        parsed_correlation_id: UUID | None = None
+        if correlation_id:
+            try:
+                parsed_correlation_id = UUID(correlation_id)
+            except ValueError:
+                logger.warning("Invalid correlation_id format: %s", correlation_id)
+                parsed_correlation_id = None
+
+        # Extract confidence and keywords defensively
+        confidence_raw = intent_data.confidence
+        confidence_val = (
+            float(confidence_raw) if isinstance(confidence_raw, int | float) else 0.0
+        )
+        keywords_raw = intent_data.keywords
+        keywords_val = list(keywords_raw) if isinstance(keywords_raw, list) else []
+
         try:
             async with asyncio.timeout(self._config.timeout_seconds):
                 query = IntentCypherTemplates.store_intent_query(
@@ -635,11 +646,13 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     "user_context": intent_category_str,
                     "intent_id": str(intent_id),
                     "intent_category": intent_category_str,
-                    "confidence": intent_data.confidence,
-                    "keywords": cast(list[JsonType], intent_data.keywords),
+                    "confidence": confidence_val,
+                    "keywords": cast(list[JsonType], keywords_val),
                     "created_at_utc": timestamp_utc_str,
                     "timestamp_utc": timestamp_utc_str,
-                    "correlation_id": correlation_id,
+                    "correlation_id": str(parsed_correlation_id)
+                    if parsed_correlation_id
+                    else None,
                 }
 
                 result = await handler.execute_query(
@@ -717,7 +730,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 error_message=f"Storage failed: {e}",
             )
 
-    async def get_session_intents(  # type: ignore[override]
+    async def get_session_intents(
         self,
         session_id: str,
         min_confidence: float = 0.0,
@@ -796,7 +809,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                         execution_time_ms,
                     )
                     return ModelIntentQueryResult(
-                        status="success",
+                        status="no_results",
                     )
 
                 # Convert records to intent models
@@ -888,7 +901,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     execution_time_ms,
                 )
                 return ModelIntentQueryResult(
-                    status="success",
+                    status="success" if intents else "no_results",
                     intents=intents,
                 )
 
@@ -1141,7 +1154,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                         effective_time_range,
                     )
                     return ModelIntentQueryResult(
-                        status="success",
+                        status="no_results",
                     )
 
                 # Convert records to intent models
@@ -1239,7 +1252,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 )
 
                 return ModelIntentQueryResult(
-                    status="success",
+                    status="success" if intents else "no_results",
                     intents=intents,
                 )
 

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -589,7 +589,10 @@ class AdapterIntentGraph:
             an error status in the result model instead.
         """
         # Extract intent category string from the classification output
-        intent_category_str = intent_data.intent_category.value
+        raw_category = intent_data.intent_category
+        intent_category_str = (
+            raw_category.value if hasattr(raw_category, "value") else str(raw_category)
+        )
 
         # Validate session_id is non-empty
         if not session_id or not session_id.strip():

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -71,6 +71,10 @@ from typing import cast
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
+# NOTE: This file uses omnibase_core's ModelIntentClassificationOutput (where
+# intent_category is EnumIntentCategory enum), not the omnimemory local version
+# (where intent_category is plain str). The core version is used because
+# store_intent() receives data from the upstream classification pipeline.
 from omnibase_core.container import ModelONEXContainer
 from omnibase_core.enums.intelligence import EnumIntentCategory
 from omnibase_core.models.intelligence import (
@@ -588,7 +592,11 @@ class AdapterIntentGraph:
             This method never raises on business errors - it returns
             an error status in the result model instead.
         """
-        # Extract intent category string from the classification output
+        # Extract intent category string from the classification output.
+        # intent_data.intent_category is EnumIntentCategory (from
+        # omnibase_core.models.intelligence.ModelIntentClassificationOutput),
+        # so .value extracts the underlying str. The hasattr guard handles
+        # any edge case where a plain str is passed instead of the enum.
         raw_category = intent_data.intent_category
         intent_category_str = (
             raw_category.value if hasattr(raw_category, "value") else str(raw_category)

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -568,7 +568,7 @@ class AdapterIntentGraph:
     ) -> ModelIntentStorageResult:
         """Store an intent classification linked to a session.
 
-        Implements ProtocolIntentGraph.store_intent.
+        Structurally conforms to ProtocolIntentGraph.store_intent.
 
         Uses MERGE semantics to create or update the session and intent
         nodes. If an intent with the same category already exists for

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -589,11 +589,7 @@ class AdapterIntentGraph:
             an error status in the result model instead.
         """
         # Extract intent category string from the classification output
-        intent_category_str = (
-            intent_data.intent_category.value
-            if hasattr(intent_data.intent_category, "value")
-            else str(intent_data.intent_category)
-        )
+        intent_category_str = intent_data.intent_category.value
 
         # Validate session_id is non-empty
         if not session_id or not session_id.strip():
@@ -643,7 +639,7 @@ class AdapterIntentGraph:
                 parameters: dict[str, JsonType] = {
                     "session_id": session_id,
                     "started_at_utc": timestamp_utc_str,
-                    "user_context": intent_category_str,
+                    "user_context": "",
                     "intent_id": str(intent_id),
                     "intent_category": intent_category_str,
                     "confidence": confidence_val,

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -72,12 +72,7 @@ from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from omnibase_core.enums.intelligence import EnumIntentCategory
-from omnibase_core.models.intelligence import (
-    ModelIntentClassificationOutput,
-    ModelIntentQueryResult,
-    ModelIntentRecord,
-    ModelIntentStorageResult,
-)
+from omnibase_core.models.events import ModelIntentStoredEvent
 from omnibase_core.types.type_json import JsonType
 from omnibase_infra.handlers.handler_graph import HandlerGraph
 from omnibase_spi.protocols.intelligence import ProtocolIntentGraph
@@ -86,10 +81,13 @@ from omnimemory.handlers.adapters.models import (
     ModelAdapterIntentGraphConfig,
     ModelIntentDistributionResult,
     ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentRecord,
 )
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
+    from omnibase_core.models.intelligence import ModelIntentClassificationInput
 
 
 __all__ = ["AdapterIntentGraph", "IntentCypherTemplates"]
@@ -569,9 +567,9 @@ class AdapterIntentGraph(ProtocolIntentGraph):
     async def store_intent(
         self,
         session_id: str,
-        intent_data: ModelIntentClassificationOutput,
-        correlation_id: str,
-    ) -> ModelIntentStorageResult:
+        intent_data: ModelIntentClassificationInput,
+        correlation_id: str | None = None,
+    ) -> ModelIntentStoredEvent:
         """Store an intent classification linked to a session.
 
         Implements ProtocolIntentGraph.store_intent.
@@ -582,38 +580,56 @@ class AdapterIntentGraph(ProtocolIntentGraph):
 
         Args:
             session_id: Unique identifier for the session.
-            intent_data: The classification output to store (category, confidence,
-                keywords). Classification happens upstream; this method persists
-                the result.
-            correlation_id: Correlation ID for request tracing.
+            intent_data: The classification input containing content, context,
+                and optional correlation metadata.
+            correlation_id: Optional correlation ID for request tracing.
 
         Returns:
-            ModelIntentStorageResult indicating success or failure.
-            On success, includes the intent_id and whether a new
-            intent was created vs merged.
+            ModelIntentStoredEvent confirming the intent was stored or
+            indicating an error via the status field.
 
         Note:
             This method never raises on business errors - it returns
             an error status in the result model instead.
         """
+        # Extract domain from context as intent category, default to "unclassified"
+        intent_category_str = intent_data.context.get("domain", "unclassified")
+
         # Validate session_id is non-empty
         if not session_id or not session_id.strip():
-            return ModelIntentStorageResult(
-                success=False,
+            return ModelIntentStoredEvent.from_error(
+                session_ref=session_id or "",
+                intent_category=intent_category_str,
                 error_message="session_id cannot be empty",
+                correlation_id=(
+                    UUID(correlation_id)
+                    if correlation_id
+                    else intent_data.correlation_id
+                ),
             )
 
         try:
             handler = self._ensure_initialized()
         except RuntimeError as e:
-            return ModelIntentStorageResult(
-                success=False,
+            return ModelIntentStoredEvent.from_error(
+                session_ref=session_id,
+                intent_category=intent_category_str,
                 error_message=str(e),
+                correlation_id=(
+                    UUID(correlation_id)
+                    if correlation_id
+                    else intent_data.correlation_id
+                ),
             )
 
         start_time = time.perf_counter()
         intent_id = uuid4()
         timestamp_utc = datetime.now(UTC)
+
+        # Resolve correlation ID: prefer explicit parameter, fall back to intent_data
+        resolved_correlation_id = (
+            UUID(correlation_id) if correlation_id else intent_data.correlation_id
+        )
 
         try:
             async with asyncio.timeout(self._config.timeout_seconds):
@@ -623,21 +639,22 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     rel_type=self._config.relationship_type,
                 )
 
-                # Convert enum/UUID/datetime to strings for database storage
-                # intent_category is an EnumIntentCategory, store its value
-                intent_category_str = intent_data.intent_category.value
                 timestamp_utc_str = timestamp_utc.isoformat()
                 parameters: dict[str, JsonType] = {
                     "session_id": session_id,
                     "started_at_utc": timestamp_utc_str,
-                    "user_context": "",  # No user_context in protocol
+                    "user_context": intent_data.content,
                     "intent_id": str(intent_id),
                     "intent_category": intent_category_str,
-                    "confidence": intent_data.confidence,
-                    "keywords": cast(list[JsonType], intent_data.keywords),
+                    "confidence": 0.0,
+                    "keywords": [],
                     "created_at_utc": timestamp_utc_str,
                     "timestamp_utc": timestamp_utc_str,
-                    "correlation_id": correlation_id,
+                    "correlation_id": (
+                        str(resolved_correlation_id)
+                        if resolved_correlation_id
+                        else None
+                    ),
                 }
 
                 result = await handler.execute_query(
@@ -676,18 +693,20 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                             )
 
                 logger.info(
-                    "Stored intent for session %s: category=%s, confidence=%.2f, created=%s (%.2fms)",
+                    "Stored intent for session %s: category=%s, created=%s (%.2fms)",
                     session_id,
                     intent_category_str,
-                    intent_data.confidence,
                     was_created,
                     execution_time_ms,
                 )
 
-                return ModelIntentStorageResult(
-                    success=True,
+                return ModelIntentStoredEvent.create(
+                    session_ref=session_id,
+                    intent_category=intent_category_str,
                     intent_id=returned_intent_id,
                     created=was_created,
+                    execution_time_ms=execution_time_ms,
+                    correlation_id=resolved_correlation_id,
                 )
 
         except TimeoutError:
@@ -698,9 +717,11 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 session_id,
                 execution_time_ms,
             )
-            return ModelIntentStorageResult(
-                success=False,
+            return ModelIntentStoredEvent.from_error(
+                session_ref=session_id,
+                intent_category=intent_category_str,
                 error_message=f"Operation timed out after {self._config.timeout_seconds}s",
+                correlation_id=resolved_correlation_id,
             )
 
         except Exception as e:
@@ -711,12 +732,14 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 session_id,
                 e,
             )
-            return ModelIntentStorageResult(
-                success=False,
+            return ModelIntentStoredEvent.from_error(
+                session_ref=session_id,
+                intent_category=intent_category_str,
                 error_message=f"Storage failed: {e}",
+                correlation_id=resolved_correlation_id,
             )
 
-    async def get_session_intents(
+    async def get_session_intents(  # type: ignore[override]
         self,
         session_id: str,
         min_confidence: float = 0.0,
@@ -746,7 +769,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
             handler = self._ensure_initialized()
         except RuntimeError as e:
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=str(e),
             )
 
@@ -795,7 +818,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                         execution_time_ms,
                     )
                     return ModelIntentQueryResult(
-                        success=True,
+                        status="success",
                     )
 
                 # Convert records to intent models
@@ -871,11 +894,11 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     intents.append(
                         ModelIntentRecord(
                             intent_id=intent_id,
-                            session_id=session_id,
-                            intent_category=intent_category,
+                            session_ref=session_id,
+                            intent_category=intent_category.value,
                             confidence=confidence_val,
                             keywords=keywords,
-                            created_at=created_at,
+                            created_at_utc=created_at,
                             correlation_id=correlation_id,
                         )
                     )
@@ -887,7 +910,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     execution_time_ms,
                 )
                 return ModelIntentQueryResult(
-                    success=True,
+                    status="success",
                     intents=intents,
                 )
 
@@ -900,7 +923,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 execution_time_ms,
             )
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=f"Query timed out after {self._config.timeout_seconds}s",
             )
 
@@ -913,7 +936,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 e,
             )
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=f"Query failed: {e}",
             )
 
@@ -1089,7 +1112,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
             handler = self._ensure_initialized()
         except RuntimeError as e:
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=str(e),
             )
 
@@ -1140,7 +1163,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                         effective_time_range,
                     )
                     return ModelIntentQueryResult(
-                        success=True,
+                        status="success",
                     )
 
                 # Convert records to intent models
@@ -1222,11 +1245,11 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     intents.append(
                         ModelIntentRecord(
                             intent_id=intent_id,
-                            session_id=record_session_id,
-                            intent_category=intent_category,
+                            session_ref=record_session_id,
+                            intent_category=intent_category.value,
                             confidence=confidence_val,
                             keywords=keywords,
-                            created_at=created_at,
+                            created_at_utc=created_at,
                             correlation_id=correlation_id,
                         )
                     )
@@ -1238,7 +1261,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 )
 
                 return ModelIntentQueryResult(
-                    success=True,
+                    status="success",
                     intents=intents,
                 )
 
@@ -1248,7 +1271,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 self._config.timeout_seconds,
             )
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=f"Query timed out after {self._config.timeout_seconds}s",
             )
 
@@ -1258,7 +1281,7 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 e,
             )
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=f"Query failed: {e}",
             )
 

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -72,7 +72,10 @@ from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from omnibase_core.enums.intelligence import EnumIntentCategory
-from omnibase_core.models.events import ModelIntentStoredEvent
+from omnibase_core.models.intelligence import (
+    ModelIntentClassificationOutput,
+    ModelIntentStorageResult,
+)
 from omnibase_core.types.type_json import JsonType
 from omnibase_infra.handlers.handler_graph import HandlerGraph
 from omnibase_spi.protocols.intelligence import ProtocolIntentGraph
@@ -87,7 +90,6 @@ from omnimemory.handlers.adapters.models import (
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
-    from omnibase_core.models.intelligence import ModelIntentClassificationInput
 
 
 __all__ = ["AdapterIntentGraph", "IntentCypherTemplates"]
@@ -567,9 +569,9 @@ class AdapterIntentGraph(ProtocolIntentGraph):
     async def store_intent(
         self,
         session_id: str,
-        intent_data: ModelIntentClassificationInput,
-        correlation_id: str | None = None,
-    ) -> ModelIntentStoredEvent:
+        intent_data: ModelIntentClassificationOutput,
+        correlation_id: str,
+    ) -> ModelIntentStorageResult:
         """Store an intent classification linked to a session.
 
         Implements ProtocolIntentGraph.store_intent.
@@ -580,56 +582,43 @@ class AdapterIntentGraph(ProtocolIntentGraph):
 
         Args:
             session_id: Unique identifier for the session.
-            intent_data: The classification input containing content, context,
-                and optional correlation metadata.
-            correlation_id: Optional correlation ID for request tracing.
+            intent_data: The classification output containing category,
+                confidence, and keywords.
+            correlation_id: Correlation ID for request tracing.
 
         Returns:
-            ModelIntentStoredEvent confirming the intent was stored or
-            indicating an error via the status field.
+            ModelIntentStorageResult indicating success or failure with
+            metadata about the stored intent.
 
         Note:
             This method never raises on business errors - it returns
             an error status in the result model instead.
         """
-        # Extract domain from context as intent category, default to "unclassified"
-        intent_category_str = intent_data.context.get("domain", "unclassified")
+        # Extract intent category string from the classification output
+        intent_category_str = (
+            intent_data.intent_category.value
+            if hasattr(intent_data.intent_category, "value")
+            else str(intent_data.intent_category)
+        )
 
         # Validate session_id is non-empty
         if not session_id or not session_id.strip():
-            return ModelIntentStoredEvent.from_error(
-                session_ref=session_id or "",
-                intent_category=intent_category_str,
+            return ModelIntentStorageResult(
+                success=False,
                 error_message="session_id cannot be empty",
-                correlation_id=(
-                    UUID(correlation_id)
-                    if correlation_id
-                    else intent_data.correlation_id
-                ),
             )
 
         try:
             handler = self._ensure_initialized()
         except RuntimeError as e:
-            return ModelIntentStoredEvent.from_error(
-                session_ref=session_id,
-                intent_category=intent_category_str,
+            return ModelIntentStorageResult(
+                success=False,
                 error_message=str(e),
-                correlation_id=(
-                    UUID(correlation_id)
-                    if correlation_id
-                    else intent_data.correlation_id
-                ),
             )
 
         start_time = time.perf_counter()
         intent_id = uuid4()
         timestamp_utc = datetime.now(UTC)
-
-        # Resolve correlation ID: prefer explicit parameter, fall back to intent_data
-        resolved_correlation_id = (
-            UUID(correlation_id) if correlation_id else intent_data.correlation_id
-        )
 
         try:
             async with asyncio.timeout(self._config.timeout_seconds):
@@ -643,18 +632,14 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 parameters: dict[str, JsonType] = {
                     "session_id": session_id,
                     "started_at_utc": timestamp_utc_str,
-                    "user_context": intent_data.content,
+                    "user_context": intent_category_str,
                     "intent_id": str(intent_id),
                     "intent_category": intent_category_str,
-                    "confidence": 0.0,
-                    "keywords": [],
+                    "confidence": intent_data.confidence,
+                    "keywords": cast(list[JsonType], intent_data.keywords),
                     "created_at_utc": timestamp_utc_str,
                     "timestamp_utc": timestamp_utc_str,
-                    "correlation_id": (
-                        str(resolved_correlation_id)
-                        if resolved_correlation_id
-                        else None
-                    ),
+                    "correlation_id": correlation_id,
                 }
 
                 result = await handler.execute_query(
@@ -700,13 +685,10 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                     execution_time_ms,
                 )
 
-                return ModelIntentStoredEvent.create(
-                    session_ref=session_id,
-                    intent_category=intent_category_str,
+                return ModelIntentStorageResult(
+                    success=True,
                     intent_id=returned_intent_id,
                     created=was_created,
-                    execution_time_ms=execution_time_ms,
-                    correlation_id=resolved_correlation_id,
                 )
 
         except TimeoutError:
@@ -717,11 +699,9 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 session_id,
                 execution_time_ms,
             )
-            return ModelIntentStoredEvent.from_error(
-                session_ref=session_id,
-                intent_category=intent_category_str,
+            return ModelIntentStorageResult(
+                success=False,
                 error_message=f"Operation timed out after {self._config.timeout_seconds}s",
-                correlation_id=resolved_correlation_id,
             )
 
         except Exception as e:
@@ -732,11 +712,9 @@ class AdapterIntentGraph(ProtocolIntentGraph):
                 session_id,
                 e,
             )
-            return ModelIntentStoredEvent.from_error(
-                session_ref=session_id,
-                intent_category=intent_category_str,
+            return ModelIntentStorageResult(
+                success=False,
                 error_message=f"Storage failed: {e}",
-                correlation_id=resolved_correlation_id,
             )
 
     async def get_session_intents(  # type: ignore[override]

--- a/src/omnimemory/handlers/adapters/adapter_intent_graph.py
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph.py
@@ -2,8 +2,8 @@
 # Copyright (c) 2025 OmniNode Team
 """Adapter for storing intent classifications in Memgraph.
 
-This adapter implements ProtocolIntentGraph from omnibase_spi, providing
-a Memgraph-backed implementation for storing and retrieving intent
+This adapter structurally conforms to ProtocolIntentGraph from omnibase_spi,
+providing a Memgraph-backed implementation for storing and retrieving intent
 classifications.
 
 The storage boundary accepts **classification output** (category, confidence,
@@ -56,7 +56,7 @@ Example::
     Initial implementation for OMN-1457.
 
 .. versionchanged:: 0.2.0
-    Implements ProtocolIntentGraph from omnibase_spi (OMN-1476).
+    Structurally conforms to ProtocolIntentGraph from omnibase_spi (OMN-1476).
 """
 
 from __future__ import annotations
@@ -745,7 +745,7 @@ class AdapterIntentGraph:
     ) -> ModelIntentQueryResult:
         """Get intents for a session with optional filtering.
 
-        Implements ProtocolIntentGraph.get_session_intents.
+        Structurally conforms to ProtocolIntentGraph.get_session_intents.
 
         Retrieves intent classifications associated with the specified
         session, ordered by creation time (most recent first).
@@ -1286,7 +1286,7 @@ class AdapterIntentGraph:
     async def health_check(self) -> bool:
         """Check if the intent graph storage is healthy and accessible.
 
-        Implements ProtocolIntentGraph.health_check.
+        Structurally conforms to ProtocolIntentGraph.health_check.
 
         Returns:
             True if the storage is healthy, False otherwise.

--- a/src/omnimemory/handlers/adapters/models/model_intent_domain.py
+++ b/src/omnimemory/handlers/adapters/models/model_intent_domain.py
@@ -185,7 +185,7 @@ class ModelIntentRecord(BaseModel):  # omnimemory-model-exempt: adapter internal
     Attributes:
         intent_id: Unique identifier (UUID) for the intent node in the graph.
         session_ref: Optional session reference this intent belongs to, used
-            for mapping to IntentRecordPayload.
+            for mapping to ModelIntentRecordPayload.
         intent_category: The classified intent category.
         confidence: Confidence score from the original classification.
         keywords: Keywords associated with this intent.

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -604,6 +604,8 @@ class HandlerIntent:
                 "correlation_id": correlation_id,
                 "session_id": session_id,
                 "intent_category": intent_category_str,
+                "confidence": intent_data.confidence,
+                "keywords": intent_data.keywords,
             },
         )
 
@@ -722,7 +724,9 @@ class HandlerIntent:
                 limit=limit,
             )
             # Record success if operation completed without exception
-            if result.status == "success":
+            # Non-error statuses (no_results, not_found) are still healthy
+            # adapter responses and should not trip the circuit breaker.
+            if result.status in {"success", "no_results", "not_found"}:
                 circuit_breaker.record_success()
             return result
         except Exception as e:

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -79,11 +79,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from omnibase_core.models.intelligence import (
-    ModelIntentClassificationOutput,
-    ModelIntentQueryResult,
-    ModelIntentStorageResult,
-)
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.handlers.adapters.adapter_intent_graph import AdapterIntentGraph
@@ -91,6 +86,8 @@ from omnimemory.handlers.adapters.models import (
     ModelAdapterIntentGraphConfig,
     ModelIntentDistributionResult,
     ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentStorageResult,
 )
 from omnimemory.utils.concurrency import (
     CircuitBreaker,
@@ -100,6 +97,7 @@ from omnimemory.utils.concurrency import (
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
+    from omnibase_core.models.intelligence import ModelIntentClassificationOutput
 
 __all__ = [
     "CircuitBreakerOpenError",
@@ -571,7 +569,8 @@ class HandlerIntent:
                 },
             )
             return ModelIntentStorageResult(
-                success=False,
+                status="error",
+                session_id=session_id,
                 error_message=str(e),
             )
 
@@ -590,6 +589,13 @@ class HandlerIntent:
                 f"Circuit breaker is {circuit_breaker.state.value}"
             )
 
+        # Resolve intent category string for logging
+        intent_category_str = (
+            intent_data.intent_category.value
+            if hasattr(intent_data.intent_category, "value")
+            else str(intent_data.intent_category)
+        )
+
         logger.debug(
             "Storing intent for session %s",
             session_id,
@@ -597,23 +603,39 @@ class HandlerIntent:
                 "handler": HANDLER_ID_INTENT,
                 "correlation_id": correlation_id,
                 "session_id": session_id,
-                "intent_category": intent_data.intent_category.value
-                if hasattr(intent_data.intent_category, "value")
-                else intent_data.intent_category,
+                "intent_category": intent_category_str,
             },
         )
 
+        # Convert ModelIntentClassificationOutput to ModelIntentClassificationInput
+        # for the adapter's protocol-conforming interface
+        from omnibase_core.models.intelligence import ModelIntentClassificationInput
+
+        adapter_input = ModelIntentClassificationInput(
+            content=intent_category_str,
+            context={"domain": intent_category_str},
+            correlation_id=None,
+        )
+
         try:
-            result = await adapter.store_intent(
+            event = await adapter.store_intent(
                 session_id=session_id,
-                intent_data=intent_data,
+                intent_data=adapter_input,
                 correlation_id=correlation_id,
             )
             # Record success if operation completed without exception
             # Business errors (e.g., validation) are not circuit breaker failures
-            if result.success:
+            if event.status == "success":
                 circuit_breaker.record_success()
-            return result
+            # Convert ModelIntentStoredEvent to ModelIntentStorageResult
+            return ModelIntentStorageResult(
+                status=event.status,
+                intent_id=event.intent_id,
+                session_id=session_id,
+                created=event.created,
+                execution_time_ms=event.execution_time_ms,
+                error_message=event.error_message,
+            )
         except Exception as e:
             circuit_breaker.record_failure()
             logger.error(
@@ -673,7 +695,7 @@ class HandlerIntent:
                 },
             )
             return ModelIntentQueryResult(
-                success=False,
+                status="error",
                 error_message=str(e),
             )
 
@@ -711,7 +733,7 @@ class HandlerIntent:
                 limit=limit,
             )
             # Record success if operation completed without exception
-            if result.success:
+            if result.status == "success":
                 circuit_breaker.record_success()
             return result
         except Exception as e:

--- a/src/omnimemory/handlers/handler_intent.py
+++ b/src/omnimemory/handlers/handler_intent.py
@@ -607,34 +607,23 @@ class HandlerIntent:
             },
         )
 
-        # Convert ModelIntentClassificationOutput to ModelIntentClassificationInput
-        # for the adapter's protocol-conforming interface
-        from omnibase_core.models.intelligence import ModelIntentClassificationInput
-
-        adapter_input = ModelIntentClassificationInput(
-            content=intent_category_str,
-            context={"domain": intent_category_str},
-            correlation_id=None,
-        )
-
         try:
-            event = await adapter.store_intent(
+            result = await adapter.store_intent(
                 session_id=session_id,
-                intent_data=adapter_input,
+                intent_data=intent_data,
                 correlation_id=correlation_id,
             )
             # Record success if operation completed without exception
             # Business errors (e.g., validation) are not circuit breaker failures
-            if event.status == "success":
+            if result.success:
                 circuit_breaker.record_success()
-            # Convert ModelIntentStoredEvent to ModelIntentStorageResult
+            # Convert omnibase_core ModelIntentStorageResult to local ModelIntentStorageResult
             return ModelIntentStorageResult(
-                status=event.status,
-                intent_id=event.intent_id,
+                status="success" if result.success else "error",
+                intent_id=result.intent_id,
                 session_id=session_id,
-                created=event.created,
-                execution_time_ms=event.execution_time_ms,
-                error_message=event.error_message,
+                created=result.created,
+                error_message=result.error_message,
             )
         except Exception as e:
             circuit_breaker.record_failure()

--- a/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/contract.yaml
@@ -3,8 +3,8 @@
 # Consumes intent-classified events from omniintelligence and persists to graph storage
 
 name: intent_event_consumer_effect
-contract_version: {major: 0, minor: 1, patch: 0}
-node_version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 2, patch: 0}
+node_version: {major: 0, minor: 2, patch: 0}
 uuid: "6fc349b1-34f0-4760-b547-6e8bebf0c9c0"
 node_type: EFFECT
 description: |
@@ -14,22 +14,100 @@ description: |
   Consumer group is derived from node identity per ADR:
   {env}.omnimemory.intent_event_consumer_effect.consume.v1
 
-# === EVENT TYPE CONFIGURATION ===
-# Note: Uses canonical ModelIntentStoredEvent from omnibase_core which
-# encodes both success and error via status field (not separate events).
-# Topic suffixes are custom extensions matching intent_query_effect pattern.
-event_type:
-  version: {major: 1, minor: 0, patch: 0}
-  primary_events: ["intent_classified_consumed", "intent_stored"]
-  event_categories: ["intent", "intelligence", "consumer", "effect"]
-  publish_events: true
-  subscribe_events: true
-  event_routing: "intent"
-  invocation_mode: "subscription"
-  # Custom topic fields (extensions to standard subcontract)
-  subscribe_topic_suffix: "onex.evt.omniintelligence.intent-classified.v1"
-  publish_stored_topic_suffix: "onex.evt.omnimemory.intent-stored.v1"
-  dlq_topic_suffix: "onex.evt.omniintelligence.intent-classified.v1.dlq"
+# =============================================================================
+# PUBLISHED EVENTS (Kafka) - Documentation Layer
+# =============================================================================
+# PURPOSE: Human-readable documentation of WHAT events this node produces.
+#
+# This section provides rich metadata for:
+#   - IntentTypeExtractor (capability inference)
+#   - Contract validation and diff computation
+#   - Human understanding of node behavior
+#
+# NOTE: This is intentionally separate from event_bus (below) which handles
+# WHERE events are routed. Both are needed for Effect nodes:
+#   - published_events = documentation layer (WHAT)
+#   - event_bus = runtime routing layer (WHERE)
+#
+# Topic naming: onex.{kind}.{producer}.{event-name}.v{n}
+#   - kind=evt for events/outputs
+# =============================================================================
+published_events:
+  - topic_suffix: "onex.evt.omnimemory.intent-stored.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.intent-stored.v1"
+    event_type: "IntentStored"
+    trigger: "Intent event consumed and stored successfully (or failed)"
+    description: "Emitted when an intent-classified event has been processed. Uses status field to distinguish
+      success/error (not separate event types)."
+    payload_fields:
+      - name: "event_type"
+        type: "string"
+        description: "Always 'onex.omnimemory.intent.stored.v1'"
+      - name: "session_ref"
+        type: "string"
+        description: "Session reference (mapped from session_id at boundary)"
+      - name: "intent_category"
+        type: "string"
+        description: "Classified intent category"
+      - name: "intent_id"
+        type: "string"
+        description: "UUID of the stored intent (null on error)"
+      - name: "status"
+        type: "string"
+        description: "success or error"
+      - name: "correlation_id"
+        type: "string"
+        description: "Correlation ID for distributed tracing"
+
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+# PURPOSE: Machine-readable configuration of WHERE events are routed.
+#
+# This subcontract provides structured topic routing for:
+#   - RuntimeHostProcess auto-discovery and wiring
+#   - Kafka topic subscription/publication
+#   - Schema validation via topic metadata
+#
+# NOTE: This is intentionally separate from published_events (above) which
+# documents WHAT events this node produces. Both are needed for Effect nodes:
+#   - published_events = documentation layer (WHAT)
+#   - event_bus = runtime routing layer (WHERE)
+#
+# Migrated from event_type.subscribe_topic_suffix per OMN-1746.
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives events from)
+  subscribe_topics:
+    - "onex.evt.omniintelligence.intent-classified.v1"
+
+  # Topics this node publishes to (sends events to)
+  publish_topics:
+    - "onex.evt.omnimemory.intent-stored.v1"
+
+  # Dead letter queue topics for failed messages
+  dlq_topics:
+    - "onex.evt.omniintelligence.intent-classified.v1.dlq"
+
+  # Metadata for subscribed topics
+  # Note: consumer_group is NOT specified here - it's derived from node identity
+  # per ADR: {env}.omnimemory.intent_event_consumer_effect.consume.v1
+  subscribe_topic_metadata:
+    "onex.evt.omniintelligence.intent-classified.v1":
+      schema_ref: "omnimemory.models.events.ModelIntentClassifiedEvent"
+      description: "Intent classification events from omniintelligence. Consumed for graph storage persistence."
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.intent-stored.v1":
+      schema_ref: "omnibase_core.models.events.ModelIntentStoredEvent"
+      description: "Intent storage result events (success or error via status field)"
 
 # === HANDLER CONFIGURATION ===
 handler_config:

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -226,12 +226,37 @@ class HandlerIntentEventConsumer:
             )
             return
 
+        if not self._config.subscribe_topics:
+            logger.warning(
+                "subscribe_topics is empty, consumer will not receive any events",
+                extra={"handler": HANDLER_ID_INTENT_CONSUMER},
+            )
+            raise ValueError(
+                "subscribe_topics must not be empty: "
+                "consumer would initialize with no subscriptions"
+            )
+
         self._env_prefix = env_prefix
         self._publish_callback = publish_callback
 
+        failed_topics: list[tuple[str, str]] = []
         for topic_suffix in self._config.subscribe_topics:
             full_topic = f"{env_prefix}.{topic_suffix}"
-            unsubscribe = subscribe_callback(full_topic, self._handle_message_sync)
+            try:
+                unsubscribe = subscribe_callback(full_topic, self._handle_message_sync)
+            except Exception as e:
+                logger.error(
+                    "Failed to subscribe to topic",
+                    extra={
+                        "handler": HANDLER_ID_INTENT_CONSUMER,
+                        "topic": full_topic,
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                    },
+                )
+                failed_topics.append((full_topic, str(e)))
+                continue
+
             self._unsubscribe_fns.append(unsubscribe)
 
             logger.info(
@@ -240,6 +265,21 @@ class HandlerIntentEventConsumer:
                     "handler": HANDLER_ID_INTENT_CONSUMER,
                     "topic": full_topic,
                     "env_prefix": env_prefix,
+                },
+            )
+
+        if failed_topics and not self._unsubscribe_fns:
+            # All subscriptions failed -- cannot operate at all
+            raise RuntimeError(f"All topic subscriptions failed: {failed_topics}")
+
+        if failed_topics:
+            logger.warning(
+                "Some topic subscriptions failed, continuing with partial subscriptions",
+                extra={
+                    "handler": HANDLER_ID_INTENT_CONSUMER,
+                    "failed_topics": [t[0] for t in failed_topics],
+                    "successful_count": len(self._unsubscribe_fns),
+                    "failed_count": len(failed_topics),
                 },
             )
 

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -498,6 +498,13 @@ class HandlerIntentEventConsumer:
             )
             return
 
+        if not self._config.publish_topics:
+            logger.warning(
+                "No publish topics configured, skipping event emission",
+                extra={"handler": HANDLER_ID_INTENT_CONSUMER},
+            )
+            return
+
         publish_topic = self._config.publish_topics[0]
         topic = f"{self._env_prefix}.{publish_topic}"
         try:
@@ -536,6 +543,14 @@ class HandlerIntentEventConsumer:
             retry_count: Number of retry attempts made before DLQ routing.
         """
         self._messages_dlq += 1
+
+        if not self._config.dlq_topics:
+            logger.warning(
+                "No DLQ topics configured, skipping DLQ publish",
+                extra={"handler": HANDLER_ID_INTENT_CONSUMER},
+            )
+            return
+
         dlq_topic = self._config.dlq_topics[0]
 
         if self._publish_callback is None:

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -119,8 +119,8 @@ class HandlerIntentEventConsumer:
 
     Topic configuration uses list-based fields matching the standard
     ``event_bus.subscribe_topics`` contract format (OMN-1746). The first
-    entry in each list is used as the primary topic for backwards
-    compatibility with single-topic consumers.
+    entry in each list is used as the primary topic. Both single topic
+    string and topic list formats are accepted.
 
     Attributes:
         _config: Consumer configuration.

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -26,6 +26,10 @@ Consumer Group:
     Derived from node identity per ADR:
     ``{env_prefix}.omnimemory.intent_event_consumer_effect.consume.v1``
 
+Contract Format:
+    Uses standard ``event_bus.subscribe_topics`` contract format (OMN-1746)
+    enabling declarative wiring via ``EventBusSubcontractWiring``.
+
 Example::
 
     from omnimemory.nodes.intent_event_consumer_effect import (
@@ -57,6 +61,11 @@ Example::
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1619.
+
+.. versionchanged:: 0.2.0
+    Migrated to standard event_bus.subscribe_topics format (OMN-1746).
+    Config now uses list-based topic fields (subscribe_topics, publish_topics,
+    dlq_topics) instead of singular suffix fields.
 """
 
 from __future__ import annotations
@@ -106,8 +115,12 @@ class HandlerIntentEventConsumer:
     The ``env_prefix`` parameter is a deployment realm (e.g., ``"dev"``,
     ``"staging"``, ``"prod"``) that isolates environments on the same Kafka
     cluster. It is separate from the ``onex.`` namespace embedded in topic
-    suffixes. See :class:`ModelIntentEventConsumerConfig` for topic suffix
-    defaults.
+    suffixes.
+
+    Topic configuration uses list-based fields matching the standard
+    ``event_bus.subscribe_topics`` contract format (OMN-1746). The first
+    entry in each list is used as the primary topic for backwards
+    compatibility with single-topic consumers.
 
     Attributes:
         _config: Consumer configuration.
@@ -133,7 +146,7 @@ class HandlerIntentEventConsumer:
         """Initialize the consumer handler.
 
         Args:
-            config: Consumer configuration including topic suffixes,
+            config: Consumer configuration including topic lists,
                 circuit breaker settings, and staleness threshold.
             storage_adapter: Adapter for storing intents to graph.
                 Must be initialized before calling consumer.initialize().
@@ -154,7 +167,7 @@ class HandlerIntentEventConsumer:
         self._messages_consumed = 0
         self._messages_failed = 0
         self._messages_dlq = 0
-        self._unsubscribe: Callable[[], None] | None = None
+        self._unsubscribe_fns: list[Callable[[], None]] = []
 
         # Kafka publish callback (set during initialize)
         self._publish_callback: Callable[[str, dict[str, object]], None] | None = None
@@ -167,8 +180,8 @@ class HandlerIntentEventConsumer:
             "HandlerIntentEventConsumer initialized",
             extra={
                 "handler": HANDLER_ID_INTENT_CONSUMER,
-                "subscribe_topic": config.subscribe_topic_suffix,
-                "publish_stored_topic": config.publish_stored_topic_suffix,
+                "subscribe_topics": config.subscribe_topics,
+                "publish_topics": config.publish_topics,
             },
         )
 
@@ -194,7 +207,10 @@ class HandlerIntentEventConsumer:
         env_prefix: str = "dev",
         publish_callback: Callable[[str, dict[str, object]], None] | None = None,
     ) -> None:
-        """Initialize Kafka subscription.
+        """Initialize Kafka subscriptions for all configured subscribe_topics.
+
+        Subscribes to each topic in ``config.subscribe_topics``, constructing
+        full topic names as ``{env_prefix}.{topic_suffix}``.
 
         Args:
             subscribe_callback: Function to subscribe to Kafka topic.
@@ -213,19 +229,21 @@ class HandlerIntentEventConsumer:
         self._env_prefix = env_prefix
         self._publish_callback = publish_callback
 
-        full_topic = f"{env_prefix}.{self._config.subscribe_topic_suffix}"
+        for topic_suffix in self._config.subscribe_topics:
+            full_topic = f"{env_prefix}.{topic_suffix}"
+            unsubscribe = subscribe_callback(full_topic, self._handle_message_sync)
+            self._unsubscribe_fns.append(unsubscribe)
 
-        self._unsubscribe = subscribe_callback(full_topic, self._handle_message_sync)
+            logger.info(
+                "Kafka subscription initialized",
+                extra={
+                    "handler": HANDLER_ID_INTENT_CONSUMER,
+                    "topic": full_topic,
+                    "env_prefix": env_prefix,
+                },
+            )
+
         self._initialized = True
-
-        logger.info(
-            "Kafka subscription initialized",
-            extra={
-                "handler": HANDLER_ID_INTENT_CONSUMER,
-                "topic": full_topic,
-                "env_prefix": env_prefix,
-            },
-        )
 
     def _handle_message_sync(self, message: dict[str, object]) -> None:
         """Synchronous message handler wrapper for Kafka callback.
@@ -349,7 +367,7 @@ class HandlerIntentEventConsumer:
                 self._last_consume_timestamp = datetime.now(timezone.utc)
 
                 # Emit success event using canonical omnibase_core model
-                # Maps session_id → session_ref at the emission boundary
+                # Maps session_id -> session_ref at the emission boundary
                 stored_event = ModelIntentStoredEvent.create(
                     session_ref=event.session_id,  # Map at boundary
                     intent_category=event.intent_category,
@@ -464,6 +482,8 @@ class HandlerIntentEventConsumer:
         both success (status="success") and error (status="error") cases
         via a single event type.
 
+        Publishes to the first topic in ``config.publish_topics``.
+
         Args:
             event: The stored event to emit (success or error).
         """
@@ -478,7 +498,8 @@ class HandlerIntentEventConsumer:
             )
             return
 
-        topic = f"{self._env_prefix}.{self._config.publish_stored_topic_suffix}"
+        publish_topic = self._config.publish_topics[0]
+        topic = f"{self._env_prefix}.{publish_topic}"
         try:
             self._publish_callback(topic, event.model_dump(mode="json"))
             logger.debug(
@@ -507,12 +528,15 @@ class HandlerIntentEventConsumer:
     ) -> None:
         """Route failed message to dead letter queue.
 
+        Publishes to the first topic in ``config.dlq_topics``.
+
         Args:
             message: The original message.
             reason: Why the message failed.
             retry_count: Number of retry attempts made before DLQ routing.
         """
         self._messages_dlq += 1
+        dlq_topic = self._config.dlq_topics[0]
 
         if self._publish_callback is None:
             logger.warning(
@@ -521,12 +545,12 @@ class HandlerIntentEventConsumer:
                     "handler": HANDLER_ID_INTENT_CONSUMER,
                     "reason": reason,
                     "retry_count": retry_count,
-                    "dlq_topic": self._config.dlq_topic_suffix,
+                    "dlq_topic": dlq_topic,
                 },
             )
             return
 
-        topic = f"{self._env_prefix}.{self._config.dlq_topic_suffix}"
+        topic = f"{self._env_prefix}.{dlq_topic}"
         dlq_message = {
             "original_message": message,
             "failure_reason": reason,
@@ -657,14 +681,14 @@ class HandlerIntentEventConsumer:
     async def stop(self) -> None:
         """Graceful shutdown.
 
-        Unsubscribes from Kafka topic, cancels pending message processing tasks,
-        and resets initialization state. Does not shutdown the storage adapter
-        (caller's responsibility).
+        Unsubscribes from all Kafka topics, cancels pending message processing
+        tasks, and resets initialization state. Does not shutdown the storage
+        adapter (caller's responsibility).
         """
         # Unsubscribe FIRST to prevent new messages during shutdown
-        if self._unsubscribe:
+        for unsubscribe in self._unsubscribe_fns:
             try:
-                self._unsubscribe()
+                unsubscribe()
             except Exception as e:
                 logger.warning(
                     "Error during Kafka unsubscribe",
@@ -673,7 +697,7 @@ class HandlerIntentEventConsumer:
                         "error": str(e),
                     },
                 )
-            self._unsubscribe = None
+        self._unsubscribe_fns.clear()
 
         # THEN cancel pending tasks
         if self._pending_tasks:

--- a/src/omnimemory/nodes/intent_event_consumer_effect/models/model_consumer_config.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/models/model_consumer_config.py
@@ -1,4 +1,8 @@
-"""Consumer configuration model for intent event consumer."""
+"""Consumer configuration model for intent event consumer.
+
+Migrated from singular topic suffix fields to standard event_bus.subscribe_topics
+list format per OMN-1746 for EventBusSubcontractWiring compatibility.
+"""
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -7,6 +11,11 @@ from pydantic import BaseModel, ConfigDict, Field
 class ModelIntentEventConsumerConfig(BaseModel):
     """Configuration for intent event consumer.
 
+    Topic configuration uses list-based fields matching the standard
+    ``event_bus.subscribe_topics`` contract format. This enables
+    declarative wiring via ``EventBusSubcontractWiring`` instead of
+    manual ``subscribe_callback`` injection.
+
     Note: consumer_group is NOT configured here. It is derived from
     ModelNodeIdentity via compute_consumer_group_id() per ADR.
     """
@@ -14,17 +23,18 @@ class ModelIntentEventConsumerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
     # Topic configuration (suffixes only - env prefix added at runtime)
-    subscribe_topic_suffix: str = Field(
-        default="onex.evt.omniintelligence.intent-classified.v1",
-        description="Topic suffix to subscribe to",
+    # Uses list format matching event_bus.subscribe_topics contract standard
+    subscribe_topics: list[str] = Field(
+        default=["onex.evt.omniintelligence.intent-classified.v1"],
+        description="Topic suffixes to subscribe to (env prefix added at runtime)",
     )
-    publish_stored_topic_suffix: str = Field(
-        default="onex.evt.omnimemory.intent-stored.v1",
-        description="Topic suffix for storage events (success and error use same topic via status field)",
+    publish_topics: list[str] = Field(
+        default=["onex.evt.omnimemory.intent-stored.v1"],
+        description="Topic suffixes to publish to (env prefix added at runtime)",
     )
-    dlq_topic_suffix: str = Field(
-        default="onex.evt.omniintelligence.intent-classified.v1.dlq",
-        description="Dead letter queue topic suffix",
+    dlq_topics: list[str] = Field(
+        default=["onex.evt.omniintelligence.intent-classified.v1.dlq"],
+        description="Dead letter queue topic suffixes",
     )
 
     # Circuit breaker configuration

--- a/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
@@ -15,9 +15,6 @@ def map_event_to_storage_request(
 ) -> ModelIntentStorageRequest:
     """Map incoming classified event to storage request.
 
-    The keywords field defaults to [] if not present in the event,
-    providing forward compatibility with OMN-1626.
-
     Args:
         event: The incoming intent-classified event from omniintelligence.
 
@@ -37,7 +34,6 @@ def map_event_to_storage_request(
             success=True,
             intent_category=intent_category,
             confidence=event.confidence,
-            keywords=event.keywords,  # Empty list if not present (forward-compatible)
         ),
         correlation_id=event.correlation_id,
     )

--- a/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
@@ -34,6 +34,7 @@ def map_event_to_storage_request(
             success=True,
             intent_category=intent_category,
             confidence=event.confidence,
+            keywords=event.keywords,
         ),
         correlation_id=event.correlation_id,
     )

--- a/src/omnimemory/nodes/intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_query_effect/contract.yaml
@@ -7,7 +7,7 @@
 
 # === REQUIRED ROOT FIELDS ===
 name: "intent_query_effect"
-contract_version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Effect node for event-driven intent queries via Kafka. Provides distribution analysis, session-based
   lookups, and recent intent retrieval from Memgraph."

--- a/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
@@ -555,7 +555,7 @@ class HandlerIntentQuery:
                 _CONTRACT_MAX_RESPONSE_TIME_MS,
             )
 
-        if not result.success:
+        if result.status != "success":
             return ModelIntentQueryResponseEvent.from_error(
                 query_id=request.query_id,
                 query_type="session",
@@ -615,7 +615,7 @@ class HandlerIntentQuery:
                 _CONTRACT_MAX_RESPONSE_TIME_MS,
             )
 
-        if not result.success:
+        if result.status != "success":
             return ModelIntentQueryResponseEvent.from_error(
                 query_id=request.query_id,
                 query_type="recent",

--- a/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/intent_query_effect/handlers/handler_intent_query.py
@@ -555,11 +555,19 @@ class HandlerIntentQuery:
                 _CONTRACT_MAX_RESPONSE_TIME_MS,
             )
 
-        if result.status != "success":
+        if result.status == "error":
             return ModelIntentQueryResponseEvent.from_error(
                 query_id=request.query_id,
                 query_type="session",
                 error_message=result.error_message or "Unknown error",
+                correlation_id=request.correlation_id,
+            )
+
+        if result.status == "no_results" or not result.intents:
+            return ModelIntentQueryResponseEvent.create_session_response(
+                query_id=request.query_id,
+                intents=[],
+                execution_time_ms=execution_time_ms,
                 correlation_id=request.correlation_id,
             )
 
@@ -615,11 +623,20 @@ class HandlerIntentQuery:
                 _CONTRACT_MAX_RESPONSE_TIME_MS,
             )
 
-        if result.status != "success":
+        if result.status == "error":
             return ModelIntentQueryResponseEvent.from_error(
                 query_id=request.query_id,
                 query_type="recent",
                 error_message=result.error_message or "Unknown error",
+                correlation_id=request.correlation_id,
+            )
+
+        if result.status == "no_results" or not result.intents:
+            return ModelIntentQueryResponseEvent.create_recent_response(
+                query_id=request.query_id,
+                intents=[],
+                time_range_hours=request.time_range_hours,
+                execution_time_ms=execution_time_ms,
                 correlation_id=request.correlation_id,
             )
 

--- a/src/omnimemory/nodes/intent_query_effect/models/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/models/__init__.py
@@ -5,19 +5,22 @@
 This module exports configuration and event models for the intent query effect node.
 
 Exports:
-    ModelIntentRecordPayload: Payload model for intent records in events.
+    IntentRecordPayload: Payload model for intent records in events.
     ModelHandlerIntentQueryConfig: Handler configuration model.
     ModelIntentQueryRequestedEvent: Request event for intent queries.
     ModelIntentQueryResponseEvent: Response event with query results.
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1504.
+
+.. versionchanged:: 0.3.0
+    ModelIntentRecordPayload renamed to IntentRecordPayload (omnibase-core 0.17).
 """
 
 from omnibase_core.models.events import (
+    IntentRecordPayload,
     ModelIntentQueryRequestedEvent,
     ModelIntentQueryResponseEvent,
-    ModelIntentRecordPayload,
 )
 
 from omnimemory.nodes.intent_query_effect.models.model_handler_intent_query_config import (
@@ -25,7 +28,7 @@ from omnimemory.nodes.intent_query_effect.models.model_handler_intent_query_conf
 )
 
 __all__ = [
-    "ModelIntentRecordPayload",
+    "IntentRecordPayload",
     "ModelHandlerIntentQueryConfig",
     "ModelIntentQueryRequestedEvent",
     "ModelIntentQueryResponseEvent",

--- a/src/omnimemory/nodes/intent_query_effect/models/__init__.py
+++ b/src/omnimemory/nodes/intent_query_effect/models/__init__.py
@@ -5,7 +5,7 @@
 This module exports configuration and event models for the intent query effect node.
 
 Exports:
-    IntentRecordPayload: Payload model for intent records in events.
+    ModelIntentRecordPayload: Payload model for intent records in events.
     ModelHandlerIntentQueryConfig: Handler configuration model.
     ModelIntentQueryRequestedEvent: Request event for intent queries.
     ModelIntentQueryResponseEvent: Response event with query results.
@@ -14,13 +14,13 @@ Exports:
     Initial implementation for OMN-1504.
 
 .. versionchanged:: 0.3.0
-    ModelIntentRecordPayload renamed to IntentRecordPayload (omnibase-core 0.17).
+    Uses ModelIntentRecordPayload from omnibase-core 0.17.
 """
 
 from omnibase_core.models.events import (
-    IntentRecordPayload,
     ModelIntentQueryRequestedEvent,
     ModelIntentQueryResponseEvent,
+    ModelIntentRecordPayload,
 )
 
 from omnimemory.nodes.intent_query_effect.models.model_handler_intent_query_config import (
@@ -28,8 +28,8 @@ from omnimemory.nodes.intent_query_effect.models.model_handler_intent_query_conf
 )
 
 __all__ = [
-    "IntentRecordPayload",
     "ModelHandlerIntentQueryConfig",
     "ModelIntentQueryRequestedEvent",
     "ModelIntentQueryResponseEvent",
+    "ModelIntentRecordPayload",
 ]

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -59,7 +59,7 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
     for transmission in Kafka events.
 
     Args:
-        record: The intent record from AdapterIntentGraph (omnibase_core model).
+        record: The intent record from AdapterIntentGraph (omnimemory domain model).
 
     Returns:
         ModelIntentRecordPayload suitable for event transmission.
@@ -67,7 +67,7 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
     Note:
         Field mappings:
             - ModelIntentRecord.session_ref -> ModelIntentRecordPayload.session_ref
-            - ModelIntentRecord.intent_category (enum) -> str value
+            - ModelIntentRecord.intent_category -> str value
             - ModelIntentRecord.created_at_utc -> ModelIntentRecordPayload.created_at
     """
     return ModelIntentRecordPayload(
@@ -88,7 +88,7 @@ def map_intent_records(
     Convenience function for bulk conversion of intent records.
 
     Args:
-        records: List of intent records from omnibase_core.
+        records: List of intent records from omnimemory.
 
     Returns:
         List of payload models for event transmission.

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -2,19 +2,19 @@
 # Copyright (c) 2025 OmniNode Team
 """Utilities for mapping between core intent models and event payloads.
 
-This module provides mapping functions to convert between core
+This module provides mapping functions to convert between
 ModelIntentRecord and the event payload models used for Kafka event
 transmission.
 
 The key difference between models:
-    - ModelIntentRecord.session_id is required (from omnibase_core)
-    - ModelIntentRecordPayload.session_ref is required (for event transmission)
+    - ModelIntentRecord.session_id is required (local domain model)
+    - IntentRecordPayload.session_ref is required (for event transmission)
     - ModelIntentRecord.intent_category is EnumIntentCategory (enum)
-    - ModelIntentRecordPayload.intent_category is str
+    - IntentRecordPayload.intent_category is str
 
 Example::
 
-    from omnibase_core.models.intelligence import ModelIntentRecord
+    from omnimemory.handlers.adapters.models import ModelIntentRecord
     from omnibase_core.enums.intelligence import EnumIntentCategory
     from omnimemory.nodes.intent_query_effect.utils import map_to_intent_payload
 
@@ -35,20 +35,26 @@ Example::
 .. versionchanged:: 0.2.0
     Updated to use omnibase_core.models.intelligence.ModelIntentRecord
     instead of local domain model (omnibase-core 0.13.1).
+
+.. versionchanged:: 0.3.0
+    ModelIntentRecordPayload renamed to IntentRecordPayload (omnibase-core 0.17).
+    ModelIntentRecord now imported from local domain model.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
-from omnibase_core.models.events import ModelIntentRecordPayload
-from omnibase_core.models.intelligence import ModelIntentRecord  # noqa: TC002
+from omnibase_core.models.events import IntentRecordPayload
+
+if TYPE_CHECKING:
+    from omnimemory.handlers.adapters.models import ModelIntentRecord
 
 __all__ = ["map_intent_records", "map_to_intent_payload"]
 
 
-def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload:
-    """Convert a ModelIntentRecord to ModelIntentRecordPayload.
+def map_to_intent_payload(record: ModelIntentRecord) -> IntentRecordPayload:
+    """Convert a ModelIntentRecord to IntentRecordPayload.
 
     Maps from the core intent model to the event payload model
     for transmission in Kafka events.
@@ -57,28 +63,28 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
         record: The intent record from AdapterIntentGraph (omnibase_core model).
 
     Returns:
-        ModelIntentRecordPayload suitable for event transmission.
+        IntentRecordPayload suitable for event transmission.
 
     Note:
         Field mappings:
-            - ModelIntentRecord.session_id -> ModelIntentRecordPayload.session_ref
+            - ModelIntentRecord.session_id -> IntentRecordPayload.session_ref
             - ModelIntentRecord.intent_category (enum) -> str value
-            - ModelIntentRecord.created_at -> ModelIntentRecordPayload.created_at
+            - ModelIntentRecord.created_at -> IntentRecordPayload.created_at
     """
-    return ModelIntentRecordPayload(
+    return IntentRecordPayload(
         intent_id=record.intent_id,
-        session_ref=record.session_id,
-        intent_category=record.intent_category.value,
+        session_ref=record.session_ref or "",
+        intent_category=record.intent_category,
         confidence=record.confidence,
         keywords=record.keywords,
-        created_at=record.created_at or datetime.now(UTC),
+        created_at=record.created_at_utc,
     )
 
 
 def map_intent_records(
     records: list[ModelIntentRecord],
-) -> list[ModelIntentRecordPayload]:
-    """Convert a list of ModelIntentRecord to ModelIntentRecordPayload.
+) -> list[IntentRecordPayload]:
+    """Convert a list of ModelIntentRecord to IntentRecordPayload.
 
     Convenience function for bulk conversion of intent records.
 

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -73,11 +73,7 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
     return ModelIntentRecordPayload(
         intent_id=record.intent_id,
         session_ref=record.session_ref or "",
-        intent_category=(
-            record.intent_category.value
-            if hasattr(record.intent_category, "value")
-            else str(record.intent_category)
-        ),
+        intent_category=record.intent_category,
         confidence=record.confidence,
         keywords=record.keywords,
         created_at=record.created_at_utc,

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -75,16 +75,11 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
             - ModelIntentRecord.intent_category (str) -> ModelIntentRecordPayload.intent_category (str)
             - ModelIntentRecord.created_at_utc -> ModelIntentRecordPayload.created_at
     """
-    # Defensive: ensure intent_category is a plain str even if an enum leaks through
-    intent_category = (
-        record.intent_category.value
-        if hasattr(record.intent_category, "value")
-        else record.intent_category
-    )
+    # ModelIntentRecord.intent_category is typed as str, so use directly.
     return ModelIntentRecordPayload(
         intent_id=record.intent_id,
         session_ref=record.session_ref or "",
-        intent_category=intent_category,
+        intent_category=record.intent_category,
         confidence=record.confidence,
         keywords=record.keywords,
         created_at=record.created_at_utc,

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -7,21 +7,20 @@ ModelIntentRecord and the event payload models used for Kafka event
 transmission.
 
 The key difference between models:
-    - ModelIntentRecord.session_id is required (local domain model)
+    - ModelIntentRecord.session_ref is required (local domain model)
     - ModelIntentRecordPayload.session_ref is required (for event transmission)
-    - ModelIntentRecord.intent_category is EnumIntentCategory (enum)
+    - ModelIntentRecord.intent_category is str
     - ModelIntentRecordPayload.intent_category is str
 
 Example::
 
     from omnimemory.handlers.adapters.models import ModelIntentRecord
-    from omnibase_core.enums.intelligence import EnumIntentCategory
     from omnimemory.nodes.intent_query_effect.utils import map_to_intent_payload
 
     record = ModelIntentRecord(
         intent_id=uuid4(),
-        session_id="session_abc123",
-        intent_category=EnumIntentCategory.DEBUGGING,
+        session_ref="session_abc123",
+        intent_category="debugging",
         confidence=0.9,
         keywords=["error", "fix"],
     )
@@ -67,14 +66,18 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
 
     Note:
         Field mappings:
-            - ModelIntentRecord.session_id -> ModelIntentRecordPayload.session_ref
+            - ModelIntentRecord.session_ref -> ModelIntentRecordPayload.session_ref
             - ModelIntentRecord.intent_category (enum) -> str value
-            - ModelIntentRecord.created_at -> ModelIntentRecordPayload.created_at
+            - ModelIntentRecord.created_at_utc -> ModelIntentRecordPayload.created_at
     """
     return ModelIntentRecordPayload(
         intent_id=record.intent_id,
         session_ref=record.session_ref or "",
-        intent_category=record.intent_category,
+        intent_category=(
+            record.intent_category.value
+            if hasattr(record.intent_category, "value")
+            else str(record.intent_category)
+        ),
         confidence=record.confidence,
         keywords=record.keywords,
         created_at=record.created_at_utc,

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -7,12 +7,16 @@ ModelIntentRecord and the event payload models used for Kafka event
 transmission.
 
 The key difference between models:
-    - ModelIntentRecord.session_ref is required (local domain model)
-    - ModelIntentRecordPayload.session_ref is required (for event transmission)
+    - ModelIntentRecord.session_ref is optional (str | None, local domain model)
+    - ModelIntentRecordPayload.session_ref is required (str, for event transmission)
     - ModelIntentRecord.intent_category is str
     - ModelIntentRecordPayload.intent_category is str
+    - ModelIntentRecord.created_at_utc -> ModelIntentRecordPayload.created_at
 
 Example::
+
+    from datetime import datetime, timezone
+    from uuid import uuid4
 
     from omnimemory.handlers.adapters.models import ModelIntentRecord
     from omnimemory.nodes.intent_query_effect.utils import map_to_intent_payload
@@ -23,6 +27,7 @@ Example::
         intent_category="debugging",
         confidence=0.9,
         keywords=["error", "fix"],
+        created_at_utc=datetime.now(tz=timezone.utc),
     )
 
     payload = map_to_intent_payload(record)
@@ -66,14 +71,20 @@ def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload
 
     Note:
         Field mappings:
-            - ModelIntentRecord.session_ref -> ModelIntentRecordPayload.session_ref
-            - ModelIntentRecord.intent_category -> str value
+            - ModelIntentRecord.session_ref (str | None) -> ModelIntentRecordPayload.session_ref (str, defaults to "")
+            - ModelIntentRecord.intent_category (str) -> ModelIntentRecordPayload.intent_category (str)
             - ModelIntentRecord.created_at_utc -> ModelIntentRecordPayload.created_at
     """
+    # Defensive: ensure intent_category is a plain str even if an enum leaks through
+    intent_category = (
+        record.intent_category.value
+        if hasattr(record.intent_category, "value")
+        else record.intent_category
+    )
     return ModelIntentRecordPayload(
         intent_id=record.intent_id,
         session_ref=record.session_ref or "",
-        intent_category=record.intent_category,
+        intent_category=intent_category,
         confidence=record.confidence,
         keywords=record.keywords,
         created_at=record.created_at_utc,

--- a/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
+++ b/src/omnimemory/nodes/intent_query_effect/utils/util_intent_mapping.py
@@ -8,9 +8,9 @@ transmission.
 
 The key difference between models:
     - ModelIntentRecord.session_id is required (local domain model)
-    - IntentRecordPayload.session_ref is required (for event transmission)
+    - ModelIntentRecordPayload.session_ref is required (for event transmission)
     - ModelIntentRecord.intent_category is EnumIntentCategory (enum)
-    - IntentRecordPayload.intent_category is str
+    - ModelIntentRecordPayload.intent_category is str
 
 Example::
 
@@ -37,7 +37,7 @@ Example::
     instead of local domain model (omnibase-core 0.13.1).
 
 .. versionchanged:: 0.3.0
-    ModelIntentRecordPayload renamed to IntentRecordPayload (omnibase-core 0.17).
+    Uses ModelIntentRecordPayload from omnibase-core 0.17.
     ModelIntentRecord now imported from local domain model.
 """
 
@@ -45,7 +45,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from omnibase_core.models.events import IntentRecordPayload
+from omnibase_core.models.events import ModelIntentRecordPayload
 
 if TYPE_CHECKING:
     from omnimemory.handlers.adapters.models import ModelIntentRecord
@@ -53,8 +53,8 @@ if TYPE_CHECKING:
 __all__ = ["map_intent_records", "map_to_intent_payload"]
 
 
-def map_to_intent_payload(record: ModelIntentRecord) -> IntentRecordPayload:
-    """Convert a ModelIntentRecord to IntentRecordPayload.
+def map_to_intent_payload(record: ModelIntentRecord) -> ModelIntentRecordPayload:
+    """Convert a ModelIntentRecord to ModelIntentRecordPayload.
 
     Maps from the core intent model to the event payload model
     for transmission in Kafka events.
@@ -63,15 +63,15 @@ def map_to_intent_payload(record: ModelIntentRecord) -> IntentRecordPayload:
         record: The intent record from AdapterIntentGraph (omnibase_core model).
 
     Returns:
-        IntentRecordPayload suitable for event transmission.
+        ModelIntentRecordPayload suitable for event transmission.
 
     Note:
         Field mappings:
-            - ModelIntentRecord.session_id -> IntentRecordPayload.session_ref
+            - ModelIntentRecord.session_id -> ModelIntentRecordPayload.session_ref
             - ModelIntentRecord.intent_category (enum) -> str value
-            - ModelIntentRecord.created_at -> IntentRecordPayload.created_at
+            - ModelIntentRecord.created_at -> ModelIntentRecordPayload.created_at
     """
-    return IntentRecordPayload(
+    return ModelIntentRecordPayload(
         intent_id=record.intent_id,
         session_ref=record.session_ref or "",
         intent_category=record.intent_category,
@@ -83,8 +83,8 @@ def map_to_intent_payload(record: ModelIntentRecord) -> IntentRecordPayload:
 
 def map_intent_records(
     records: list[ModelIntentRecord],
-) -> list[IntentRecordPayload]:
-    """Convert a list of ModelIntentRecord to IntentRecordPayload.
+) -> list[ModelIntentRecordPayload]:
+    """Convert a list of ModelIntentRecord to ModelIntentRecordPayload.
 
     Convenience function for bulk conversion of intent records.
 

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -350,10 +350,17 @@ class HandlerIntentStorageAdapter:
             limit=request.limit,
         )
 
+        # Handle no_results/not_found as valid (non-error) outcomes
+        status = getattr(result, "status", None)
+        if status in {"no_results", "not_found"}:
+            return ModelIntentStorageResponse(
+                status="no_results",
+                intents=[],
+                total_count=0,
+            )
+
         # Handle both local model (status field) and core model (success field)
-        is_success = getattr(result, "status", None) == "success" or getattr(
-            result, "success", False
-        )
+        is_success = status == "success" or getattr(result, "success", False)
 
         if is_success:
             if not result.intents:
@@ -365,17 +372,28 @@ class HandlerIntentStorageAdapter:
             # Convert to response model format
             # Handle both omnibase_core field name (created_at) and local field
             # name (created_at_utc) for cross-model compatibility.
-            intents = [
-                ModelIntentRecordResponse(
-                    intent_id=intent.intent_id,
-                    intent_category=str(intent.intent_category),
-                    confidence=intent.confidence,
-                    keywords=intent.keywords,
-                    created_at_utc=intent.created_at_utc.isoformat(),
-                    correlation_id=intent.correlation_id,
+            intents: list[ModelIntentRecordResponse] = []
+            for intent in result.intents:
+                created_at = getattr(intent, "created_at_utc", None) or getattr(
+                    intent, "created_at", None
                 )
-                for intent in result.intents
-            ]
+                created_at_str = (
+                    created_at.isoformat() if created_at is not None else ""
+                )
+                intents.append(
+                    ModelIntentRecordResponse(
+                        intent_id=intent.intent_id,
+                        intent_category=(
+                            intent.intent_category.value
+                            if hasattr(intent.intent_category, "value")
+                            else str(intent.intent_category)
+                        ),
+                        confidence=intent.confidence,
+                        keywords=intent.keywords,
+                        created_at_utc=created_at_str,
+                        correlation_id=intent.correlation_id,
+                    )
+                )
             return ModelIntentStorageResponse(
                 status="success",
                 intents=intents,

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -351,18 +351,14 @@ class HandlerIntentStorageAdapter:
         )
 
         # Handle no_results/not_found as valid (non-error) outcomes
-        status = getattr(result, "status", None)
-        if status in {"no_results", "not_found"}:
+        if result.status in {"no_results", "not_found"}:
             return ModelIntentStorageResponse(
                 status="no_results",
                 intents=[],
                 total_count=0,
             )
 
-        # Handle both local model (status field) and core model (success field)
-        is_success = status == "success" or getattr(result, "success", False)
-
-        if is_success:
+        if result.status == "success":
             if not result.intents:
                 return ModelIntentStorageResponse(
                     status="no_results",
@@ -370,27 +366,15 @@ class HandlerIntentStorageAdapter:
                     total_count=0,
                 )
             # Convert to response model format
-            # Handle both omnibase_core field name (created_at) and local field
-            # name (created_at_utc) for cross-model compatibility.
             intents: list[ModelIntentRecordResponse] = []
             for intent in result.intents:
-                created_at = getattr(intent, "created_at_utc", None) or getattr(
-                    intent, "created_at", None
-                )
-                created_at_str = (
-                    created_at.isoformat() if created_at is not None else ""
-                )
                 intents.append(
                     ModelIntentRecordResponse(
                         intent_id=intent.intent_id,
-                        intent_category=(
-                            intent.intent_category.value
-                            if hasattr(intent.intent_category, "value")
-                            else str(intent.intent_category)
-                        ),
+                        intent_category=intent.intent_category,
                         confidence=intent.confidence,
                         keywords=intent.keywords,
-                        created_at_utc=created_at_str,
+                        created_at_utc=intent.created_at_utc.isoformat(),
                         correlation_id=intent.correlation_id,
                     )
                 )

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -363,6 +363,8 @@ class HandlerIntentStorageAdapter:
                     total_count=0,
                 )
             # Convert to response model format
+            # Handle both omnibase_core field name (created_at) and local field
+            # name (created_at_utc) for cross-model compatibility.
             intents = [
                 ModelIntentRecordResponse(
                     intent_id=intent.intent_id,

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -302,14 +302,29 @@ class HandlerIntentStorageAdapter:
             str(request.correlation_id) if request.correlation_id else str(uuid4())
         )
 
+        # Convert ModelIntentClassificationOutput to ModelIntentClassificationInput
+        # for the adapter's protocol-conforming interface
+        from omnibase_core.models.intelligence import ModelIntentClassificationInput
+
+        intent_category_str = (
+            request.intent_data.intent_category.value
+            if hasattr(request.intent_data.intent_category, "value")
+            else str(request.intent_data.intent_category)
+        )
+        adapter_input = ModelIntentClassificationInput(
+            content=intent_category_str,
+            context={"domain": intent_category_str},
+            correlation_id=request.correlation_id,
+        )
+
         # Call the adapter (user_context removed in omnibase-core 0.13.1)
         result = await self._adapter.store_intent(
             session_id=request.session_id,
-            intent_data=request.intent_data,
+            intent_data=adapter_input,
             correlation_id=correlation_id,
         )
 
-        if result.success:
+        if result.status == "success":
             return ModelIntentStorageResponse(
                 status="success",
                 intent_id=result.intent_id,
@@ -350,7 +365,7 @@ class HandlerIntentStorageAdapter:
             limit=request.limit,
         )
 
-        if result.success:
+        if result.status == "success":
             if not result.intents:
                 return ModelIntentStorageResponse(
                     status="no_results",
@@ -361,14 +376,10 @@ class HandlerIntentStorageAdapter:
             intents = [
                 ModelIntentRecordResponse(
                     intent_id=intent.intent_id,
-                    intent_category=intent.intent_category.value
-                    if hasattr(intent.intent_category, "value")
-                    else str(intent.intent_category),
+                    intent_category=str(intent.intent_category),
                     confidence=intent.confidence,
                     keywords=intent.keywords,
-                    created_at_utc=intent.created_at.isoformat()
-                    if intent.created_at
-                    else "",
+                    created_at_utc=intent.created_at_utc.isoformat(),
                     correlation_id=intent.correlation_id,
                 )
                 for intent in result.intents

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping
+from datetime import datetime
 from uuid import uuid4
 
 import structlog
@@ -368,13 +369,25 @@ class HandlerIntentStorageAdapter:
             # Convert to response model format
             intents: list[ModelIntentRecordResponse] = []
             for intent in result.intents:
+                # Defensive enum normalization: extract .value if an enum leaks through
+                category = (
+                    intent.intent_category.value
+                    if hasattr(intent.intent_category, "value")
+                    else intent.intent_category
+                )
+                # Guard against None created_at_utc from external data sources
+                created_at = (
+                    intent.created_at_utc
+                    if intent.created_at_utc is not None
+                    else datetime.min
+                )
                 intents.append(
                     ModelIntentRecordResponse(
                         intent_id=intent.intent_id,
-                        intent_category=intent.intent_category,
+                        intent_category=category,
                         confidence=intent.confidence,
                         keywords=intent.keywords,
-                        created_at_utc=intent.created_at_utc.isoformat(),
+                        created_at_utc=created_at.isoformat(),
                         correlation_id=intent.correlation_id,
                     )
                 )

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -302,29 +302,14 @@ class HandlerIntentStorageAdapter:
             str(request.correlation_id) if request.correlation_id else str(uuid4())
         )
 
-        # Convert ModelIntentClassificationOutput to ModelIntentClassificationInput
-        # for the adapter's protocol-conforming interface
-        from omnibase_core.models.intelligence import ModelIntentClassificationInput
-
-        intent_category_str = (
-            request.intent_data.intent_category.value
-            if hasattr(request.intent_data.intent_category, "value")
-            else str(request.intent_data.intent_category)
-        )
-        adapter_input = ModelIntentClassificationInput(
-            content=intent_category_str,
-            context={"domain": intent_category_str},
-            correlation_id=request.correlation_id,
-        )
-
-        # Call the adapter (user_context removed in omnibase-core 0.13.1)
+        # Call the adapter with classification output directly
         result = await self._adapter.store_intent(
             session_id=request.session_id,
-            intent_data=adapter_input,
+            intent_data=request.intent_data,
             correlation_id=correlation_id,
         )
 
-        if result.status == "success":
+        if result.success:
             return ModelIntentStorageResponse(
                 status="success",
                 intent_id=result.intent_id,
@@ -365,7 +350,12 @@ class HandlerIntentStorageAdapter:
             limit=request.limit,
         )
 
-        if result.status == "success":
+        # Handle both local model (status field) and core model (success field)
+        is_success = getattr(result, "status", None) == "success" or getattr(
+            result, "success", False
+        )
+
+        if is_success:
             if not result.intents:
                 return ModelIntentStorageResponse(
                     status="no_results",

--- a/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
+++ b/src/omnimemory/nodes/intent_storage_effect/adapters/adapter_intent_storage.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping
-from datetime import datetime
 from uuid import uuid4
 
 import structlog
@@ -369,25 +368,13 @@ class HandlerIntentStorageAdapter:
             # Convert to response model format
             intents: list[ModelIntentRecordResponse] = []
             for intent in result.intents:
-                # Defensive enum normalization: extract .value if an enum leaks through
-                category = (
-                    intent.intent_category.value
-                    if hasattr(intent.intent_category, "value")
-                    else intent.intent_category
-                )
-                # Guard against None created_at_utc from external data sources
-                created_at = (
-                    intent.created_at_utc
-                    if intent.created_at_utc is not None
-                    else datetime.min
-                )
                 intents.append(
                     ModelIntentRecordResponse(
                         intent_id=intent.intent_id,
-                        intent_category=category,
+                        intent_category=intent.intent_category,
                         confidence=intent.confidence,
                         keywords=intent.keywords,
-                        created_at_utc=created_at.isoformat(),
+                        created_at_utc=intent.created_at_utc.isoformat(),
                         correlation_id=intent.correlation_id,
                     )
                 )

--- a/src/omnimemory/nodes/intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/intent_storage_effect/contract.yaml
@@ -7,7 +7,7 @@
 
 # === REQUIRED ROOT FIELDS ===
 name: "intent_storage_effect"
-contract_version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Intent storage effect node for persisting classified intents to Memgraph. Links intents
   to sessions for analytics and pattern learning."
@@ -111,6 +111,7 @@ event_type:
   publish_events: true
   subscribe_events: false
   event_routing: "intent"
+  invocation_mode: "orchestrator"
 
 # === VALIDATION RULES ===
 validation_rules:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -231,15 +231,15 @@ event_bus:
       description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
         from ACTIVE to EXPIRED state."
     "onex.evt.omnimemory.memory-archived.v1":
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
+      # schema_ref: TBD - ModelMemoryArchivedEvent not yet implemented (OMN-1453)
       description: "Memory archival event. Emitted when an EXPIRED memory is successfully transitioned
         to ARCHIVED state in cold storage."
     "onex.evt.omnimemory.memory-archive-initiated.v1":
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchiveInitiatedEvent"
+      # schema_ref: TBD - ModelMemoryArchiveInitiatedEvent not yet implemented (OMN-1453)
       description: "Memory archive initiation event. Emitted when an archive operation begins for an EXPIRED
         memory entity."
     "onex.evt.omnimemory.lifecycle-transition-failed.v1":
-      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
+      # schema_ref: TBD - ModelLifecycleTransitionFailedEvent not yet implemented (OMN-1453)
       description: "Lifecycle transition failure event. Emitted when a memory lifecycle state transition
         fails due to validation errors, storage failures, or constraint violations."
 

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -52,7 +52,7 @@
 
 contract_version:
   major: 0
-  minor: 1
+  minor: 2
   patch: 0
 
 node_version:
@@ -230,6 +230,18 @@ event_bus:
       schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick.ModelMemoryExpiredEvent"
       description: "Memory expiration event. Emitted when a memory exceeds its hard TTL and transitions
         from ACTIVE to EXPIRED state."
+    "onex.evt.omnimemory.memory-archived.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchivedEvent"
+      description: "Memory archival event. Emitted when an EXPIRED memory is successfully transitioned
+        to ARCHIVED state in cold storage."
+    "onex.evt.omnimemory.memory-archive-initiated.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelMemoryArchiveInitiatedEvent"
+      description: "Memory archive initiation event. Emitted when an archive operation begins for an EXPIRED
+        memory entity."
+    "onex.evt.omnimemory.lifecycle-transition-failed.v1":
+      schema_ref: "omnimemory.nodes.memory_lifecycle_orchestrator.models.ModelLifecycleTransitionFailedEvent"
+      description: "Lifecycle transition failure event. Emitted when a memory lifecycle state transition
+        fails due to validation errors, storage failures, or constraint violations."
 
 # Orchestration configuration - use defaults
 load_balancing_enabled: true

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -118,12 +118,11 @@ consumed_events:
   - event_pattern: "onex.cmd.omnimemory.expire-memory.v1"
     handler_function: "handle_expire_memory"
 
-  - event_pattern: "onex.cmd.omnimemory.restore-memory.v1"
-    handler_function: "handle_restore_memory"
-
-  # Memory access events for lifecycle tracking
-  - event_pattern: "onex.evt.omnimemory.memory-accessed.v1"
-    handler_function: "handle_memory_accessed"
+# Planned events (OMN-1453) - uncomment when handlers are implemented:
+#   - event_pattern: "onex.cmd.omnimemory.restore-memory.v1"
+#     handler_function: "handle_restore_memory"
+#   - event_pattern: "onex.evt.omnimemory.memory-accessed.v1"
+#     handler_function: "handle_memory_accessed"
 
 # Published events - empty list since ModelEventDescriptor requires complex
 # fields (UUIDs, enums, etc.) that are better defined at runtime
@@ -203,8 +202,14 @@ event_bus:
     - "onex.cmd.omnimemory.expire-memory.v1"
 
   # Topics this node publishes to (sends events to)
+  # See ARCHITECTURAL NOTES above for full list of published event topics
   publish_topics:
     - "onex.evt.omnimemory.memory-expired.v1"
+    - "onex.evt.omnimemory.memory-archived.v1"
+    - "onex.evt.omnimemory.memory-archive-initiated.v1"
+    # Planned topics (OMN-1453) - uncomment when handlers are implemented:
+    #   - "onex.evt.omnimemory.memory-restored.v1"
+    - "onex.evt.omnimemory.lifecycle-transition-failed.v1"
 
   # Metadata for subscribed topics
   subscribe_topic_metadata:

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -7,7 +7,7 @@
 
 # === REQUIRED ROOT FIELDS ===
 name: "memory_retrieval_effect"
-contract_version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Memory retrieval effect node for search operations. P2A: Qdrant semantic search, PostgreSQL
   full-text search, and Graph traversal backends."

--- a/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_retrieval_effect/contract.yaml
@@ -150,6 +150,7 @@ validation_rules:
 # === HANDLER ROUTING (ONEX Multi-Backend Effect Pattern) ===
 # Declarative routing configuration for backend handlers.
 # The main HandlerMemoryRetrieval acts as router, dispatching to backend handlers.
+# Supports both orchestrator invocation and event subscription (OMN-1746/OMN-2212).
 handler_routing:
   version:
     major: 1

--- a/src/omnimemory/nodes/memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/memory_storage_effect/contract.yaml
@@ -7,7 +7,7 @@
 
 # === REQUIRED ROOT FIELDS ===
 name: "memory_storage_effect"
-contract_version: {major: 0, minor: 1, patch: 0}
+contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Memory storage effect node for CRUD operations. P1A: FileSystem backend for snapshot persistence.
   Phase 2: PostgreSQL, Redis, and Pinecone backends."
@@ -149,6 +149,7 @@ event_type:
   publish_events: true
   subscribe_events: false
   event_routing: "memory"
+  invocation_mode: "orchestrator"
 
 # === INFRASTRUCTURE ===
 infrastructure:

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
+from collections.abc import Callable
 
 import yaml
 
@@ -82,27 +83,9 @@ def collect_subscribe_topics_from_contracts(
     all_topics: list[str] = []
 
     for package in packages:
-        try:
-            topics = _read_subscribe_topics(package)
-        except FileNotFoundError:
-            logger.warning(
-                "contract.yaml not found in package %s, skipping",
-                package,
-            )
-            continue
-        except ModuleNotFoundError:
-            logger.warning(
-                "Package %s is not installed/importable, skipping",
-                package,
-            )
-            continue
-        except yaml.YAMLError:
-            logger.warning(
-                "contract.yaml in package %s contains invalid YAML, skipping",
-                package,
-            )
-            continue
-        all_topics.extend(topics)
+        topics = _safe_read_topics(_read_subscribe_topics, package)
+        if topics is not None:
+            all_topics.extend(topics)
 
     logger.debug(
         "Collected %d omnimemory subscribe topics from %d contracts",
@@ -150,26 +133,7 @@ def collect_publish_topics_for_dispatch(
     result: dict[str, str] = {}
 
     for package in packages:
-        try:
-            topics = _read_publish_topics(package)
-        except FileNotFoundError:
-            logger.warning(
-                "contract.yaml not found in package %s, skipping",
-                package,
-            )
-            continue
-        except ModuleNotFoundError:
-            logger.warning(
-                "Package %s is not installed/importable, skipping",
-                package,
-            )
-            continue
-        except yaml.YAMLError:
-            logger.warning(
-                "contract.yaml in package %s contains invalid YAML, skipping",
-                package,
-            )
-            continue
+        topics = _safe_read_topics(_read_publish_topics, package)
         if topics:
             key = _derive_dispatch_key(package)
             result[key] = topics[0]
@@ -212,27 +176,9 @@ def collect_all_publish_topics(
     all_topics: list[str] = []
 
     for package in packages:
-        try:
-            topics = _read_publish_topics(package)
-        except FileNotFoundError:
-            logger.warning(
-                "contract.yaml not found in package %s, skipping",
-                package,
-            )
-            continue
-        except ModuleNotFoundError:
-            logger.warning(
-                "Package %s is not installed/importable, skipping",
-                package,
-            )
-            continue
-        except yaml.YAMLError:
-            logger.warning(
-                "contract.yaml in package %s contains invalid YAML, skipping",
-                package,
-            )
-            continue
-        all_topics.extend(topics)
+        topics = _safe_read_topics(_read_publish_topics, package)
+        if topics is not None:
+            all_topics.extend(topics)
 
     return all_topics
 
@@ -258,6 +204,48 @@ def canonical_topic_to_dispatch_alias(topic: str) -> str:
 # ============================================================================
 # Internal helpers
 # ============================================================================
+
+
+def _safe_read_topics(
+    reader: Callable[[str], list[str]],
+    package: str,
+) -> list[str] | None:
+    """Call *reader* for *package*, handling common contract read errors.
+
+    Wraps ``FileNotFoundError``, ``ModuleNotFoundError``, and
+    ``yaml.YAMLError`` with appropriate warning-level log messages and
+    returns ``None`` so the caller can skip the package.
+
+    Args:
+        reader: A callable that accepts a package name and returns a list
+            of topic strings (e.g. ``_read_subscribe_topics``).
+        package: Fully-qualified Python package path containing a
+            ``contract.yaml`` file.
+
+    Returns:
+        The topic list on success, or ``None`` if the contract could not
+        be read.
+    """
+    try:
+        return reader(package)
+    except FileNotFoundError:
+        logger.warning(
+            "contract.yaml not found in package %s, skipping",
+            package,
+        )
+        return None
+    except ModuleNotFoundError:
+        logger.warning(
+            "Package %s is not installed/importable, skipping",
+            package,
+        )
+        return None
+    except yaml.YAMLError:
+        logger.warning(
+            "contract.yaml in package %s contains invalid YAML, skipping",
+            package,
+        )
+        return None
 
 
 def _derive_dispatch_key(package: str) -> str:

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -71,16 +71,30 @@ def collect_subscribe_topics_from_contracts(
     Returns:
         Ordered list of subscribe topic strings.
 
-    Raises:
-        ModuleNotFoundError: If a node package is not installed/importable.
-        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
-        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
+    Note:
+        If a ``contract.yaml`` is missing or a node package is not
+        installed, a warning is logged and the package is skipped.
+        This prevents a single missing contract from blocking
+        discovery of topics from all other valid contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     all_topics: list[str] = []
 
     for package in packages:
-        topics = _read_subscribe_topics(package)
+        try:
+            topics = _read_subscribe_topics(package)
+        except FileNotFoundError:
+            logger.warning(
+                "contract.yaml not found in package %s, skipping",
+                package,
+            )
+            continue
+        except ModuleNotFoundError:
+            logger.warning(
+                "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
         all_topics.extend(topics)
 
     logger.debug(
@@ -118,16 +132,30 @@ def collect_publish_topics_for_dispatch(
         Dict mapping dispatch key to first publish topic string.
         Empty dict if no publish topics are declared.
 
-    Raises:
-        ModuleNotFoundError: If a node package is not installed/importable.
-        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
-        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
+    Note:
+        If a ``contract.yaml`` is missing or a node package is not
+        installed, a warning is logged and the package is skipped.
+        This prevents a single missing contract from blocking
+        discovery of topics from all other valid contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     result: dict[str, str] = {}
 
     for package in packages:
-        topics = _read_publish_topics(package)
+        try:
+            topics = _read_publish_topics(package)
+        except FileNotFoundError:
+            logger.warning(
+                "contract.yaml not found in package %s, skipping",
+                package,
+            )
+            continue
+        except ModuleNotFoundError:
+            logger.warning(
+                "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
         if topics:
             key = _derive_dispatch_key(package)
             result[key] = topics[0]
@@ -159,16 +187,30 @@ def collect_all_publish_topics(
         Ordered list of all publish topic strings.  Results may contain
         duplicate topics if multiple nodes publish to the same topic.
 
-    Raises:
-        ModuleNotFoundError: If a node package is not installed/importable.
-        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
-        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
+    Note:
+        If a ``contract.yaml`` is missing or a node package is not
+        installed, a warning is logged and the package is skipped.
+        This prevents a single missing contract from blocking
+        discovery of topics from all other valid contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     all_topics: list[str] = []
 
     for package in packages:
-        topics = _read_publish_topics(package)
+        try:
+            topics = _read_publish_topics(package)
+        except FileNotFoundError:
+            logger.warning(
+                "contract.yaml not found in package %s, skipping",
+                package,
+            )
+            continue
+        except ModuleNotFoundError:
+            logger.warning(
+                "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
         all_topics.extend(topics)
 
     return all_topics

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -58,8 +58,8 @@ def collect_subscribe_topics_from_contracts(
     """Collect subscribe topics from omnimemory node contracts.
 
     Scans ``contract.yaml`` files from omnimemory nodes and extracts
-    ``event_bus.subscribe_topics`` from each enabled node.  Returns the union
-    of all topics in package-declaration order.
+    ``event_bus.subscribe_topics`` from each enabled node.  Returns the
+    aggregate list of all topics in package-declaration order.
 
     This is the single replacement for formerly-hardcoded topic constants
     such as ``RegistryIntentQueryEffect.get_topic_suffixes()["subscribe"]``.
@@ -117,6 +117,11 @@ def collect_publish_topics_for_dispatch(
     Returns:
         Dict mapping dispatch key to first publish topic string.
         Empty dict if no publish topics are declared.
+
+    Raises:
+        ModuleNotFoundError: If a node package is not installed/importable.
+        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
+        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     result: dict[str, str] = {}
@@ -151,7 +156,13 @@ def collect_all_publish_topics(
             the built-in omnimemory event bus nodes.
 
     Returns:
-        Ordered list of all publish topic strings.
+        Ordered list of all publish topic strings.  Results may contain
+        duplicate topics if multiple nodes publish to the same topic.
+
+    Raises:
+        ModuleNotFoundError: If a node package is not installed/importable.
+        FileNotFoundError: If a ``contract.yaml`` is missing from a package.
+        yaml.YAMLError: If a ``contract.yaml`` is malformed YAML.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     all_topics: list[str] = []

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -72,10 +72,11 @@ def collect_subscribe_topics_from_contracts(
         Ordered list of subscribe topic strings.
 
     Note:
-        If a ``contract.yaml`` is missing or a node package is not
-        installed, a warning is logged and the package is skipped.
-        This prevents a single missing contract from blocking
-        discovery of topics from all other valid contracts.
+        If a ``contract.yaml`` is missing, contains invalid YAML, or a
+        node package is not installed, a warning is logged and the
+        package is skipped.  This prevents a single missing or corrupt
+        contract from blocking discovery of topics from all other valid
+        contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     all_topics: list[str] = []
@@ -92,6 +93,12 @@ def collect_subscribe_topics_from_contracts(
         except ModuleNotFoundError:
             logger.warning(
                 "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
+        except yaml.YAMLError:
+            logger.warning(
+                "contract.yaml in package %s contains invalid YAML, skipping",
                 package,
             )
             continue
@@ -133,10 +140,11 @@ def collect_publish_topics_for_dispatch(
         Empty dict if no publish topics are declared.
 
     Note:
-        If a ``contract.yaml`` is missing or a node package is not
-        installed, a warning is logged and the package is skipped.
-        This prevents a single missing contract from blocking
-        discovery of topics from all other valid contracts.
+        If a ``contract.yaml`` is missing, contains invalid YAML, or a
+        node package is not installed, a warning is logged and the
+        package is skipped.  This prevents a single missing or corrupt
+        contract from blocking discovery of topics from all other valid
+        contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     result: dict[str, str] = {}
@@ -153,6 +161,12 @@ def collect_publish_topics_for_dispatch(
         except ModuleNotFoundError:
             logger.warning(
                 "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
+        except yaml.YAMLError:
+            logger.warning(
+                "contract.yaml in package %s contains invalid YAML, skipping",
                 package,
             )
             continue
@@ -188,10 +202,11 @@ def collect_all_publish_topics(
         duplicate topics if multiple nodes publish to the same topic.
 
     Note:
-        If a ``contract.yaml`` is missing or a node package is not
-        installed, a warning is logged and the package is skipped.
-        This prevents a single missing contract from blocking
-        discovery of topics from all other valid contracts.
+        If a ``contract.yaml`` is missing, contains invalid YAML, or a
+        node package is not installed, a warning is logged and the
+        package is skipped.  This prevents a single missing or corrupt
+        contract from blocking discovery of topics from all other valid
+        contracts.
     """
     packages = node_packages or _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES
     all_topics: list[str] = []
@@ -208,6 +223,12 @@ def collect_all_publish_topics(
         except ModuleNotFoundError:
             logger.warning(
                 "Package %s is not installed/importable, skipping",
+                package,
+            )
+            continue
+        except yaml.YAMLError:
+            logger.warning(
+                "contract.yaml in package %s contains invalid YAML, skipping",
                 package,
             )
             continue

--- a/tests/handlers/adapters/test_adapter_intent_graph.py
+++ b/tests/handlers/adapters/test_adapter_intent_graph.py
@@ -454,11 +454,11 @@ class TestModels:
     def test_intent_query_result_no_results(self) -> None:
         """Test ModelIntentQueryResult when no intents found."""
         result = ModelIntentQueryResult(
-            status="success",
+            status="no_results",
             intents=[],
         )
 
-        assert result.status == "success"
+        assert result.status == "no_results"
         assert result.intents == []
 
     def test_intent_query_result_error(self) -> None:
@@ -1295,7 +1295,7 @@ class TestGetSessionIntents:
             session_id="session_empty",
         )
 
-        assert result.status == "success"
+        assert result.status == "no_results"
         assert result.intents == []
 
     @pytest.mark.asyncio

--- a/tests/handlers/adapters/test_adapter_intent_graph.py
+++ b/tests/handlers/adapters/test_adapter_intent_graph.py
@@ -1273,7 +1273,7 @@ class TestGetSessionIntents:
             session_id="session_123",
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert len(result.intents) == 2
 
         # Verify first intent
@@ -1295,7 +1295,7 @@ class TestGetSessionIntents:
             session_id="session_empty",
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert result.intents == []
 
     @pytest.mark.asyncio
@@ -1367,7 +1367,7 @@ class TestGetSessionIntents:
 
         result = await adapter.get_session_intents(session_id="session_123")
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.error_message is not None
         assert "not initialized" in result.error_message.lower()
 
@@ -1384,7 +1384,7 @@ class TestGetSessionIntents:
             session_id="session_123",
         )
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.error_message is not None
         assert "failed" in result.error_message.lower()
 
@@ -1683,7 +1683,7 @@ class TestErrorHandling:
 
         result = await adapter_with_mock.get_session_intents(session_id="session_123")
 
-        assert result.success is True
+        assert result.status == "success"
         # Only the valid record with proper UUID should be included
         assert len(result.intents) == 1
         assert result.intents[0].intent_id == TEST_INTENT_ID_1
@@ -1714,7 +1714,7 @@ class TestErrorHandling:
         query_result = await adapter_with_mock.get_session_intents(
             session_id="session_123",
         )
-        assert query_result.success is False
+        assert query_result.status == "error"
 
         distribution = await adapter_with_mock.get_intent_distribution()
         assert distribution.status == "error"

--- a/tests/handlers/adapters/test_adapter_intent_graph.py
+++ b/tests/handlers/adapters/test_adapter_intent_graph.py
@@ -1294,7 +1294,7 @@ class TestGetSessionIntents:
 
         # Verify first intent
         assert result.intents[0].intent_id == TEST_INTENT_ID_1
-        assert result.intents[0].intent_category == EnumIntentCategory.DEBUGGING
+        assert result.intents[0].intent_category == EnumIntentCategory.DEBUGGING.value
         assert result.intents[0].confidence == 0.92
         assert result.intents[0].keywords == ["error", "fix"]
 

--- a/tests/handlers/adapters/test_adapter_intent_graph.py
+++ b/tests/handlers/adapters/test_adapter_intent_graph.py
@@ -124,7 +124,6 @@ def adapter_with_mock(
 def sample_intent_classification() -> ModelIntentClassificationOutput:
     """Create a sample intent classification for testing."""
     return ModelIntentClassificationOutput(
-        success=True,
         intent_category=EnumIntentCategory.DEBUGGING,
         confidence=0.92,
         keywords=["error", "traceback", "fix"],
@@ -312,44 +311,62 @@ class TestModels:
     """Tests for Pydantic model validation."""
 
     def test_intent_classification_output_required_fields(self) -> None:
-        """Test ModelIntentClassificationOutput with required fields only."""
+        """Test ModelIntentClassificationOutput requires intent_category and confidence."""
+        from pydantic import ValidationError
+
+        # Verify that omitting required fields raises ValidationError
+        with pytest.raises(ValidationError, match="intent_category"):
+            ModelIntentClassificationOutput(confidence=0.5)
+
+        with pytest.raises(ValidationError, match="confidence"):
+            ModelIntentClassificationOutput(intent_category="debugging")
+
+        # Verify construction with only required fields succeeds
         classification = ModelIntentClassificationOutput(
-            success=True,
+            intent_category="unknown",
+            confidence=0.0,
         )
 
-        assert classification.success is True
-        assert classification.intent_category == EnumIntentCategory.UNKNOWN
+        assert classification.intent_category == "unknown"
         assert classification.confidence == 0.0
         assert classification.keywords == []
+        assert classification.raw_text is None
+        assert classification.metadata == {}
 
     def test_intent_classification_output_all_fields(self) -> None:
         """Test ModelIntentClassificationOutput with all fields."""
         classification = ModelIntentClassificationOutput(
-            success=True,
             intent_category=EnumIntentCategory.CODE_GENERATION,
             confidence=0.95,
             keywords=["python", "function", "async"],
+            raw_text="Write a python async function",
+            metadata={"model_version": "1.0"},
         )
 
-        assert classification.success is True
-        assert classification.intent_category == EnumIntentCategory.CODE_GENERATION
+        assert (
+            classification.intent_category == EnumIntentCategory.CODE_GENERATION.value
+        )
         assert classification.confidence == 0.95
         assert classification.keywords == ["python", "function", "async"]
+        assert classification.raw_text == "Write a python async function"
+        assert classification.metadata == {"model_version": "1.0"}
 
     def test_intent_classification_output_confidence_bounds(self) -> None:
         """Test ModelIntentClassificationOutput confidence must be 0.0-1.0."""
         from pydantic import ValidationError
 
         # Valid bounds
-        ModelIntentClassificationOutput(success=True, confidence=0.0)
-        ModelIntentClassificationOutput(success=True, confidence=1.0)
+        ModelIntentClassificationOutput(intent_category="debugging", confidence=0.0)
+        ModelIntentClassificationOutput(intent_category="debugging", confidence=1.0)
 
         # Invalid
         with pytest.raises(ValidationError):
-            ModelIntentClassificationOutput(success=True, confidence=-0.1)
+            ModelIntentClassificationOutput(
+                intent_category="debugging", confidence=-0.1
+            )
 
         with pytest.raises(ValidationError):
-            ModelIntentClassificationOutput(success=True, confidence=1.1)
+            ModelIntentClassificationOutput(intent_category="debugging", confidence=1.1)
 
     def test_intent_storage_result_success(self) -> None:
         """Test ModelIntentStorageResult success case."""
@@ -1027,7 +1044,6 @@ class TestContextManager:
                     result = await adapter.store_intent(
                         session_id="session_123",
                         intent_data=ModelIntentClassificationOutput(
-                            success=True,
                             intent_category=EnumIntentCategory.DEBUGGING,
                             confidence=0.9,
                         ),
@@ -1631,7 +1647,6 @@ class TestErrorHandling:
         mock_handler.execute_query.side_effect = RuntimeError("Unexpected error")
 
         classification = ModelIntentClassificationOutput(
-            success=True,
             intent_category=EnumIntentCategory.UNKNOWN,
             confidence=0.5,
         )
@@ -1699,7 +1714,6 @@ class TestErrorHandling:
 
         # All operations should return error status
         classification = ModelIntentClassificationOutput(
-            success=True,
             intent_category=EnumIntentCategory.UNKNOWN,
             confidence=0.5,
         )

--- a/tests/handlers/adapters/test_adapter_intent_graph.py
+++ b/tests/handlers/adapters/test_adapter_intent_graph.py
@@ -354,12 +354,13 @@ class TestModels:
     def test_intent_storage_result_success(self) -> None:
         """Test ModelIntentStorageResult success case."""
         result = ModelIntentStorageResult(
-            success=True,
+            status="success",
             intent_id=TEST_INTENT_ID_1,
+            session_id="session_123",
             created=True,
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert result.intent_id == TEST_INTENT_ID_1
         assert result.created is True
         assert result.error_message is None
@@ -367,11 +368,12 @@ class TestModels:
     def test_intent_storage_result_error(self) -> None:
         """Test ModelIntentStorageResult error case."""
         result = ModelIntentStorageResult(
-            success=False,
+            status="error",
+            session_id="session_123",
             error_message="Connection timeout",
         )
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.intent_id is None
         assert result.created is False
         assert result.error_message == "Connection timeout"
@@ -379,41 +381,43 @@ class TestModels:
     def test_intent_storage_result_merged(self) -> None:
         """Test ModelIntentStorageResult when intent was merged (not created)."""
         result = ModelIntentStorageResult(
-            success=True,
+            status="success",
             intent_id=TEST_INTENT_ID_EXISTING,
+            session_id="session_123",
             created=False,  # Merged with existing
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert result.created is False
 
     def test_intent_record_model(self) -> None:
         """Test ModelIntentRecord creation."""
         record = ModelIntentRecord(
             intent_id=TEST_INTENT_ID_1,
-            session_id="session_123",
-            intent_category=EnumIntentCategory.DEBUGGING,
+            session_ref="session_123",
+            intent_category=EnumIntentCategory.DEBUGGING.value,
             confidence=0.92,
             keywords=["error", "fix"],
-            created_at=TEST_CREATED_AT_1,
+            created_at_utc=TEST_CREATED_AT_1,
             correlation_id=TEST_CORRELATION_ID,
         )
 
         assert record.intent_id == TEST_INTENT_ID_1
-        assert record.session_id == "session_123"
-        assert record.intent_category == EnumIntentCategory.DEBUGGING
+        assert record.session_ref == "session_123"
+        assert record.intent_category == EnumIntentCategory.DEBUGGING.value
         assert record.confidence == 0.92
         assert record.keywords == ["error", "fix"]
-        assert record.created_at == TEST_CREATED_AT_1
+        assert record.created_at_utc == TEST_CREATED_AT_1
         assert record.correlation_id == TEST_CORRELATION_ID
 
     def test_intent_record_defaults(self) -> None:
         """Test ModelIntentRecord default values."""
         record = ModelIntentRecord(
             intent_id=TEST_INTENT_ID_1,
-            session_id="session_123",
-            intent_category=EnumIntentCategory.UNKNOWN,
+            session_ref="session_123",
+            intent_category=EnumIntentCategory.UNKNOWN.value,
             confidence=0.5,
+            created_at_utc=TEST_CREATED_AT_1,
         )
 
         assert record.keywords == []
@@ -424,63 +428,59 @@ class TestModels:
         intents = [
             ModelIntentRecord(
                 intent_id=TEST_INTENT_ID_1,
-                session_id="session_123",
-                intent_category=EnumIntentCategory.DEBUGGING,
+                session_ref="session_123",
+                intent_category=EnumIntentCategory.DEBUGGING.value,
                 confidence=0.9,
-                created_at=TEST_CREATED_AT_1,
+                created_at_utc=TEST_CREATED_AT_1,
             ),
             ModelIntentRecord(
                 intent_id=TEST_INTENT_ID_2,
-                session_id="session_123",
-                intent_category=EnumIntentCategory.CODE_GENERATION,
+                session_ref="session_123",
+                intent_category=EnumIntentCategory.CODE_GENERATION.value,
                 confidence=0.85,
-                created_at=TEST_CREATED_AT_2,
+                created_at_utc=TEST_CREATED_AT_2,
             ),
         ]
 
         result = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=intents,
-            total_count=2,
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert len(result.intents) == 2
-        assert result.total_count == 2
         assert result.error_message is None
 
     def test_intent_query_result_no_results(self) -> None:
         """Test ModelIntentQueryResult when no intents found."""
         result = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[],
-            total_count=0,
         )
 
-        assert result.success is True
+        assert result.status == "success"
         assert result.intents == []
-        assert result.total_count == 0
 
     def test_intent_query_result_error(self) -> None:
         """Test ModelIntentQueryResult error case."""
         result = ModelIntentQueryResult(
-            success=False,
+            status="error",
             error_message="Query timeout",
         )
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.intents == []
         assert result.error_message == "Query timeout"
 
     def test_intent_query_result_status_values(self) -> None:
         """Test ModelIntentQueryResult with success/failure states."""
         # Success case
-        result_success = ModelIntentQueryResult(success=True)
-        assert result_success.success is True
+        result_success = ModelIntentQueryResult(status="success")
+        assert result_success.status == "success"
 
         # Error case
-        result_error = ModelIntentQueryResult(success=False, error_message="Failed")
-        assert result_error.success is False
+        result_error = ModelIntentQueryResult(status="error", error_message="Failed")
+        assert result_error.status == "error"
 
     def test_intent_graph_health_healthy(self) -> None:
         """Test ModelIntentGraphHealth when healthy."""

--- a/tests/handlers/test_handler_intent.py
+++ b/tests/handlers/test_handler_intent.py
@@ -30,16 +30,16 @@ from uuid import UUID, uuid4
 
 import pytest
 from omnibase_core.enums.intelligence import EnumIntentCategory
+from omnibase_core.models.intelligence import ModelIntentClassificationOutput
 from omnibase_core.models.intelligence import (
-    ModelIntentClassificationOutput,
-    ModelIntentQueryResult,
-    ModelIntentRecord,
-    ModelIntentStorageResult,
+    ModelIntentStorageResult as CoreIntentStorageResult,
 )
 
 from omnimemory.handlers.adapters.models import (
     ModelIntentDistributionResult,
     ModelIntentGraphHealth,
+    ModelIntentQueryResult,
+    ModelIntentRecord,
 )
 from omnimemory.handlers.handler_intent import (
     CircuitBreakerOpenError,
@@ -72,7 +72,7 @@ class MockAdapterIntentGraph:
     def __init__(
         self,
         *,
-        store_result: ModelIntentStorageResult | None = None,
+        store_result: CoreIntentStorageResult | None = None,
         query_result: ModelIntentQueryResult | None = None,
         distribution_result: ModelIntentDistributionResult | None = None,
         health_result: ModelIntentGraphHealth | None = None,
@@ -118,7 +118,7 @@ class MockAdapterIntentGraph:
         session_id: str,
         intent_data: ModelIntentClassificationOutput,
         correlation_id: str,
-    ) -> ModelIntentStorageResult:
+    ) -> CoreIntentStorageResult:
         self.store_intent_calls.append(
             {
                 "session_id": session_id,
@@ -133,7 +133,7 @@ class MockAdapterIntentGraph:
         if self._store_result:
             return self._store_result
 
-        return ModelIntentStorageResult(
+        return CoreIntentStorageResult(
             success=True,
             intent_id=uuid4(),
             created=True,
@@ -160,7 +160,7 @@ class MockAdapterIntentGraph:
             return self._query_result
 
         return ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[],
         )
 
@@ -481,7 +481,7 @@ class TestCircuitBreaker:
                 correlation_id=str(uuid4()),
             )
 
-            assert result.success is True
+            assert result.status == "success"
             assert handler._circuit_breaker is not None
             assert handler._circuit_breaker.state == CircuitBreakerState.CLOSED
             assert handler._circuit_breaker.failure_count == 0
@@ -497,7 +497,7 @@ class TestCircuitBreaker:
         class PartiallyFailingAdapter(MockAdapterIntentGraph):
             async def store_intent(
                 self, *args: object, **kwargs: object
-            ) -> ModelIntentStorageResult:
+            ) -> CoreIntentStorageResult:
                 nonlocal call_count
                 call_count += 1
                 if call_count <= 2:
@@ -541,7 +541,7 @@ class TestCircuitBreaker:
                 correlation_id=str(uuid4()),
             )
 
-            assert result.success is True
+            assert result.status == "success"
             assert handler._circuit_breaker.failure_count == 0
 
 
@@ -574,7 +574,7 @@ class TestOperations:
                 correlation_id=correlation_id,
             )
 
-            assert result.success is True
+            assert result.status == "success"
             assert len(mock_adapter.store_intent_calls) == 1
 
             call = mock_adapter.store_intent_calls[0]
@@ -596,7 +596,7 @@ class TestOperations:
             correlation_id=correlation_id,
         )
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.error_message is not None
         assert "not initialized" in result.error_message.lower()
 
@@ -609,15 +609,15 @@ class TestOperations:
         expected_intents = [
             ModelIntentRecord(
                 intent_id=uuid4(),
-                session_id="session_123",
-                intent_category=EnumIntentCategory.DEBUGGING,
+                session_ref="session_123",
+                intent_category="debugging",
                 confidence=0.92,
                 keywords=["error"],
-                created_at=datetime.now(UTC),
+                created_at_utc=datetime.now(UTC),
             )
         ]
         mock_adapter._query_result = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=expected_intents,
         )
 
@@ -633,7 +633,7 @@ class TestOperations:
                 limit=10,
             )
 
-            assert result.success is True
+            assert result.status == "success"
             assert len(result.intents) == 1
             assert len(mock_adapter.get_session_intents_calls) == 1
 
@@ -649,7 +649,7 @@ class TestOperations:
         """query_session on uninitialized handler should return error result."""
         result = await handler.query_session(session_id="session_123")
 
-        assert result.success is False
+        assert result.status == "error"
         assert result.error_message is not None
         assert "not initialized" in result.error_message.lower()
 
@@ -989,15 +989,15 @@ class TestIntegration:
         # Set up query to return the stored intent
         stored_intent = ModelIntentRecord(
             intent_id=uuid4(),
-            session_id="session_123",
-            intent_category=intent_data.intent_category,
+            session_ref="session_123",
+            intent_category=intent_data.intent_category.value,
             confidence=intent_data.confidence,
             keywords=intent_data.keywords,
-            created_at=datetime.now(UTC),
+            created_at_utc=datetime.now(UTC),
             correlation_id=UUID(correlation_id),
         )
         mock_adapter._query_result = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[stored_intent],
         )
 
@@ -1013,18 +1013,16 @@ class TestIntegration:
                 intent_data=intent_data,
                 correlation_id=correlation_id,
             )
-            assert store_result.success is True
+            assert store_result.status == "success"
 
             # Query it back
             query_result = await handler.query_session(
                 session_id="session_123",
                 min_confidence=0.5,
             )
-            assert query_result.success is True
+            assert query_result.status == "success"
             assert len(query_result.intents) == 1
-            assert (
-                query_result.intents[0].intent_category == EnumIntentCategory.DEBUGGING
-            )
+            assert query_result.intents[0].intent_category == "debugging"
 
     @pytest.mark.asyncio
     async def test_reinitialize_after_shutdown(self, handler: HandlerIntent) -> None:

--- a/tests/nodes/intent_event_consumer_effect/test_handler_intent_event_consumer.py
+++ b/tests/nodes/intent_event_consumer_effect/test_handler_intent_event_consumer.py
@@ -11,6 +11,10 @@ These tests verify the handler's integration behavior including:
 - Retry logic with exponential backoff
 
 All tests use mocked dependencies (no real Kafka/Memgraph).
+
+.. versionchanged:: 0.2.0
+    Updated for event_bus.subscribe_topics migration (OMN-1746).
+    Config uses list-based topic fields instead of singular suffix fields.
 """
 
 from __future__ import annotations
@@ -130,7 +134,11 @@ class TestInitialization:
 
     @pytest.mark.asyncio
     async def test_consumer_initialized_after_initialize(self) -> None:
-        """Consumer should report initialized after initialize() is called."""
+        """Consumer should report initialized after initialize() is called.
+
+        Verifies that all topics in subscribe_topics are subscribed to
+        with the correct env prefix.
+        """
         config = ModelIntentEventConsumerConfig()
         storage = create_mock_storage_adapter()
         subscribe_fn, subscriptions = create_mock_subscribe()
@@ -142,6 +150,30 @@ class TestInitialization:
         assert len(subscriptions) == 1
         assert (
             subscriptions[0][0] == "test.onex.evt.omniintelligence.intent-classified.v1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_consumer_subscribes_to_multiple_topics(self) -> None:
+        """Consumer should subscribe to all topics in subscribe_topics list."""
+        config = ModelIntentEventConsumerConfig(
+            subscribe_topics=[
+                "onex.evt.omniintelligence.intent-classified.v1",
+                "onex.evt.omniintelligence.intent-classified.v2",
+            ],
+        )
+        storage = create_mock_storage_adapter()
+        subscribe_fn, subscriptions = create_mock_subscribe()
+
+        consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
+        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+
+        assert consumer.is_initialized is True
+        assert len(subscriptions) == 2
+        assert (
+            subscriptions[0][0] == "test.onex.evt.omniintelligence.intent-classified.v1"
+        )
+        assert (
+            subscriptions[1][0] == "test.onex.evt.omniintelligence.intent-classified.v2"
         )
 
     @pytest.mark.asyncio
@@ -711,7 +743,7 @@ class TestStopCleanup:
 
     @pytest.mark.asyncio
     async def test_stop_unsubscribes_and_resets(self) -> None:
-        """stop() should unsubscribe and reset initialization state."""
+        """stop() should unsubscribe from all topics and reset initialization state."""
         storage = create_mock_storage_adapter()
         config = ModelIntentEventConsumerConfig()
         unsubscribe_mock = MagicMock()
@@ -726,10 +758,41 @@ class TestStopCleanup:
 
         await consumer.stop()
 
-        # Should have called unsubscribe
+        # Should have called unsubscribe for each topic
         unsubscribe_mock.assert_called_once()
 
         # Should reset state
+        assert consumer.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_stop_unsubscribes_multiple_topics(self) -> None:
+        """stop() should unsubscribe from all topics when multiple are configured."""
+        storage = create_mock_storage_adapter()
+        config = ModelIntentEventConsumerConfig(
+            subscribe_topics=[
+                "onex.evt.topic-a.v1",
+                "onex.evt.topic-b.v1",
+            ],
+        )
+        unsubscribe_mocks: list[MagicMock] = []
+
+        def mock_subscribe(topic: str, handler: object) -> MagicMock:
+            mock = MagicMock()
+            unsubscribe_mocks.append(mock)
+            return mock
+
+        consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
+        await consumer.initialize(subscribe_callback=mock_subscribe, env_prefix="test")
+
+        assert consumer.is_initialized is True
+        assert len(unsubscribe_mocks) == 2
+
+        await consumer.stop()
+
+        # Both unsubscribe functions should have been called
+        for mock in unsubscribe_mocks:
+            mock.assert_called_once()
+
         assert consumer.is_initialized is False
 
     @pytest.mark.asyncio
@@ -748,3 +811,43 @@ class TestStopCleanup:
         await consumer.stop()
 
         assert consumer.is_initialized is False
+
+
+# =============================================================================
+# Config Model Tests
+# =============================================================================
+
+
+class TestConfigModel:
+    """Tests for ModelIntentEventConsumerConfig with list-based topic fields."""
+
+    def test_default_config_has_correct_topics(self) -> None:
+        """Default config should have the standard topic suffixes."""
+        config = ModelIntentEventConsumerConfig()
+
+        assert config.subscribe_topics == [
+            "onex.evt.omniintelligence.intent-classified.v1"
+        ]
+        assert config.publish_topics == ["onex.evt.omnimemory.intent-stored.v1"]
+        assert config.dlq_topics == [
+            "onex.evt.omniintelligence.intent-classified.v1.dlq"
+        ]
+
+    def test_config_accepts_multiple_topics(self) -> None:
+        """Config should accept multiple topics in each list."""
+        config = ModelIntentEventConsumerConfig(
+            subscribe_topics=["topic-a.v1", "topic-b.v1"],
+            publish_topics=["publish-a.v1", "publish-b.v1"],
+            dlq_topics=["dlq-a.v1", "dlq-b.v1"],
+        )
+
+        assert len(config.subscribe_topics) == 2
+        assert len(config.publish_topics) == 2
+        assert len(config.dlq_topics) == 2
+
+    def test_config_rejects_extra_fields(self) -> None:
+        """Config with extra='forbid' should reject unknown fields."""
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            ModelIntentEventConsumerConfig(
+                unknown_field="value",  # type: ignore[call-arg]
+            )

--- a/tests/nodes/intent_event_consumer_effect/test_handler_intent_event_consumer.py
+++ b/tests/nodes/intent_event_consumer_effect/test_handler_intent_event_consumer.py
@@ -194,6 +194,76 @@ class TestInitialization:
         assert len(subscriptions) == 1  # Still 1, not 2
         assert consumer.is_initialized is True
 
+    @pytest.mark.asyncio
+    async def test_initialize_raises_on_empty_subscribe_topics(self) -> None:
+        """Initialize should raise ValueError when subscribe_topics is empty."""
+        config = ModelIntentEventConsumerConfig(subscribe_topics=[])
+        storage = create_mock_storage_adapter()
+        subscribe_fn, subscriptions = create_mock_subscribe()
+
+        consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
+
+        with pytest.raises(ValueError, match="subscribe_topics must not be empty"):
+            await consumer.initialize(
+                subscribe_callback=subscribe_fn, env_prefix="test"
+            )
+
+        assert consumer.is_initialized is False
+        assert len(subscriptions) == 0
+
+    @pytest.mark.asyncio
+    async def test_initialize_partial_subscription_failure(self) -> None:
+        """Initialize should continue with partial subscriptions if some fail."""
+        config = ModelIntentEventConsumerConfig(
+            subscribe_topics=[
+                "onex.evt.topic-good.v1",
+                "onex.evt.topic-bad.v1",
+                "onex.evt.topic-good2.v1",
+            ],
+        )
+        storage = create_mock_storage_adapter()
+        subscriptions: list[SubscriptionEntry] = []
+
+        def subscribe_with_failure(topic: str, handler: object) -> MagicMock:
+            if "topic-bad" in topic:
+                raise RuntimeError("Subscription failed for topic-bad")
+            subscriptions.append((topic, handler))
+            return MagicMock()
+
+        consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
+        await consumer.initialize(
+            subscribe_callback=subscribe_with_failure, env_prefix="test"
+        )
+
+        # Should be initialized with 2 of 3 topics
+        assert consumer.is_initialized is True
+        assert len(subscriptions) == 2
+        assert subscriptions[0][0] == "test.onex.evt.topic-good.v1"
+        assert subscriptions[1][0] == "test.onex.evt.topic-good2.v1"
+
+    @pytest.mark.asyncio
+    async def test_initialize_all_subscriptions_fail_raises(self) -> None:
+        """Initialize should raise RuntimeError when all subscriptions fail."""
+        config = ModelIntentEventConsumerConfig(
+            subscribe_topics=[
+                "onex.evt.topic-a.v1",
+                "onex.evt.topic-b.v1",
+            ],
+        )
+        storage = create_mock_storage_adapter()
+
+        def subscribe_always_fails(topic: str, handler: object) -> MagicMock:
+            raise RuntimeError(f"Cannot subscribe to {topic}")
+
+        consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
+
+        with pytest.raises(RuntimeError, match="All topic subscriptions failed"):
+            await consumer.initialize(
+                subscribe_callback=subscribe_always_fails, env_prefix="test"
+            )
+
+        assert consumer.is_initialized is False
+
 
 # =============================================================================
 # Message Processing Tests

--- a/tests/nodes/intent_storage_effect/test_handler_intent_storage_adapter_integration.py
+++ b/tests/nodes/intent_storage_effect/test_handler_intent_storage_adapter_integration.py
@@ -44,14 +44,14 @@ try:
     from omnibase_core.enums.intelligence import EnumIntentCategory
     from omnibase_core.models.intelligence import (
         ModelIntentClassificationOutput,
-        ModelIntentQueryResult,
-        ModelIntentRecord,
         ModelIntentStorageResult,
     )
 
     from omnimemory.handlers.adapters.models import (
         ModelAdapterIntentGraphConfig,
         ModelIntentDistributionResult,
+        ModelIntentQueryResult,
+        ModelIntentRecord,
     )
     from omnimemory.models.utils import ModelPIIDetectionResult, ModelPIIMatch, PIIType
     from omnimemory.nodes.intent_storage_effect import (
@@ -150,11 +150,11 @@ def sample_intent_record() -> ModelIntentRecord:
     """Create a sample intent record as returned by adapter queries."""
     return ModelIntentRecord(
         intent_id=TEST_INTENT_ID,
-        session_id=TEST_SESSION_ID,
-        intent_category=EnumIntentCategory.DEBUGGING,
+        session_ref=TEST_SESSION_ID,
+        intent_category="debugging",
         confidence=0.92,
         keywords=["error", "traceback"],
-        created_at=TEST_CREATED_AT,
+        created_at_utc=TEST_CREATED_AT,
         correlation_id=TEST_CORRELATION_ID,
     )
 
@@ -415,7 +415,7 @@ class TestGetSessionOperation:
         """Verify get_session_intents() is called with correct arguments."""
         # Arrange
         mock_adapter.get_session_intents.return_value = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[sample_intent_record],
         )
 
@@ -445,7 +445,7 @@ class TestGetSessionOperation:
         """Verify get_session returns correctly populated response."""
         # Arrange
         mock_adapter.get_session_intents.return_value = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[sample_intent_record],
         )
 
@@ -479,7 +479,7 @@ class TestGetSessionOperation:
         """Verify error status when adapter returns failure."""
         # Arrange - in new model, not_found is represented as success=False with error
         mock_adapter.get_session_intents.return_value = ModelIntentQueryResult(
-            success=False,
+            status="error",
             error_message="Session not found",
         )
 
@@ -503,7 +503,7 @@ class TestGetSessionOperation:
         """Verify no_results status when adapter returns empty list."""
         # Arrange - in new model, no_results is success=True with empty intents
         mock_adapter.get_session_intents.return_value = ModelIntentQueryResult(
-            success=True,
+            status="success",
             intents=[],
         )
 

--- a/tests/nodes/intent_storage_effect/test_handler_intent_storage_adapter_integration.py
+++ b/tests/nodes/intent_storage_effect/test_handler_intent_storage_adapter_integration.py
@@ -476,10 +476,10 @@ class TestGetSessionOperation:
         handler_with_mock: HandlerIntentStorageAdapter,
         mock_adapter: MagicMock,
     ) -> None:
-        """Verify error status when adapter returns failure."""
-        # Arrange - in new model, not_found is represented as success=False with error
+        """Verify no_results status when adapter returns not_found."""
+        # Arrange - adapter returns not_found which handler maps to no_results
         mock_adapter.get_session_intents.return_value = ModelIntentQueryResult(
-            status="error",
+            status="no_results",
             error_message="Session not found",
         )
 
@@ -492,8 +492,8 @@ class TestGetSessionOperation:
         response = await handler_with_mock.execute(request)
 
         # Assert
-        assert response.status == "error"
-        assert "not found" in (response.error_message or "").lower()
+        assert response.status == "no_results"
+        assert response.error_message is None
 
     async def test_get_session_handles_no_results(
         self,

--- a/tests/test_contract_version.py
+++ b/tests/test_contract_version.py
@@ -276,29 +276,39 @@ class TestContractVersionField:
                 )
 
     @pytest.mark.migration
-    @pytest.mark.parametrize("node_name", MIGRATED_CONTRACTS, ids=str)
+    @pytest.mark.parametrize(
+        ("node_name", "expected_version"),
+        [
+            ("memory_retrieval_effect", {"major": 0, "minor": 2, "patch": 0}),
+            ("memory_storage_effect", {"major": 0, "minor": 2, "patch": 0}),
+            ("similarity_compute", {"major": 0, "minor": 1, "patch": 0}),
+        ],
+        ids=["memory_retrieval_effect", "memory_storage_effect", "similarity_compute"],
+    )
     def test_contract_version_values(
-        self, contract_data: MappingResultDict, node_name: str
+        self,
+        contract_data: MappingResultDict,
+        node_name: str,
+        expected_version: dict[str, int],
     ) -> None:
-        """Verify contract_version has expected initial values after migration.
+        """Verify contract_version has expected values for each migrated contract.
 
         This test validates the actual version values, not just the structure.
-        All contracts migrated in PR #19 (OMN-1436) should have the initial
-        version 0.1.0 (major=0, minor=1, patch=0) as their starting point.
+        Contracts migrated in PR #19 (OMN-1436) started at 0.1.0. Some were
+        bumped to 0.2.0 when event_bus subcontracts were added (OMN-1746).
 
         This ensures:
         - Migration set consistent initial versions across all contracts
-        - Future version bumps can be tracked against this baseline
-        - No accidental version drift during migration
+        - Version bumps from subsequent PRs are tracked correctly
+        - No accidental version drift
 
         Note:
             This test has the @pytest.mark.migration marker because it asserts
             exact version values that will change when versions are bumped.
             Post-release, skip with: pytest -m "not migration"
         """
-        expected: dict[str, int] = {"major": 0, "minor": 1, "patch": 0}
-        assert contract_data.get("contract_version") == expected, (
-            f"Expected contract_version {expected} for {node_name}, "
+        assert contract_data.get("contract_version") == expected_version, (
+            f"Expected contract_version {expected_version} for {node_name}, "
             f"got {contract_data.get('contract_version')}"
         )
 

--- a/tests/unit/runtime/test_contract_topics.py
+++ b/tests/unit/runtime/test_contract_topics.py
@@ -89,6 +89,9 @@ EXPECTED_ALL_PUBLISH_TOPICS = {
     "onex.evt.omnimemory.memory-deleted.v1",
     # memory_lifecycle_orchestrator
     "onex.evt.omnimemory.memory-expired.v1",
+    "onex.evt.omnimemory.memory-archived.v1",
+    "onex.evt.omnimemory.memory-archive-initiated.v1",
+    "onex.evt.omnimemory.lifecycle-transition-failed.v1",
 }
 
 


### PR DESCRIPTION
## Summary

- Migrates `intent_event_consumer_effect` from non-standard `event_type.subscribe_topic_suffix` to standard `event_bus.subscribe_topics` format for `EventBusSubcontractWiring` compatibility
- Fixes all pre-existing mypy strict errors from omnibase_core 0.17 API changes (renamed/removed models, protocol signature alignment)

## Changes

### Contract Migration (OMN-1746 scope)
- **contract.yaml**: Replaced `event_type` block with standard `event_bus` block (`subscribe_topics`, `publish_topics`, `dlq_topics` as lists)
- **model_consumer_config.py**: Singular `str` fields → `list[str]` fields
- **handler_intent_event_consumer.py**: Loop-based multi-topic subscription, list-based unsubscribe cleanup
- **test_handler_intent_event_consumer.py**: Added multi-topic subscription/unsubscription tests + config model tests

### omnibase_core 0.17 Import Fixes (pre-existing, blocking push)
- `ModelIntentRecordPayload` → `IntentRecordPayload` (renamed in omnibase_core)
- `ModelIntentQueryResult`/`ModelIntentRecord`/`ModelIntentStorageResult` → imported from local `omnimemory.handlers.adapters.models` (never belonged in omnibase_core)
- `store_intent` signature aligned with `ProtocolIntentGraph` (Input type, optional correlation_id, ModelIntentStoredEvent return)
- Removed `keywords` field usage from `ModelIntentClassificationOutput` (field removed in 0.17)

## Test plan
- [x] All 20 pre-commit hooks pass
- [x] mypy --strict: 0 issues in 230 source files
- [x] pyright basic: pass
- [x] ruff check + format: clean
- [ ] CI pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-topic event subscription/publishing support (backward-compatible single-topic).
  * New published event topics for memory lifecycle and orchestration flags.

* **Bug Fixes**
  * Consistent status-based results ("success"/"no_results"/"error") for intent store/query flows.
  * Safer handling of IDs, correlation, and timestamps; standardized fields (session_ref, created_at_utc, intent_category as string).

* **Refactor**
  * Public model exports reorganized to a centralized adapters models surface; adapters/handlers convert to new status-based shapes.
  * Contract topic discovery now skips invalid/missing contracts non-fatally.

* **Documentation**
  * Contracts enriched with published_events docs and multiple contract version bumps.

* **Tests**
  * Expanded tests for multi-topic behavior, updated model shapes, and new topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->