### PR TITLE
feat(arch): ARCH-002 compliance — abstract Kafka from handlers (OMN-2214)

### DIFF
--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -908,7 +908,7 @@ class HandlerSubscription:
         # Publish event via protocol adapter (ARCH-002 compliant)
         # Agents consume from this topic via consumer groups keyed by agent_id
         kafka_topic = config.kafka_notification_topic
-        event_payload = json.loads(event.model_dump_json())
+        event_payload = cast(dict[str, object], event.model_dump(mode="json"))
         await publisher.publish(
             topic=kafka_topic,
             key=topic,  # Partition by topic for ordering
@@ -1778,7 +1778,8 @@ class HandlerSubscription:
                 errors.append(f"Database check failed: {e}")
 
         # Check event bus health via protocol
-        event_bus_healthy = False
+        # None = unknown (bus does not implement health check protocol)
+        event_bus_healthy: bool | None = None
         if self._event_bus_health:
             try:
                 health_result = await self._event_bus_health.health_check()
@@ -1814,9 +1815,13 @@ class HandlerSubscription:
             except Exception as e:
                 errors.append(f"Event bus check failed: {e}")
 
-        # Only fully healthy if all components are explicitly True
+        # Healthy when all known components report True.
+        # event_bus_healthy=None means the bus lacks health-check support;
+        # this is acceptable (not a failure), so treat None as non-blocking.
         is_healthy = (
-            valkey_healthy is True and db_healthy is True and event_bus_healthy is True
+            valkey_healthy is True
+            and db_healthy is True
+            and event_bus_healthy is not False
         )
 
         return ModelSubscriptionHealth(

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -920,11 +920,6 @@ class HandlerSubscription:
                 topic=kafka_topic,
                 key=topic,  # Partition by topic for ordering
                 value=event_payload,
-                headers={
-                    "event_id": event.event_id,
-                    "topic": topic,
-                    "subscriber_count": str(subscriber_count),
-                },
             )
         except Exception as exc:
             logger.warning(

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -3,19 +3,19 @@
 This module provides the core subscription management functionality:
 - subscribe(): Register agent subscriptions to memory topics
 - unsubscribe(): Remove agent subscriptions
-- notify(): Publish notification events to Kafka for subscriber consumption
+- notify(): Publish notification events to the event bus for subscriber consumption
 - list_subscriptions(): Get subscriptions for an agent (with optional pagination)
 
 Architecture:
 - Persistence: Valkey (fast lookups) + PostgreSQL (source of truth)
-- Delivery: Kafka event bus (agents consume directly)
+- Delivery: Event bus (agents consume directly)
 - Topic naming: memory.<entity>.<event> convention
 
 Event Bus Strategy:
-    Notifications are published to Kafka topics. Internal agents consume
-    events directly via consumer groups. If external (non-Kafka) delivery
-    is needed in the future, implement a WebhookEmitterEffect node that
-    consumes bus events and handles HTTP delivery separately.
+    Notifications are published to event bus topics. Internal agents consume
+    events directly via consumer groups. If external delivery is needed in
+    the future, implement a WebhookEmitterEffect node that consumes bus
+    events and handles HTTP delivery separately.
 
 Known Limitations:
     Transaction Boundaries:
@@ -70,7 +70,7 @@ Example::
         topic="memory.item.created",
     )
 
-    # Notify all subscribers (publishes to Kafka)
+    # Notify all subscribers (publishes to event bus)
     event = ModelNotificationEvent(
         event_id="evt_456",
         topic="memory.item.created",
@@ -88,7 +88,7 @@ Example::
     Initial implementation for OMN-1393.
 
 .. versionchanged:: 0.2.0
-    Removed webhook delivery in favor of Kafka event bus.
+    Removed webhook delivery in favor of event bus.
     Webhook delivery moved to optional WebhookEmitterEffect node.
 """
 
@@ -278,7 +278,7 @@ class ModelSubscriptionMetrics(  # omnimemory-model-exempt: handler internal
     and observability.
 
     Attributes:
-        notifications_published: Count of notifications published to Kafka.
+        notifications_published: Count of notifications published to event bus.
         subscriptions_created: Count of new subscriptions created.
         subscriptions_updated: Count of existing subscriptions updated (re-subscriptions).
         subscriptions_deleted: Count of subscriptions deleted.
@@ -293,7 +293,7 @@ class ModelSubscriptionMetrics(  # omnimemory-model-exempt: handler internal
     notifications_published: int = Field(
         default=0,
         ge=0,
-        description="Count of notifications published to Kafka",
+        description="Count of notifications published to event bus",
     )
     subscriptions_created: int = Field(
         default=0,
@@ -322,7 +322,7 @@ class ModelSubscriptionHealth(  # omnimemory-model-exempt: handler health
         initialized: Whether the handler has been initialized.
         db_healthy: Database connection health.
         valkey_healthy: Valkey connection health.
-        kafka_healthy: Kafka connection health.
+        event_bus_healthy: Event bus connection health.
         error_message: Error details if unhealthy.
         metrics: Optional metrics for observability.
     """
@@ -349,9 +349,9 @@ class ModelSubscriptionHealth(  # omnimemory-model-exempt: handler health
         default=None,
         description="Valkey connection health",
     )
-    kafka_healthy: bool | None = Field(
+    event_bus_healthy: bool | None = Field(
         default=None,
-        description="Kafka connection health",
+        description="Event bus connection health",
     )
     error_message: str | None = Field(
         default=None,
@@ -438,17 +438,17 @@ class HandlerSubscription:
     """Handler for agent subscriptions and memory change notifications.
 
     Manages the lifecycle of subscriptions and publishes notification events
-    to Kafka for consumption by subscribing agents.
+    to the event bus for consumption by subscribing agents.
 
     Architecture:
         - Subscription store: PostgreSQL (source of truth) + Valkey (cache)
-        - Notification delivery: Kafka event bus
+        - Notification delivery: Event bus
         - Agents consume events directly via consumer groups
 
     Note on External Delivery:
         If webhook delivery to external systems is needed, implement a
-        WebhookEmitterEffect node that consumes Kafka events and handles
-        HTTP delivery with its own retry/circuit breaker logic.
+        WebhookEmitterEffect node that consumes event bus messages and
+        handles HTTP delivery with its own retry/circuit breaker logic.
 
     ONEX Container Pattern:
         This handler follows the ONEX container-driven pattern:
@@ -593,6 +593,11 @@ class HandlerSubscription:
                     if isinstance(event_bus, ProtocolEventBusHealthCheck)
                     else None
                 )
+                if self._event_bus_health is None:
+                    logger.warning(
+                        "Event bus does not implement ProtocolEventBusHealthCheck; "
+                        "health status will be unknown"
+                    )
                 self._publisher = AdapterKafkaPublisher(event_bus)
                 logger.info("Event bus initialized (via protocol adapter)")
 
@@ -870,11 +875,11 @@ class HandlerSubscription:
         topic: str,
         event: ModelNotificationEvent,
     ) -> int:
-        """Publish notification event to Kafka for subscriber consumption.
+        """Publish notification event to the event bus for subscriber consumption.
 
-        Agents subscribe to Kafka topics and consume events via consumer groups.
-        This method publishes the event to the event bus - actual delivery to
-        agents happens through their Kafka consumers.
+        Agents subscribe to event bus topics and consume events via consumer
+        groups. This method publishes the event to the event bus - actual
+        delivery to agents happens through their event bus consumers.
 
         Args:
             topic: The topic to notify (format: memory.<entity>.<event>).
@@ -909,16 +914,25 @@ class HandlerSubscription:
         # Agents consume from this topic via consumer groups keyed by agent_id
         kafka_topic = config.kafka_notification_topic
         event_payload = cast(dict[str, object], event.model_dump(mode="json"))
-        await publisher.publish(
-            topic=kafka_topic,
-            key=topic,  # Partition by topic for ordering
-            value=event_payload,
-            headers={
-                "event_id": event.event_id,
-                "topic": topic,
-                "subscriber_count": str(subscriber_count),
-            },
-        )
+        try:
+            await publisher.publish(
+                topic=kafka_topic,
+                key=topic,  # Partition by topic for ordering
+                value=event_payload,
+                headers={
+                    "event_id": event.event_id,
+                    "topic": topic,
+                    "subscriber_count": str(subscriber_count),
+                },
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to publish notification to topic %s for event %s: %s",
+                kafka_topic,
+                event.event_id,
+                exc,
+            )
+            raise
 
         await self._increment_metric("notifications_published")
 
@@ -1731,7 +1745,7 @@ class HandlerSubscription:
     async def health_check(self) -> ModelSubscriptionHealth:
         """Check if all handler components are healthy.
 
-        Performs health checks on Valkey, database, and Kafka handlers.
+        Performs health checks on Valkey, database, and event bus handlers.
         Component health is reported as:
         - True: Component is healthy and responding
         - False: Component is unhealthy or failed health check
@@ -1830,7 +1844,7 @@ class HandlerSubscription:
             initialized=True,
             db_healthy=db_healthy,
             valkey_healthy=valkey_healthy,
-            kafka_healthy=event_bus_healthy,
+            event_bus_healthy=event_bus_healthy,
             error_message="; ".join(errors) if errors else None,
             metrics=await self.get_metrics(),
         )
@@ -1855,7 +1869,7 @@ class HandlerSubscription:
             "pagination",
             "metrics",
             "health_check",
-            "kafka_delivery",
+            "event_bus_delivery",
             "valkey_caching",
             "postgresql_persistence",
         ]

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -681,6 +681,7 @@ class HandlerSubscription:
             not self._initialized
             or self._valkey is None
             or self._db_handler is None
+            or self._event_bus is None
             or self._publisher is None
             or self._config is None
         ):
@@ -1747,10 +1748,21 @@ class HandlerSubscription:
 
         Performs health checks on Valkey, database, and event bus handlers.
         Component health is reported as:
+
         - True: Component is healthy and responding
         - False: Component is unhealthy or failed health check
+        - None (event bus only): Event bus does not implement
+          ``ProtocolEventBusHealthCheck``; treated as non-failure so that
+          adapters without health-check support do not block overall health.
 
-        The overall is_healthy is True when ALL components are healthy.
+        The overall ``is_healthy`` is True when Valkey and DB are True **and**
+        event bus is not explicitly False (None is acceptable).
+
+        .. versionchanged:: 0.3.0
+            Event bus health uses ``is not False`` instead of ``is True``,
+            so ``None`` (health check not supported) is no longer treated
+            as unhealthy. This accommodates event bus adapters that do not
+            implement ``ProtocolEventBusHealthCheck``.
 
         Returns:
             ModelSubscriptionHealth with detailed status for each component.
@@ -1831,8 +1843,14 @@ class HandlerSubscription:
                 errors.append(f"Event bus check failed: {e}")
 
         # Healthy when all known components report True.
-        # event_bus_healthy=None means the bus lacks health-check support;
-        # this is acceptable (not a failure), so treat None as non-blocking.
+        # event_bus_healthy semantics (uses ``is not False`` deliberately):
+        #   True  -> bus is healthy
+        #   False -> bus is unhealthy (explicit failure)
+        #   None  -> bus does not implement ProtocolEventBusHealthCheck;
+        #            treated as non-failure for backwards compatibility with
+        #            adapters that don't support health checks. This means
+        #            None (unknown) does NOT block overall health, unlike the
+        #            prior Kafka-specific check which required ``is True``.
         is_healthy = (
             valkey_healthy is True
             and db_healthy is True

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -1813,6 +1813,7 @@ class HandlerSubscription:
                         f"({type(health_result).__name__})"
                     )
             except Exception as e:
+                event_bus_healthy = False
                 errors.append(f"Event bus check failed: {e}")
 
         # Healthy when all known components report True.

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -120,6 +120,7 @@ from omnimemory.runtime.adapters import (
     ProtocolEventBusHealthCheck,
     ProtocolEventBusLifecycle,
     ProtocolEventBusPublish,
+    create_default_event_bus,
 )
 
 if TYPE_CHECKING:
@@ -204,9 +205,9 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
         valkey_port: Valkey server port.
         valkey_db: Valkey database index.
         valkey_password: Optional Valkey password.
-        kafka_bootstrap_servers: Kafka bootstrap servers.
+        kafka_bootstrap_servers: Event bus bootstrap servers (Kafka endpoint).
         cache_ttl_seconds: TTL for cached subscription data.
-        kafka_notification_topic: Kafka topic for memory notification events.
+        kafka_notification_topic: Event bus topic for memory notification events.
         pagination_max_limit: Maximum allowed limit for pagination queries.
         cache_rebuild_batch_size: Batch size for cache rebuild operations.
     """
@@ -243,7 +244,7 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
     )
     kafka_bootstrap_servers: str = Field(
         default="localhost:9092",
-        description="Kafka bootstrap servers (comma-separated)",
+        description="Event bus bootstrap servers, comma-separated (Kafka endpoint)",
     )
     cache_ttl_seconds: int = Field(
         default=3600,
@@ -253,7 +254,7 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
     )
     kafka_notification_topic: str = Field(
         default="omnimemory.memory.notification.v1",
-        description="Kafka topic for memory notification events",
+        description="Event bus topic for memory notification events (Kafka topic name)",
     )
     pagination_max_limit: int = Field(
         default=1000,
@@ -576,8 +577,6 @@ class HandlerSubscription:
                 # Initialize event bus (ARCH-002 compliant)
                 # Handler depends on protocol, not concrete transport.
                 if event_bus is None:
-                    from omnimemory.runtime.adapters import create_default_event_bus
-
                     event_bus = await create_default_event_bus(
                         bootstrap_servers=self._config.kafka_bootstrap_servers,
                     )
@@ -882,6 +881,13 @@ class HandlerSubscription:
         groups. This method publishes the event to the event bus - actual
         delivery to agents happens through their event bus consumers.
 
+        Error Propagation:
+            Publish failures are propagated to callers rather than silently
+            swallowed. This is intentional -- silent failures masked delivery
+            problems and violated the principle of least surprise. Callers
+            that need fire-and-forget semantics should catch exceptions at
+            their own level.
+
         Args:
             topic: The topic to notify (format: memory.<entity>.<event>).
             event: The notification event to publish.
@@ -892,6 +898,8 @@ class HandlerSubscription:
         Raises:
             RuntimeError: If handler is not initialized.
             ValueError: If event.topic does not match the topic argument.
+            Exception: If the event bus publish operation fails (propagated
+                intentionally; see Error Propagation above).
         """
         _, _, publisher, config = self._ensure_initialized()
 
@@ -928,6 +936,7 @@ class HandlerSubscription:
                 event.event_id,
                 exc,
             )
+            # Intentionally propagate: silent failures were a bug, not a feature.
             raise
 
         await self._increment_metric("notifications_published")

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -102,7 +102,6 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
-from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
 from omnibase_infra.handlers.handler_db import HandlerDb
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
@@ -116,6 +115,12 @@ from omnimemory.models.subscription import (
     ModelSubscription,
 )
 from omnimemory.models.subscription.constants import TOPIC_PATTERN
+from omnimemory.runtime.adapters import (
+    AdapterKafkaPublisher,
+    ProtocolEventBusHealthCheck,
+    ProtocolEventBusLifecycle,
+    ProtocolEventBusPublish,
+)
 
 if TYPE_CHECKING:
     from omnibase_core.container import ModelONEXContainer
@@ -471,7 +476,10 @@ class HandlerSubscription:
         self._container = container
         self._config: ModelHandlerSubscriptionConfig | None = None
         self._db_handler: HandlerDb | None = None
-        self._kafka_handler: EventBusKafka | None = None
+        self._event_bus: ProtocolEventBusPublish | None = None
+        self._event_bus_lifecycle: ProtocolEventBusLifecycle | None = None
+        self._event_bus_health: ProtocolEventBusHealthCheck | None = None
+        self._publisher: AdapterKafkaPublisher | None = None
         self._valkey: AdapterValkey | None = None
         self._initialized = False
         self._init_lock = asyncio.Lock()
@@ -510,15 +518,28 @@ class HandlerSubscription:
         """Check if the handler has been initialized."""
         return self._initialized
 
-    async def initialize(self, config: ModelHandlerSubscriptionConfig) -> None:
-        """Initialize DB, Valkey, and Kafka handlers.
+    async def initialize(
+        self,
+        config: ModelHandlerSubscriptionConfig,
+        event_bus: ProtocolEventBusPublish | None = None,
+    ) -> None:
+        """Initialize DB, Valkey, and event bus handlers.
 
         Creates connections to all required services and optionally
         rebuilds the Valkey cache from PostgreSQL on cold start.
 
+        ARCH-002 Compliance:
+            The event_bus parameter accepts any ProtocolEventBusPublish-conforming
+            object. If not provided, a default EventBusKafka is constructed via
+            the runtime factory (``create_default_event_bus``). Handlers never
+            import transport modules directly.
+
         Args:
             config: The handler configuration specifying database, Valkey,
-                and Kafka connection details.
+                and event bus connection details.
+            event_bus: Optional pre-configured event bus. If None, a default
+                EventBusKafka is created from config.kafka_bootstrap_servers
+                via the runtime adapter factory.
 
         Raises:
             RuntimeError: If initialization fails.
@@ -552,14 +573,28 @@ class HandlerSubscription:
                 )
                 logger.info("Database handler initialized")
 
-                # Initialize Kafka handler
-                self._kafka_handler = EventBusKafka()
-                await self._kafka_handler.initialize(
-                    {
-                        "bootstrap_servers": self._config.kafka_bootstrap_servers,
-                    }
+                # Initialize event bus (ARCH-002 compliant)
+                # Handler depends on protocol, not concrete transport.
+                if event_bus is None:
+                    from omnimemory.runtime.adapters import create_default_event_bus
+
+                    event_bus = await create_default_event_bus(
+                        bootstrap_servers=self._config.kafka_bootstrap_servers,
+                    )
+                self._event_bus = event_bus
+                # Store lifecycle/health references if the bus supports them
+                self._event_bus_lifecycle = (
+                    event_bus
+                    if isinstance(event_bus, ProtocolEventBusLifecycle)
+                    else None
                 )
-                logger.info("Kafka handler initialized")
+                self._event_bus_health = (
+                    event_bus
+                    if isinstance(event_bus, ProtocolEventBusHealthCheck)
+                    else None
+                )
+                self._publisher = AdapterKafkaPublisher(event_bus)
+                logger.info("Event bus initialized (via protocol adapter)")
 
                 # Rebuild cache from DB on cold start
                 await self._rebuild_cache_from_db()
@@ -588,12 +623,16 @@ class HandlerSubscription:
                 logger.warning("Failed to shutdown DB handler during cleanup: %s", e)
             self._db_handler = None
 
-        if self._kafka_handler:
+        if self._event_bus_lifecycle:
             try:
-                await self._kafka_handler.shutdown()
+                await self._event_bus_lifecycle.shutdown()
             except Exception as e:
-                logger.warning("Failed to shutdown Kafka handler during cleanup: %s", e)
-            self._kafka_handler = None
+                logger.warning("Failed to shutdown event bus during cleanup: %s", e)
+        # Always clear references, even if lifecycle protocol is unsupported
+        self._event_bus = None
+        self._event_bus_lifecycle = None
+        self._event_bus_health = None
+        self._publisher = None
 
     async def shutdown(self) -> None:
         """Cleanup all resources."""
@@ -609,20 +648,26 @@ class HandlerSubscription:
                 await self._db_handler.shutdown()
                 self._db_handler = None
 
-            if self._kafka_handler:
-                await self._kafka_handler.shutdown()
-                self._kafka_handler = None
+            if self._event_bus_lifecycle:
+                await self._event_bus_lifecycle.shutdown()
+            # Always clear references, even if lifecycle protocol is unsupported
+            self._event_bus = None
+            self._event_bus_lifecycle = None
+            self._event_bus_health = None
+            self._publisher = None
 
             self._initialized = False
             logger.info("HandlerSubscription shutdown complete")
 
     def _ensure_initialized(
         self,
-    ) -> tuple[AdapterValkey, HandlerDb, EventBusKafka, ModelHandlerSubscriptionConfig]:
+    ) -> tuple[
+        AdapterValkey, HandlerDb, AdapterKafkaPublisher, ModelHandlerSubscriptionConfig
+    ]:
         """Ensure handler is initialized and return components.
 
         Returns:
-            Tuple of (valkey, db_handler, kafka_handler, config).
+            Tuple of (valkey, db_handler, publisher, config).
 
         Raises:
             RuntimeError: If handler is not initialized.
@@ -631,13 +676,13 @@ class HandlerSubscription:
             not self._initialized
             or self._valkey is None
             or self._db_handler is None
-            or self._kafka_handler is None
+            or self._publisher is None
             or self._config is None
         ):
             raise RuntimeError(
                 "HandlerSubscription not initialized. Call initialize(config) first."
             )
-        return self._valkey, self._db_handler, self._kafka_handler, self._config
+        return self._valkey, self._db_handler, self._publisher, self._config
 
     # =========================================================================
     # Core Operations
@@ -842,7 +887,7 @@ class HandlerSubscription:
             RuntimeError: If handler is not initialized.
             ValueError: If event.topic does not match the topic argument.
         """
-        _, _, kafka_handler, config = self._ensure_initialized()
+        _, _, publisher, config = self._ensure_initialized()
 
         # Validate that event topic matches the topic argument
         if event.topic != topic:
@@ -860,38 +905,20 @@ class HandlerSubscription:
             logger.debug("No subscribers for topic %s", topic)
             return 0
 
-        # Publish event to Kafka
+        # Publish event via protocol adapter (ARCH-002 compliant)
         # Agents consume from this topic via consumer groups keyed by agent_id
         kafka_topic = config.kafka_notification_topic
-        envelope = {
-            "operation": "kafka.produce",
-            "payload": {
-                "topic": kafka_topic,
-                "key": topic,  # Partition by topic for ordering
-                "value": event.model_dump_json(),
-                "headers": {
-                    "event_id": event.event_id,
-                    "topic": topic,
-                    "subscriber_count": str(subscriber_count),
-                },
+        event_payload = json.loads(event.model_dump_json())
+        await publisher.publish(
+            topic=kafka_topic,
+            key=topic,  # Partition by topic for ordering
+            value=event_payload,
+            headers={
+                "event_id": event.event_id,
+                "topic": topic,
+                "subscriber_count": str(subscriber_count),
             },
-        }
-        result = await kafka_handler.execute(envelope)
-
-        # Validate Kafka publish succeeded
-        if result is None:
-            logger.warning(
-                "Kafka publish returned None for topic %s, event %s",
-                kafka_topic,
-                event.event_id,
-            )
-        elif hasattr(result, "result") and not result.result.get("success", True):
-            logger.warning(
-                "Kafka publish may have failed for topic %s, event %s: %s",
-                kafka_topic,
-                event.event_id,
-                result.result.get("error", "unknown error"),
-            )
+        )
 
         await self._increment_metric("notifications_published")
 
@@ -1750,51 +1777,46 @@ class HandlerSubscription:
             except Exception as e:
                 errors.append(f"Database check failed: {e}")
 
-        # Check Kafka with robust type handling
-        # EventBusKafka.health_check() may return:
-        #   - dict: {"healthy": bool, "circuit_state": str, ...}
-        #   - bool: Direct healthy status
-        #   - Pydantic model: Object with is_healthy attribute
-        kafka_healthy = False
-        if self._kafka_handler:
+        # Check event bus health via protocol
+        event_bus_healthy = False
+        if self._event_bus_health:
             try:
-                health_result = await self._kafka_handler.health_check()
-                # Handle different return types from EventBusKafka
+                health_result = await self._event_bus_health.health_check()
+                # ProtocolEventBusHealthCheck returns dict[str, object]
                 if isinstance(health_result, dict):
-                    kafka_healthy = bool(health_result.get("healthy", False))
-                    if not kafka_healthy:
+                    event_bus_healthy = bool(health_result.get("healthy", False))
+                    if not event_bus_healthy:
                         circuit_state = health_result.get("circuit_state", "unknown")
                         errors.append(
-                            f"Kafka: unhealthy (circuit_state={circuit_state})"
+                            f"Event bus: unhealthy (circuit_state={circuit_state})"
                         )
                 elif isinstance(health_result, bool):
-                    kafka_healthy = health_result
-                    if not kafka_healthy:
-                        errors.append("Kafka: unhealthy (returned False)")
+                    event_bus_healthy = health_result
+                    if not event_bus_healthy:
+                        errors.append("Event bus: unhealthy (returned False)")
                 elif hasattr(health_result, "is_healthy"):
-                    # Handle Pydantic model response (e.g., ModelHealthStatus)
-                    kafka_healthy = bool(health_result.is_healthy)
-                    if not kafka_healthy:
+                    # Handle Pydantic model response
+                    event_bus_healthy = bool(health_result.is_healthy)
+                    if not event_bus_healthy:
                         error_detail = getattr(health_result, "error", None) or getattr(
                             health_result, "error_message", "unknown"
                         )
-                        errors.append(f"Kafka: unhealthy ({error_detail})")
+                        errors.append(f"Event bus: unhealthy ({error_detail})")
                 else:
-                    # Unexpected return type - log warning and treat as unhealthy
                     logger.warning(
-                        "Unexpected Kafka health_check return type: %s, treating as unhealthy",
+                        "Unexpected event bus health_check return type: %s, treating as unhealthy",
                         type(health_result).__name__,
                     )
                     errors.append(
-                        f"Kafka: unexpected health_check return type "
+                        f"Event bus: unexpected health_check return type "
                         f"({type(health_result).__name__})"
                     )
             except Exception as e:
-                errors.append(f"Kafka check failed: {e}")
+                errors.append(f"Event bus check failed: {e}")
 
         # Only fully healthy if all components are explicitly True
         is_healthy = (
-            valkey_healthy is True and db_healthy is True and kafka_healthy is True
+            valkey_healthy is True and db_healthy is True and event_bus_healthy is True
         )
 
         return ModelSubscriptionHealth(
@@ -1802,7 +1824,7 @@ class HandlerSubscription:
             initialized=True,
             db_healthy=db_healthy,
             valkey_healthy=valkey_healthy,
-            kafka_healthy=kafka_healthy,
+            kafka_healthy=event_bus_healthy,
             error_message="; ".join(errors) if errors else None,
             metrics=await self.get_metrics(),
         )

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -46,9 +46,10 @@ Example::
             storage_adapter=storage_adapter,
         )
 
-        # Initialize with Kafka subscription callback
+        # Initialize with event bus subscription callback
+        # (event_bus.subscribe is injected by the runtime layer)
         await consumer.initialize(
-            subscribe_callback=kafka_bus.subscribe,
+            subscribe_callback=event_bus.subscribe,
             env_prefix="dev",
         )
 
@@ -122,7 +123,7 @@ class HandlerIntentEventConsumer:
         await storage.initialize(connection_uri="bolt://localhost:7687")
 
         consumer = HandlerIntentEventConsumer(config, storage)
-        await consumer.initialize(kafka_subscribe, "dev")
+        await consumer.initialize(event_bus_subscribe, "dev")
     """
 
     def __init__(
@@ -194,11 +195,12 @@ class HandlerIntentEventConsumer:
         env_prefix: str = "dev",
         publish_callback: Callable[[str, dict[str, object]], None] | None = None,
     ) -> None:
-        """Initialize Kafka subscription.
+        """Initialize event bus subscription.
 
         Args:
-            subscribe_callback: Function to subscribe to Kafka topic.
-                Signature: (topic, handler) -> unsubscribe_fn
+            subscribe_callback: Function to subscribe to an event bus topic.
+                Signature: (topic, handler) -> unsubscribe_fn.
+                Injected by the runtime layer (e.g., EventBusKafka.subscribe).
             env_prefix: Environment prefix for topic names (e.g., "dev", "staging").
             publish_callback: Optional callback for publishing events.
                 Signature: (topic, message_dict) -> None
@@ -219,7 +221,7 @@ class HandlerIntentEventConsumer:
         self._initialized = True
 
         logger.info(
-            "Kafka subscription initialized",
+            "Event bus subscription initialized",
             extra={
                 "handler": HANDLER_ID_INTENT_CONSUMER,
                 "topic": full_topic,
@@ -228,29 +230,29 @@ class HandlerIntentEventConsumer:
         )
 
     def _handle_message_sync(self, message: dict[str, object]) -> None:
-        """Synchronous message handler wrapper for Kafka callback.
+        """Synchronous message handler wrapper for event bus callback.
 
-        Kafka callbacks are typically synchronous, so this wraps the
+        Event bus callbacks are typically synchronous, so this wraps the
         async handler. In production, use an event loop runner.
 
         Threading Model:
             This method handles two scenarios:
 
-            1. **No running event loop** (e.g., called from a synchronous Kafka
+            1. **No running event loop** (e.g., called from a synchronous
                consumer thread): Creates a new event loop via ``asyncio.run()``.
                Note: In high-throughput scenarios, consider using a dedicated
                event loop thread to avoid per-message loop creation overhead.
 
             2. **Existing event loop** (e.g., called from an async context or
-               when the consumer is integrated with an async Kafka client):
+               when the consumer is integrated with an async event bus client):
                Schedules the handler as a task in the existing loop.
 
-            For production deployments, prefer using an async Kafka client
-            (e.g., aiokafka) that provides native async message handling,
-            avoiding the need for this synchronous wrapper.
+            For production deployments, prefer using an async event bus client
+            that provides native async message handling, avoiding the need for
+            this synchronous wrapper.
 
         Args:
-            message: Raw Kafka message payload.
+            message: Raw event bus message payload.
         """
         try:
             loop = asyncio.get_running_loop()
@@ -269,13 +271,13 @@ class HandlerIntentEventConsumer:
     async def _handle_message(
         self, message: dict[str, object], *, retry_count: int = 0
     ) -> None:
-        """Process a single Kafka message with retry support.
+        """Process a single event bus message with retry support.
 
         On storage failures (not validation errors), retries with exponential
         backoff up to retry_max_attempts times before routing to DLQ.
 
         Args:
-            message: Raw Kafka message payload.
+            message: Raw event bus message payload.
             retry_count: Current retry attempt (0 = first attempt).
         """
         correlation_id: UUID | None = None
@@ -657,9 +659,9 @@ class HandlerIntentEventConsumer:
     async def stop(self) -> None:
         """Graceful shutdown.
 
-        Unsubscribes from Kafka topic, cancels pending message processing tasks,
-        and resets initialization state. Does not shutdown the storage adapter
-        (caller's responsibility).
+        Unsubscribes from event bus topic, cancels pending message processing
+        tasks, and resets initialization state. Does not shutdown the storage
+        adapter (caller's responsibility).
         """
         # Unsubscribe FIRST to prevent new messages during shutdown
         if self._unsubscribe:
@@ -667,7 +669,7 @@ class HandlerIntentEventConsumer:
                 self._unsubscribe()
             except Exception as e:
                 logger.warning(
-                    "Error during Kafka unsubscribe",
+                    "Error during event bus unsubscribe",
                     extra={
                         "handler": HANDLER_ID_INTENT_CONSUMER,
                         "error": str(e),

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Intent event consumer handler.
 
-Consumes intent-classified.v1 events from Kafka and persists to Memgraph.
+Consumes intent-classified.v1 events from the event bus and persists to Memgraph.
 
 Architecture:
     This handler subscribes to intent classification events from omniintelligence
@@ -16,7 +16,7 @@ Topic Naming:
     Full topic names are constructed as ``{env_prefix}.{topic_suffix}`` where:
 
     - ``env_prefix`` is a deployment realm (e.g., ``"dev"``, ``"staging"``,
-      ``"prod"``) that isolates environments on the same Kafka cluster.
+      ``"prod"``) that isolates environments on the same cluster.
     - ``topic_suffix`` contains the ``onex.`` namespace and event path
       (e.g., ``onex.evt.omnimemory.intent-stored.v1``).
 
@@ -97,7 +97,7 @@ HANDLER_ID_INTENT_CONSUMER: str = "intent-event-consumer"
 
 
 class HandlerIntentEventConsumer:
-    """Kafka consumer for intent-classified events.
+    """Event bus consumer for intent-classified events.
 
     Consumer group is derived from node identity per ADR:
     ``{env_prefix}.{service}.{node_name}.{purpose}.{version}``
@@ -105,7 +105,7 @@ class HandlerIntentEventConsumer:
     Example: ``dev.omnimemory.intent_event_consumer_effect.consume.v1``
 
     The ``env_prefix`` parameter is a deployment realm (e.g., ``"dev"``,
-    ``"staging"``, ``"prod"``) that isolates environments on the same Kafka
+    ``"staging"``, ``"prod"``) that isolates environments on the same event bus
     cluster. It is separate from the ``onex.`` namespace embedded in topic
     suffixes. See :class:`ModelIntentEventConsumerConfig` for topic suffix
     defaults.
@@ -157,7 +157,7 @@ class HandlerIntentEventConsumer:
         self._messages_dlq = 0
         self._unsubscribe: Callable[[], None] | None = None
 
-        # Kafka publish callback (set during initialize)
+        # Event bus publish callback (set during initialize)
         self._publish_callback: Callable[[str, dict[str, object]], None] | None = None
         self._env_prefix: str = "dev"
 
@@ -460,7 +460,7 @@ class HandlerIntentEventConsumer:
             await self._route_to_dlq(message, str(e), retry_count=retry_count)
 
     async def _emit_stored_event(self, event: ModelIntentStoredEvent) -> None:
-        """Emit intent-stored event to Kafka.
+        """Emit intent-stored event to the event bus.
 
         Uses canonical omnibase_core.ModelIntentStoredEvent which supports
         both success (status="success") and error (status="error") cases

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -25,6 +25,7 @@ Usage:
     )
 """
 
+# Eager imports: adapters module is lightweight and used by all handler consumers.
 from omnimemory.runtime.adapters import (
     AdapterKafkaPublisher,
     ProtocolEventBusHealthCheck,

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -2,17 +2,12 @@
 # Copyright (c) 2025 OmniNode Team
 """OmniMemory Runtime Package.
 
-Provides contract-driven topic discovery for the OmniMemory domain.
+Provides contract-driven topic discovery and protocol adapters for the
+OmniMemory domain.
 
 This package contains:
-    - collect_subscribe_topics_from_contracts: Discover subscribe topics from
-      effect node contract.yaml files.
-    - collect_publish_topics_for_dispatch: Discover publish topics keyed by
-      dispatch alias from effect node contract.yaml files.
-    - collect_all_publish_topics: Discover all publish topics declared across
-      effect node contract.yaml files.
-    - canonical_topic_to_dispatch_alias: Convert ONEX canonical topic naming
-      to dispatch engine format.
+    - Contract-driven topic discovery (contract_topics module)
+    - Protocol adapters bridging infrastructure to handler protocols (adapters module)
 
 Usage:
     from omnimemory.runtime.contract_topics import (
@@ -22,16 +17,21 @@ Usage:
         canonical_topic_to_dispatch_alias,
     )
 
-    # Get all subscribe topics declared across omnimemory effect nodes
-    topics = collect_subscribe_topics_from_contracts()
-
-    # Get publish topics keyed by dispatch alias
-    publish_map = collect_publish_topics_for_dispatch()
-
-    # Get all publish topics (full list, not just first per node)
-    all_publish = collect_all_publish_topics()
+    from omnimemory.runtime.adapters import (
+        AdapterKafkaPublisher,
+        ProtocolEventBusPublish,
+        ProtocolEventBusHealthCheck,
+        ProtocolEventBusLifecycle,
+    )
 """
 
+from omnimemory.runtime.adapters import (
+    AdapterKafkaPublisher,
+    ProtocolEventBusHealthCheck,
+    ProtocolEventBusLifecycle,
+    ProtocolEventBusPublish,
+    create_default_event_bus,
+)
 from omnimemory.runtime.contract_topics import (
     canonical_topic_to_dispatch_alias,
     collect_all_publish_topics,
@@ -40,6 +40,13 @@ from omnimemory.runtime.contract_topics import (
 )
 
 __all__ = [
+    # Protocol adapters (ARCH-002)
+    "AdapterKafkaPublisher",
+    "ProtocolEventBusHealthCheck",
+    "ProtocolEventBusLifecycle",
+    "ProtocolEventBusPublish",
+    "create_default_event_bus",
+    # Contract-driven topic discovery
     "canonical_topic_to_dispatch_alias",
     "collect_all_publish_topics",
     "collect_publish_topics_for_dispatch",

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -58,13 +58,23 @@ class ProtocolEventBusPublish(Protocol):
                 await self._bus.publish(topic=topic, key=None, value=data)
     """
 
-    async def publish(self, *, topic: str, key: bytes | None, value: bytes) -> None:
+    async def publish(
+        self,
+        *,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
         """Publish raw bytes to a topic.
 
         Args:
             topic: Target topic name.
             key: Optional message key for partitioning.
             value: Message payload as bytes.
+            headers: Optional string key-value headers. Concrete implementations
+                may convert these to transport-specific formats (e.g.,
+                ModelEventHeaders for Kafka).
         """
         ...
 
@@ -80,7 +90,12 @@ class ProtocolEventBusHealthCheck(Protocol):
         """Return health status.
 
         Returns:
-            Dict with at minimum a "healthy" key (bool).
+            Dict with health information. Required keys:
+
+            - ``"healthy"`` (bool): Whether the bus is operational and can
+              accept publish calls. Implementations may include additional
+              keys (e.g., ``"started"``, ``"environment"``,
+              ``"circuit_state"``).
         """
         ...
 
@@ -96,7 +111,16 @@ class ProtocolEventBusLifecycle(Protocol):
         """Initialize the event bus with configuration.
 
         Args:
-            config: Configuration dictionary.
+            config: Configuration dictionary. Recognized keys:
+
+                - ``"bootstrap_servers"`` (str): Kafka broker addresses,
+                  comma-separated (e.g., ``"kafka:9092,kafka2:9092"``).
+                - ``"environment"`` (str): Environment identifier for
+                  message routing (e.g., ``"dev"``, ``"prod"``).
+                - ``"timeout_seconds"`` (int): Timeout in seconds for
+                  connection and publish operations.
+
+                Unknown keys are ignored by the default implementation.
         """
         ...
 
@@ -117,7 +141,7 @@ class AdapterKafkaPublisher:
     to the event bus protocol interface (topic, key: bytes, value: bytes).
 
     Serialization:
-        - key: UTF-8 encoded bytes
+        - key: UTF-8 encoded bytes (empty string encodes as b"")
         - value: compact JSON bytes (no whitespace, non-ASCII preserved)
 
     Example::
@@ -147,15 +171,16 @@ class AdapterKafkaPublisher:
 
         Args:
             topic: Target topic name.
-            key: Message key (for partitioning).
+            key: Message key (for partitioning). Empty string is preserved
+                as ``b""``, which differs from ``None`` in Kafka partitioning.
             value: Event payload dict (serialized to JSON bytes).
-            headers: Optional headers (logged but not passed to raw publish;
-                extend ProtocolEventBusPublish if header support is required).
+            headers: Optional string key-value headers forwarded to the
+                event bus publish call.
         """
         value_bytes = json.dumps(
             value, separators=(",", ":"), ensure_ascii=False, default=str
         ).encode("utf-8")
-        key_bytes = key.encode("utf-8") if key else None
+        key_bytes = key.encode("utf-8") if key is not None else None
 
         if headers:
             logger.debug(
@@ -164,7 +189,9 @@ class AdapterKafkaPublisher:
                 list(headers.keys()),
             )
 
-        await self._event_bus.publish(topic=topic, key=key_bytes, value=value_bytes)
+        await self._event_bus.publish(
+            topic=topic, key=key_bytes, value=value_bytes, headers=headers
+        )
 
 
 # =============================================================================
@@ -173,7 +200,7 @@ class AdapterKafkaPublisher:
 
 
 async def create_default_event_bus(
-    bootstrap_servers: str = "localhost:9092",
+    bootstrap_servers: str,
 ) -> ProtocolEventBusPublish:
     """Create and initialize a default event bus instance.
 
@@ -183,6 +210,8 @@ async def create_default_event_bus(
 
     Args:
         bootstrap_servers: Event bus bootstrap servers (comma-separated).
+            Must be provided explicitly; no default to prevent accidental
+            use of localhost in production.
 
     Returns:
         An initialized event bus conforming to ProtocolEventBusPublish.
@@ -193,10 +222,14 @@ async def create_default_event_bus(
         RuntimeError: If the event bus cannot be initialized.
     """
     from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+    from omnibase_infra.event_bus.models.config import ModelKafkaEventBusConfig
 
-    event_bus = EventBusKafka()
+    config = ModelKafkaEventBusConfig(
+        bootstrap_servers=bootstrap_servers,
+    )
+    event_bus = EventBusKafka(config=config)
     try:
-        await event_bus.initialize({"bootstrap_servers": bootstrap_servers})
+        await event_bus.start()
     except Exception as e:
         raise RuntimeError(f"Failed to initialize event bus: {e}") from e
     # EventBusKafka satisfies ProtocolEventBusPublish (has async publish method)

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -29,12 +29,8 @@ Related:
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import Mapping
 from typing import Protocol, cast, runtime_checkable
-
-logger = logging.getLogger(__name__)
-
 
 # =============================================================================
 # Protocol Definitions

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -195,7 +195,10 @@ async def create_default_event_bus(
     from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
 
     event_bus = EventBusKafka()
-    await event_bus.initialize({"bootstrap_servers": bootstrap_servers})
+    try:
+        await event_bus.initialize({"bootstrap_servers": bootstrap_servers})
+    except Exception as e:
+        raise RuntimeError(f"Failed to initialize event bus: {e}") from e
     # EventBusKafka satisfies ProtocolEventBusPublish (has async publish method)
     # but mypy cannot verify cross-package structural subtyping.
     return cast(ProtocolEventBusPublish, event_bus)

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -60,7 +60,6 @@ class ProtocolEventBusPublish(Protocol):
 
     async def publish(
         self,
-        *,
         topic: str,
         key: bytes | None,
         value: bytes,

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Protocol adapters for omnimemory handler dependencies.
+
+Bridges available infrastructure (event bus, handlers) to the protocol
+interfaces expected by omnimemory domain handlers.
+
+Adapters:
+    - AdapterEventBusPublisher: event bus -> ProtocolEventBusPublisher
+      Wraps a ProtocolEventBusPublish-conforming event bus into the
+      higher-level publish interface used by HandlerSubscription.
+
+Design:
+    Each adapter is a thin explicit boundary that prevents accidental coupling
+    to infrastructure-specific methods. Protocol conformance is verified in
+    tests, not at import time (avoids import-time landmines with optional deps).
+
+    ARCH-002 Compliance:
+        No handler or node file may import directly from aiokafka,
+        omnibase_infra.event_bus, or other transport modules. All event bus
+        interaction goes through the ProtocolEventBusPublish protocol defined
+        here. Concrete wiring happens in the runtime layer only.
+
+Related:
+    - OMN-2214: Phase 3 -- ARCH-002 compliance, abstract Kafka from handlers
+    - omniintelligence runtime/adapters.py (reference implementation)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol, cast, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Protocol Definitions
+# =============================================================================
+
+
+@runtime_checkable
+class ProtocolEventBusPublish(Protocol):
+    """Minimal protocol for event bus publish capability.
+
+    Matches the publish signature used by EventBusKafka and EventBusInmemory.
+    Handlers depend on this protocol, never on concrete implementations.
+
+    Example::
+
+        class MyPublisher:
+            def __init__(self, bus: ProtocolEventBusPublish) -> None:
+                self._bus = bus
+
+            async def emit(self, topic: str, data: bytes) -> None:
+                await self._bus.publish(topic=topic, key=None, value=data)
+    """
+
+    async def publish(self, *, topic: str, key: bytes | None, value: bytes) -> None:
+        """Publish raw bytes to a topic.
+
+        Args:
+            topic: Target topic name.
+            key: Optional message key for partitioning.
+            value: Message payload as bytes.
+        """
+        ...
+
+
+@runtime_checkable
+class ProtocolEventBusHealthCheck(Protocol):
+    """Minimal protocol for event bus health check capability.
+
+    Matches the health_check signature used by EventBusKafka.
+    """
+
+    async def health_check(self) -> dict[str, object]:
+        """Return health status.
+
+        Returns:
+            Dict with at minimum a "healthy" key (bool).
+        """
+        ...
+
+
+@runtime_checkable
+class ProtocolEventBusLifecycle(Protocol):
+    """Minimal protocol for event bus lifecycle (initialize/shutdown).
+
+    Matches the initialize/shutdown signatures used by EventBusKafka.
+    """
+
+    async def initialize(self, config: dict[str, object]) -> None:
+        """Initialize the event bus with configuration.
+
+        Args:
+            config: Configuration dictionary.
+        """
+        ...
+
+    async def shutdown(self) -> None:
+        """Gracefully shutdown the event bus."""
+        ...
+
+
+# =============================================================================
+# AdapterKafkaPublisher
+# =============================================================================
+
+
+class AdapterKafkaPublisher:
+    """Wraps a ProtocolEventBusPublish event bus for handler-level publishing.
+
+    Normalizes the handler's publish interface (topic, key: str, value: dict)
+    to the event bus protocol interface (topic, key: bytes, value: bytes).
+
+    Serialization:
+        - key: UTF-8 encoded bytes
+        - value: compact JSON bytes (no whitespace, non-ASCII preserved)
+
+    Example::
+
+        from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+
+        bus = EventBusKafka(config=config)
+        await bus.start()
+
+        publisher = AdapterKafkaPublisher(bus)
+        await publisher.publish("my.topic", "key", {"data": "value"})
+    """
+
+    __slots__ = ("_event_bus",)
+
+    def __init__(self, event_bus: ProtocolEventBusPublish) -> None:
+        self._event_bus = event_bus
+
+    async def publish(
+        self,
+        topic: str,
+        key: str,
+        value: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """Publish event to topic via event bus protocol.
+
+        Args:
+            topic: Target topic name.
+            key: Message key (for partitioning).
+            value: Event payload dict (serialized to JSON bytes).
+            headers: Optional headers (logged but not passed to raw publish;
+                use ProtocolEventBusPublisher for header support).
+        """
+        value_bytes = json.dumps(
+            value, separators=(",", ":"), ensure_ascii=False, default=str
+        ).encode("utf-8")
+        key_bytes = key.encode("utf-8") if key else None
+
+        if headers:
+            logger.debug(
+                "Publishing to %s with headers: %s",
+                topic,
+                list(headers.keys()),
+            )
+
+        await self._event_bus.publish(topic=topic, key=key_bytes, value=value_bytes)
+
+
+# =============================================================================
+# Factory Functions
+# =============================================================================
+
+
+async def create_default_event_bus(
+    bootstrap_servers: str = "localhost:9092",
+) -> ProtocolEventBusPublish:
+    """Create and initialize a default event bus instance.
+
+    This factory centralizes the concrete transport construction so that
+    handler and node files never import from omnibase_infra.event_bus
+    directly (ARCH-002 compliance).
+
+    Args:
+        bootstrap_servers: Event bus bootstrap servers (comma-separated).
+
+    Returns:
+        An initialized event bus conforming to ProtocolEventBusPublish.
+        The returned object also satisfies ProtocolEventBusLifecycle and
+        ProtocolEventBusHealthCheck.
+
+    Raises:
+        RuntimeError: If the event bus cannot be initialized.
+    """
+    from omnibase_infra.event_bus.event_bus_kafka import EventBusKafka
+
+    event_bus = EventBusKafka()
+    await event_bus.initialize({"bootstrap_servers": bootstrap_servers})
+    # EventBusKafka satisfies ProtocolEventBusPublish (has async publish method)
+    # but mypy cannot verify cross-package structural subtyping.
+    return cast(ProtocolEventBusPublish, event_bus)
+
+
+__all__ = [
+    "AdapterKafkaPublisher",
+    "ProtocolEventBusHealthCheck",
+    "ProtocolEventBusLifecycle",
+    "ProtocolEventBusPublish",
+    "create_default_event_bus",
+]

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -64,7 +64,6 @@ class ProtocolEventBusPublish(Protocol):
         topic: str,
         key: bytes | None,
         value: bytes,
-        headers: Mapping[str, str] | None = None,
     ) -> None:
         """Publish raw bytes to a topic.
 
@@ -72,9 +71,6 @@ class ProtocolEventBusPublish(Protocol):
             topic: Target topic name.
             key: Optional message key for partitioning.
             value: Message payload as bytes.
-            headers: Optional string key-value headers. Concrete implementations
-                may convert these to transport-specific formats (e.g.,
-                ModelEventHeaders for Kafka).
         """
         ...
 
@@ -179,7 +175,6 @@ class AdapterKafkaPublisher:
         topic: str,
         key: str | None,
         value: Mapping[str, object],
-        headers: dict[str, str] | None = None,
     ) -> None:
         """Publish event to topic via event bus protocol.
 
@@ -189,8 +184,6 @@ class AdapterKafkaPublisher:
                 partitioning. Empty string is preserved as ``b""``, which
                 differs from ``None`` in Kafka partitioning.
             value: Event payload dict (serialized to JSON bytes).
-            headers: Optional string key-value headers forwarded to the
-                event bus publish call.
         """
         # default=str handles datetime/UUID serialization; callers should
         # pre-validate complex types to avoid silent str() conversion.
@@ -199,16 +192,7 @@ class AdapterKafkaPublisher:
         ).encode("utf-8")
         key_bytes = key.encode("utf-8") if key is not None else None
 
-        if headers:
-            logger.debug(
-                "Publishing to %s with headers: %s",
-                topic,
-                list(headers.keys()),
-            )
-
-        await self._event_bus.publish(
-            topic=topic, key=key_bytes, value=value_bytes, headers=headers
-        )
+        await self._event_bus.publish(topic=topic, key=key_bytes, value=value_bytes)
 
 
 # =============================================================================

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -105,10 +105,24 @@ class ProtocolEventBusLifecycle(Protocol):
     """Minimal protocol for event bus lifecycle (initialize/shutdown).
 
     Matches the initialize/shutdown signatures used by EventBusKafka.
+
+    Note on ``initialize()``:
+        This method supports implementations that require deferred
+        initialization separate from construction. The default factory
+        (``create_default_event_bus()``) does **not** call ``initialize()``
+        because ``EventBusKafka`` handles setup via its constructor and
+        ``start()`` method. Implementations that need a two-phase init
+        (construct, then configure) should document this requirement and
+        have their own factory call ``initialize()`` explicitly.
     """
 
     async def initialize(self, config: dict[str, object]) -> None:
         """Initialize the event bus with configuration.
+
+        This method is for implementations that require deferred
+        initialization separate from construction. The default factory
+        (``create_default_event_bus()``) uses constructor + ``start()``
+        instead, so this method is not called by that factory.
 
         Args:
             config: Configuration dictionary. Recognized keys:
@@ -163,7 +177,7 @@ class AdapterKafkaPublisher:
     async def publish(
         self,
         topic: str,
-        key: str,
+        key: str | None,
         value: Mapping[str, object],
         headers: dict[str, str] | None = None,
     ) -> None:
@@ -171,12 +185,15 @@ class AdapterKafkaPublisher:
 
         Args:
             topic: Target topic name.
-            key: Message key (for partitioning). Empty string is preserved
-                as ``b""``, which differs from ``None`` in Kafka partitioning.
+            key: Message key (for partitioning), or None for round-robin
+                partitioning. Empty string is preserved as ``b""``, which
+                differs from ``None`` in Kafka partitioning.
             value: Event payload dict (serialized to JSON bytes).
             headers: Optional string key-value headers forwarded to the
                 event bus publish call.
         """
+        # default=str handles datetime/UUID serialization; callers should
+        # pre-validate complex types to avoid silent str() conversion.
         value_bytes = json.dumps(
             value, separators=(",", ":"), ensure_ascii=False, default=str
         ).encode("utf-8")

--- a/src/omnimemory/runtime/adapters.py
+++ b/src/omnimemory/runtime/adapters.py
@@ -6,7 +6,7 @@ Bridges available infrastructure (event bus, handlers) to the protocol
 interfaces expected by omnimemory domain handlers.
 
 Adapters:
-    - AdapterEventBusPublisher: event bus -> ProtocolEventBusPublisher
+    - AdapterKafkaPublisher: event bus -> ProtocolEventBusPublish
       Wraps a ProtocolEventBusPublish-conforming event bus into the
       higher-level publish interface used by HandlerSubscription.
 
@@ -30,7 +30,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Protocol, cast, runtime_checkable
+from collections.abc import Mapping
+from typing import Protocol, cast, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class AdapterKafkaPublisher:
         self,
         topic: str,
         key: str,
-        value: dict[str, Any],
+        value: Mapping[str, object],
         headers: dict[str, str] | None = None,
     ) -> None:
         """Publish event to topic via event bus protocol.
@@ -149,7 +150,7 @@ class AdapterKafkaPublisher:
             key: Message key (for partitioning).
             value: Event payload dict (serialized to JSON bytes).
             headers: Optional headers (logged but not passed to raw publish;
-                use ProtocolEventBusPublisher for header support).
+                extend ProtocolEventBusPublish if header support is required).
         """
         value_bytes = json.dumps(
             value, separators=(",", ":"), ensure_ascii=False, default=str

--- a/tests/integration/test_handler_subscription.py
+++ b/tests/integration/test_handler_subscription.py
@@ -462,7 +462,8 @@ class TestNotify:
             )
             assert count == 1
         except RuntimeError as e:
-            # Event bus may not be available - skip gracefully
+            # NOTE: Error message matching is coupled to EventBusKafka's exception text.
+            # If the event bus adapter changes error messages, update these skip guards.
             if "Kafka" in str(e) or "kafka" in str(e).lower():
                 pytest.skip(f"Event bus not available: {e}")
             raise
@@ -1245,7 +1246,7 @@ class TestEventBusFailureHandling:
     """
 
     @pytest.mark.asyncio
-    async def test_notify_returns_subscriber_count_even_with_kafka_issues(
+    async def test_notify_returns_subscriber_count_even_with_bus_issues(
         self,
         subscription_handler: HandlerSubscription,
         unique_agent_id: str,
@@ -1287,7 +1288,7 @@ class TestEventBusFailureHandling:
             raise
 
     @pytest.mark.asyncio
-    async def test_notify_handles_kafka_timeout_gracefully(
+    async def test_notify_handles_event_bus_timeout_gracefully(
         self,
         subscription_handler: HandlerSubscription,
     ) -> None:

--- a/tests/integration/test_handler_subscription.py
+++ b/tests/integration/test_handler_subscription.py
@@ -660,7 +660,7 @@ class TestHealthCheck:
         assert health.initialized is True
         assert health.db_healthy is not None
         assert health.valkey_healthy is not None
-        assert health.kafka_healthy is not None
+        assert health.event_bus_healthy is not None
 
     @pytest.mark.asyncio
     async def test_health_check_before_initialize(

--- a/tests/integration/test_handler_subscription.py
+++ b/tests/integration/test_handler_subscription.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 OmniNode Team
-"""Integration tests for HandlerSubscription with Kafka-based notification.
+"""Integration tests for HandlerSubscription with event bus notification.
 
 This module tests the subscription handler which manages agent subscriptions
-and publishes notification events to Kafka for subscriber consumption.
+and publishes notification events via the event bus for subscriber consumption.
 
 Test Categories:
     - TestSubscribe: Create subscription, topic validation, idempotency, metadata
@@ -17,7 +17,7 @@ Test Categories:
 Prerequisites:
     - PostgreSQL running at TEST_DB_DSN
     - Valkey running at TEST_VALKEY_HOST:TEST_VALKEY_PORT
-    - Kafka running for notify tests (graceful skip if unavailable)
+    - Event bus running for notify tests (graceful skip if unavailable)
     - omnibase_infra installed (dev dependency)
 
 Usage:
@@ -31,10 +31,10 @@ Environment Variables:
     TEST_DB_DSN: PostgreSQL connection string
     TEST_VALKEY_HOST: Valkey hostname (default: localhost)
     TEST_VALKEY_PORT: Valkey port (default: 6379)
-    TEST_KAFKA_BOOTSTRAP_SERVERS: Kafka servers (default: localhost:9092)
+    TEST_KAFKA_BOOTSTRAP_SERVERS: Event bus servers (default: localhost:9092)
 
 .. versionadded:: 0.2.0
-    Refactored for Kafka-based notification (OMN-1393).
+    Refactored for event bus notification (OMN-1393).
 """
 
 from __future__ import annotations
@@ -93,10 +93,10 @@ DEFAULT_KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
 
 
 def get_test_kafka_bootstrap_servers() -> str:
-    """Get Kafka bootstrap servers from environment or default.
+    """Get event bus bootstrap servers from environment or default.
 
     Returns:
-        Kafka bootstrap servers string.
+        Event bus bootstrap servers string.
     """
     return os.environ.get(
         "TEST_KAFKA_BOOTSTRAP_SERVERS",
@@ -462,9 +462,9 @@ class TestNotify:
             )
             assert count == 1
         except RuntimeError as e:
-            # Kafka may not be available - skip gracefully
+            # Event bus may not be available - skip gracefully
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
     @pytest.mark.asyncio
@@ -489,7 +489,7 @@ class TestNotify:
             assert count == 0
         except RuntimeError as e:
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
     @pytest.mark.asyncio
@@ -542,7 +542,7 @@ class TestNotify:
             assert count == 3
         except RuntimeError as e:
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
 
@@ -782,7 +782,7 @@ class TestMetrics:
             )
         except RuntimeError as e:
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
         final_metrics = await subscription_handler.get_metrics()
@@ -1139,9 +1139,9 @@ class TestLargeBatch:
             subscriber_count = await subscription_handler.notify(topic, event)
             assert subscriber_count == 100
         except RuntimeError as e:
-            # Kafka may not be available - skip gracefully
+            # Event bus may not be available - skip gracefully
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
     @pytest.mark.asyncio
@@ -1232,15 +1232,15 @@ class TestLargeBatch:
 
 
 # =============================================================================
-# TestKafkaFailureHandling
+# TestEventBusFailureHandling
 # =============================================================================
 
 
-class TestKafkaFailureHandling:
-    """Tests for Kafka failure scenarios.
+class TestEventBusFailureHandling:
+    """Tests for event bus failure scenarios.
 
     These tests verify that the subscription handler behaves correctly
-    when Kafka operations fail, including proper error propagation
+    when event bus operations fail, including proper error propagation
     and graceful degradation.
     """
 
@@ -1251,10 +1251,10 @@ class TestKafkaFailureHandling:
         unique_agent_id: str,
         unique_topic: str,
     ) -> None:
-        """Notify correctly counts subscribers regardless of Kafka status.
+        """Notify correctly counts subscribers regardless of event bus status.
 
         The subscriber count is determined from the database/cache before
-        Kafka publish, so it should be accurate even if Kafka has issues.
+        event bus publish, so it should be accurate even if the bus has issues.
         """
         # Subscribe an agent
         await subscription_handler.subscribe(
@@ -1280,10 +1280,10 @@ class TestKafkaFailureHandling:
             # Count should reflect actual subscribers
             assert count == 1
         except RuntimeError as e:
-            # If Kafka is unavailable, the test demonstrates the handler's
-            # behavior - it requires Kafka for notify operations
+            # If the event bus is unavailable, the test demonstrates the
+            # handler's behavior - it requires an event bus for notify operations
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
     @pytest.mark.asyncio
@@ -1291,9 +1291,9 @@ class TestKafkaFailureHandling:
         self,
         subscription_handler: HandlerSubscription,
     ) -> None:
-        """Notify operation handles potential Kafka timeouts.
+        """Notify operation handles potential event bus timeouts.
 
-        Verifies that the system properly handles slow Kafka responses
+        Verifies that the system properly handles slow event bus responses
         without hanging indefinitely or corrupting state.
         """
         topic = f"memory.timeout_test_{uuid4().hex[:8]}.created"
@@ -1323,7 +1323,7 @@ class TestKafkaFailureHandling:
             pytest.fail("Notify operation timed out after 30 seconds")
         except RuntimeError as e:
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
     @pytest.mark.asyncio
@@ -1355,7 +1355,7 @@ class TestKafkaFailureHandling:
             )
         except RuntimeError as e:
             if "Kafka" in str(e) or "kafka" in str(e).lower():
-                pytest.skip(f"Kafka not available: {e}")
+                pytest.skip(f"Event bus not available: {e}")
             raise
 
         final_metrics = await subscription_handler.get_metrics()

--- a/tests/integration/test_handler_subscription.py
+++ b/tests/integration/test_handler_subscription.py
@@ -89,10 +89,10 @@ pytestmark = [
 # Test Configuration
 # =============================================================================
 
-DEFAULT_KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
+DEFAULT_EVENT_BUS_BOOTSTRAP_SERVERS = "localhost:9092"
 
 
-def get_test_kafka_bootstrap_servers() -> str:
+def get_test_event_bus_bootstrap_servers() -> str:
     """Get event bus bootstrap servers from environment or default.
 
     Returns:
@@ -100,7 +100,7 @@ def get_test_kafka_bootstrap_servers() -> str:
     """
     return os.environ.get(
         "TEST_KAFKA_BOOTSTRAP_SERVERS",
-        DEFAULT_KAFKA_BOOTSTRAP_SERVERS,
+        DEFAULT_EVENT_BUS_BOOTSTRAP_SERVERS,
     )
 
 
@@ -131,7 +131,7 @@ async def subscription_handler(
         db_dsn=test_db_dsn,
         valkey_host=test_valkey_host,
         valkey_port=test_valkey_port,
-        kafka_bootstrap_servers=get_test_kafka_bootstrap_servers(),
+        kafka_bootstrap_servers=get_test_event_bus_bootstrap_servers(),
     )
     handler = HandlerSubscription(container)
 
@@ -160,7 +160,7 @@ def handler_config(
         db_dsn=test_db_dsn,
         valkey_host=test_valkey_host,
         valkey_port=test_valkey_port,
-        kafka_bootstrap_servers=get_test_kafka_bootstrap_servers(),
+        kafka_bootstrap_servers=get_test_event_bus_bootstrap_servers(),
     )
 
 

--- a/tests/unit/runtime/test_adapters.py
+++ b/tests/unit/runtime/test_adapters.py
@@ -15,7 +15,7 @@ Related:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -24,6 +24,7 @@ from omnimemory.runtime.adapters import (
     ProtocolEventBusHealthCheck,
     ProtocolEventBusLifecycle,
     ProtocolEventBusPublish,
+    create_default_event_bus,
 )
 
 # =============================================================================
@@ -322,8 +323,6 @@ class TestCreateDefaultEventBus:
     @pytest.mark.asyncio
     async def test_factory_returns_protocol_conforming_object(self) -> None:
         """create_default_event_bus must return ProtocolEventBusPublish."""
-        from unittest.mock import patch
-
         mock_config_cls = MagicMock()
         mock_bus_instance = AsyncMock(spec=_StubFullBus)
         mock_bus_instance.start = AsyncMock()
@@ -340,8 +339,6 @@ class TestCreateDefaultEventBus:
                 mock_config_cls,
             ),
         ):
-            from omnimemory.runtime.adapters import create_default_event_bus
-
             result = await create_default_event_bus(
                 bootstrap_servers="localhost:9092",
             )
@@ -352,8 +349,6 @@ class TestCreateDefaultEventBus:
     @pytest.mark.asyncio
     async def test_factory_calls_start_on_bus(self) -> None:
         """create_default_event_bus must call start() on the bus."""
-        from unittest.mock import patch
-
         mock_config_cls = MagicMock()
         mock_bus_instance = AsyncMock(spec=_StubFullBus)
         mock_bus_instance.start = AsyncMock()
@@ -369,8 +364,6 @@ class TestCreateDefaultEventBus:
                 mock_config_cls,
             ),
         ):
-            from omnimemory.runtime.adapters import create_default_event_bus
-
             await create_default_event_bus(
                 bootstrap_servers="localhost:9092",
             )
@@ -380,8 +373,6 @@ class TestCreateDefaultEventBus:
     @pytest.mark.asyncio
     async def test_factory_raises_runtime_error_on_start_failure(self) -> None:
         """create_default_event_bus must raise RuntimeError if start() fails."""
-        from unittest.mock import patch
-
         mock_config_cls = MagicMock()
         mock_bus_instance = AsyncMock(spec=_StubFullBus)
         mock_bus_instance.start = AsyncMock(side_effect=ConnectionError("broker down"))
@@ -397,8 +388,6 @@ class TestCreateDefaultEventBus:
                 mock_config_cls,
             ),
         ):
-            from omnimemory.runtime.adapters import create_default_event_bus
-
             with pytest.raises(RuntimeError, match="Failed to initialize event bus"):
                 await create_default_event_bus(
                     bootstrap_servers="localhost:9092",

--- a/tests/unit/runtime/test_adapters.py
+++ b/tests/unit/runtime/test_adapters.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for runtime protocol adapters.
+
+Validates:
+    - ProtocolEventBusPublish conformance (runtime_checkable isinstance checks)
+    - ProtocolEventBusHealthCheck conformance
+    - ProtocolEventBusLifecycle conformance
+    - AdapterKafkaPublisher serialization and delegation
+    - create_default_event_bus factory return type
+
+Related:
+    - OMN-2214: Phase 3 -- ARCH-002 compliance, abstract Kafka from handlers
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnimemory.runtime.adapters import (
+    AdapterKafkaPublisher,
+    ProtocolEventBusHealthCheck,
+    ProtocolEventBusLifecycle,
+    ProtocolEventBusPublish,
+)
+
+# =============================================================================
+# Helpers: Stub classes for protocol conformance testing
+# =============================================================================
+
+
+class _StubPublishOnly:
+    """Stub that implements only the publish protocol."""
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+    ) -> None:
+        pass
+
+
+class _StubHealthCheckOnly:
+    """Stub that implements only the health_check protocol."""
+
+    async def health_check(self) -> dict[str, object]:
+        return {"healthy": True}
+
+
+class _StubLifecycleOnly:
+    """Stub that implements only the lifecycle protocol."""
+
+    async def initialize(self, config: dict[str, object]) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+class _StubFullBus:
+    """Stub implementing all three protocols (publish, health, lifecycle)."""
+
+    async def publish(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes,
+    ) -> None:
+        pass
+
+    async def health_check(self) -> dict[str, object]:
+        return {"healthy": True}
+
+    async def initialize(self, config: dict[str, object]) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+class _StubNotABus:
+    """Stub that does NOT implement any event bus protocol."""
+
+    async def do_something(self) -> None:
+        pass
+
+
+# =============================================================================
+# Tests: ProtocolEventBusPublish conformance
+# =============================================================================
+
+
+class TestProtocolEventBusPublishConformance:
+    """Validate ProtocolEventBusPublish runtime_checkable isinstance checks."""
+
+    def test_stub_publish_satisfies_protocol(self) -> None:
+        """Class with matching publish() signature satisfies the protocol."""
+        bus = _StubPublishOnly()
+        assert isinstance(bus, ProtocolEventBusPublish)
+
+    def test_full_bus_satisfies_publish_protocol(self) -> None:
+        """Class with all protocols still satisfies publish protocol."""
+        bus = _StubFullBus()
+        assert isinstance(bus, ProtocolEventBusPublish)
+
+    def test_non_bus_does_not_satisfy_publish_protocol(self) -> None:
+        """Class without publish() does not satisfy the protocol."""
+        obj = _StubNotABus()
+        assert not isinstance(obj, ProtocolEventBusPublish)
+
+    def test_health_only_does_not_satisfy_publish_protocol(self) -> None:
+        """Class with only health_check() does not satisfy publish protocol."""
+        obj = _StubHealthCheckOnly()
+        assert not isinstance(obj, ProtocolEventBusPublish)
+
+    @pytest.mark.asyncio
+    async def test_publish_accepts_positional_args(self) -> None:
+        """Protocol publish() must accept positional arguments (not keyword-only).
+
+        This verifies the fix for the signature mismatch where the protocol
+        used keyword-only args (``*,``) but EventBusKafka uses positional args.
+        """
+        bus = _StubPublishOnly()
+        # This should not raise - positional args must be accepted
+        await bus.publish("topic", None, b"value")
+
+
+# =============================================================================
+# Tests: ProtocolEventBusHealthCheck conformance
+# =============================================================================
+
+
+class TestProtocolEventBusHealthCheckConformance:
+    """Validate ProtocolEventBusHealthCheck runtime_checkable isinstance checks."""
+
+    def test_stub_health_satisfies_protocol(self) -> None:
+        """Class with matching health_check() satisfies the protocol."""
+        bus = _StubHealthCheckOnly()
+        assert isinstance(bus, ProtocolEventBusHealthCheck)
+
+    def test_full_bus_satisfies_health_protocol(self) -> None:
+        """Class with all protocols still satisfies health check protocol."""
+        bus = _StubFullBus()
+        assert isinstance(bus, ProtocolEventBusHealthCheck)
+
+    def test_publish_only_does_not_satisfy_health_protocol(self) -> None:
+        """Class with only publish() does not satisfy health check protocol."""
+        obj = _StubPublishOnly()
+        assert not isinstance(obj, ProtocolEventBusHealthCheck)
+
+    def test_non_bus_does_not_satisfy_health_protocol(self) -> None:
+        """Class without health_check() does not satisfy the protocol."""
+        obj = _StubNotABus()
+        assert not isinstance(obj, ProtocolEventBusHealthCheck)
+
+
+# =============================================================================
+# Tests: ProtocolEventBusLifecycle conformance
+# =============================================================================
+
+
+class TestProtocolEventBusLifecycleConformance:
+    """Validate ProtocolEventBusLifecycle runtime_checkable isinstance checks."""
+
+    def test_stub_lifecycle_satisfies_protocol(self) -> None:
+        """Class with matching initialize()/shutdown() satisfies the protocol."""
+        bus = _StubLifecycleOnly()
+        assert isinstance(bus, ProtocolEventBusLifecycle)
+
+    def test_full_bus_satisfies_lifecycle_protocol(self) -> None:
+        """Class with all protocols still satisfies lifecycle protocol."""
+        bus = _StubFullBus()
+        assert isinstance(bus, ProtocolEventBusLifecycle)
+
+    def test_publish_only_does_not_satisfy_lifecycle_protocol(self) -> None:
+        """Class with only publish() does not satisfy lifecycle protocol."""
+        obj = _StubPublishOnly()
+        assert not isinstance(obj, ProtocolEventBusLifecycle)
+
+    def test_non_bus_does_not_satisfy_lifecycle_protocol(self) -> None:
+        """Class without initialize()/shutdown() does not satisfy the protocol."""
+        obj = _StubNotABus()
+        assert not isinstance(obj, ProtocolEventBusLifecycle)
+
+
+# =============================================================================
+# Tests: AdapterKafkaPublisher delegation
+# =============================================================================
+
+
+class TestAdapterKafkaPublisherDelegation:
+    """Validate that AdapterKafkaPublisher delegates to the underlying bus."""
+
+    @pytest.fixture
+    def mock_bus(self) -> AsyncMock:
+        """Create a mock event bus with publish method."""
+        bus = AsyncMock(spec=_StubPublishOnly)
+        bus.publish = AsyncMock()
+        return bus
+
+    @pytest.fixture
+    def publisher(self, mock_bus: AsyncMock) -> AdapterKafkaPublisher:
+        """Create an AdapterKafkaPublisher wrapping the mock bus."""
+        return AdapterKafkaPublisher(mock_bus)
+
+    @pytest.mark.asyncio
+    async def test_publish_delegates_to_bus(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must call the underlying bus publish method."""
+        await publisher.publish("test.topic", "my-key", {"data": "value"})
+        mock_bus.publish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publish_passes_correct_topic(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must pass the topic unchanged to the bus."""
+        await publisher.publish("my.topic.name", "key", {"x": 1})
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "my.topic.name"
+
+    @pytest.mark.asyncio
+    async def test_publish_encodes_key_to_bytes(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must encode string key to UTF-8 bytes."""
+        await publisher.publish("topic", "my-key", {"x": 1})
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        assert call_kwargs["key"] == b"my-key"
+
+    @pytest.mark.asyncio
+    async def test_publish_none_key_passes_none(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must pass None key as None (not b'None')."""
+        await publisher.publish("topic", None, {"x": 1})
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        assert call_kwargs["key"] is None
+
+    @pytest.mark.asyncio
+    async def test_publish_serializes_dict_value_to_json_bytes(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must serialize dict value to compact JSON bytes."""
+        import json
+
+        payload = {"action": "created", "entity_id": "abc-123"}
+        await publisher.publish("topic", "key", payload)
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        value_bytes: bytes = call_kwargs["value"]
+
+        # Must be bytes
+        assert isinstance(value_bytes, bytes)
+
+        # Must be valid JSON
+        decoded = json.loads(value_bytes)
+        assert decoded == payload
+
+    @pytest.mark.asyncio
+    async def test_publish_uses_compact_json_separators(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must use compact separators (no whitespace)."""
+        await publisher.publish("topic", "key", {"a": 1, "b": 2})
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        value_str = call_kwargs["value"].decode("utf-8")
+        # Compact JSON has no spaces after : or ,
+        assert " " not in value_str
+
+    @pytest.mark.asyncio
+    async def test_publish_empty_string_key_encodes_to_empty_bytes(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must encode empty string key as b'' (not None)."""
+        await publisher.publish("topic", "", {"x": 1})
+        call_kwargs = mock_bus.publish.call_args.kwargs
+        assert call_kwargs["key"] == b""
+
+    @pytest.mark.asyncio
+    async def test_publish_propagates_bus_exception(
+        self,
+        publisher: AdapterKafkaPublisher,
+        mock_bus: AsyncMock,
+    ) -> None:
+        """publish() must propagate exceptions from the underlying bus."""
+        mock_bus.publish.side_effect = ConnectionError("bus unavailable")
+        with pytest.raises(ConnectionError, match="bus unavailable"):
+            await publisher.publish("topic", "key", {"x": 1})
+
+
+# =============================================================================
+# Tests: create_default_event_bus factory
+# =============================================================================
+
+
+class TestCreateDefaultEventBus:
+    """Validate create_default_event_bus factory behavior.
+
+    These tests mock the omnibase_infra imports since the actual Kafka
+    infrastructure is not available in unit tests. The factory uses
+    local imports so patches target the source modules.
+    """
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_protocol_conforming_object(self) -> None:
+        """create_default_event_bus must return ProtocolEventBusPublish."""
+        from unittest.mock import patch
+
+        mock_config_cls = MagicMock()
+        mock_bus_instance = AsyncMock(spec=_StubFullBus)
+        mock_bus_instance.start = AsyncMock()
+        mock_bus_instance.publish = AsyncMock()
+        mock_bus_cls = MagicMock(return_value=mock_bus_instance)
+
+        with (
+            patch(
+                "omnibase_infra.event_bus.event_bus_kafka.EventBusKafka",
+                mock_bus_cls,
+            ),
+            patch(
+                "omnibase_infra.event_bus.models.config.ModelKafkaEventBusConfig",
+                mock_config_cls,
+            ),
+        ):
+            from omnimemory.runtime.adapters import create_default_event_bus
+
+            result = await create_default_event_bus(
+                bootstrap_servers="localhost:9092",
+            )
+
+        # Result must not be None
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_factory_calls_start_on_bus(self) -> None:
+        """create_default_event_bus must call start() on the bus."""
+        from unittest.mock import patch
+
+        mock_config_cls = MagicMock()
+        mock_bus_instance = AsyncMock(spec=_StubFullBus)
+        mock_bus_instance.start = AsyncMock()
+        mock_bus_cls = MagicMock(return_value=mock_bus_instance)
+
+        with (
+            patch(
+                "omnibase_infra.event_bus.event_bus_kafka.EventBusKafka",
+                mock_bus_cls,
+            ),
+            patch(
+                "omnibase_infra.event_bus.models.config.ModelKafkaEventBusConfig",
+                mock_config_cls,
+            ),
+        ):
+            from omnimemory.runtime.adapters import create_default_event_bus
+
+            await create_default_event_bus(
+                bootstrap_servers="localhost:9092",
+            )
+
+        mock_bus_instance.start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_factory_raises_runtime_error_on_start_failure(self) -> None:
+        """create_default_event_bus must raise RuntimeError if start() fails."""
+        from unittest.mock import patch
+
+        mock_config_cls = MagicMock()
+        mock_bus_instance = AsyncMock(spec=_StubFullBus)
+        mock_bus_instance.start = AsyncMock(side_effect=ConnectionError("broker down"))
+        mock_bus_cls = MagicMock(return_value=mock_bus_instance)
+
+        with (
+            patch(
+                "omnibase_infra.event_bus.event_bus_kafka.EventBusKafka",
+                mock_bus_cls,
+            ),
+            patch(
+                "omnibase_infra.event_bus.models.config.ModelKafkaEventBusConfig",
+                mock_config_cls,
+            ),
+        ):
+            from omnimemory.runtime.adapters import create_default_event_bus
+
+            with pytest.raises(RuntimeError, match="Failed to initialize event bus"):
+                await create_default_event_bus(
+                    bootstrap_servers="localhost:9092",
+                )


### PR DESCRIPTION
## Summary

- **Created `runtime/adapters.py`** — protocol adapter layer that bridges `ProtocolEventBusPublish` to concrete Kafka implementation. This is the **only** file that imports from `omnibase_infra.event_bus`
- **Refactored `handler_subscription.py`** — replaced direct `EventBusKafka` import with protocol-typed references and dependency injection via `initialize(event_bus=...)`
- **Updated `handler_intent_event_consumer.py`** — transport-agnostic docstrings (already used callback injection, no import violations)

## ARCH-002 Compliance

| Check | Result |
|-------|--------|
| Zero Kafka imports in `handlers/` | Passed |
| Zero Kafka imports in `nodes/` | Passed |
| All publishing via `ProtocolEventBusPublish` | Passed |
| Runtime adapter bridges protocol → concrete | Passed |

## Test plan

- [x] All 1565 functional tests pass (157 skipped)
- [x] mypy strict: 0 errors
- [x] ruff lint + format: clean
- [x] All 20 pre-commit hooks pass
- [x] AST-based import scan: zero `omnibase_infra.event_bus` in handlers/nodes
- [x] Shutdown reference leak fixed in local review

Closes OMN-2214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription initialization can accept an external event bus or create a default one.
  * Added a default event-bus adapter factory for runtime wiring.

* **Refactor**
  * Replaced transport-specific handling with protocol-driven event bus abstractions.
  * Runtime exports reorganized to surface new adapter interfaces.

* **Documentation**
  * Updated docstrings and user-facing messages to use event-bus terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->