### PR TITLE
feat(runtime): Add MessageDispatchEngine integration (OMN-2215)

### DIFF
--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/contract.yaml
@@ -108,7 +108,7 @@ author: "OmniNode Team"
 # Topic names follow ONEX canonical naming: onex.{cmd/evt}.omnimemory.{action}.v{N}
 consumed_events:
   # RuntimeTick - Periodic lifecycle evaluation trigger
-  - event_pattern: "onex.internal.runtime-tick.v1"
+  - event_pattern: "onex.cmd.omnimemory.runtime-tick.v1"
     handler_function: "handle_runtime_tick"
 
   # Memory lifecycle command events
@@ -187,7 +187,7 @@ handler_routing:
 # Topic naming: onex.{kind}.omnimemory.{event-name}.v{n}
 #   - kind=cmd for commands/inputs
 #   - kind=evt for events/outputs
-#   - Internal runtime events use onex.internal.* namespace
+#   - Runtime tick uses onex.cmd.omnimemory.* (command namespace)
 # =============================================================================
 event_bus:
   version:
@@ -198,7 +198,7 @@ event_bus:
 
   # Topics this node subscribes to (receives events from)
   subscribe_topics:
-    - "onex.internal.runtime-tick.v1"
+    - "onex.cmd.omnimemory.runtime-tick.v1"
     - "onex.cmd.omnimemory.archive-memory.v1"
     - "onex.cmd.omnimemory.expire-memory.v1"
 
@@ -208,7 +208,7 @@ event_bus:
 
   # Metadata for subscribed topics
   subscribe_topic_metadata:
-    "onex.internal.runtime-tick.v1":
+    "onex.cmd.omnimemory.runtime-tick.v1":
       schema_ref: "omnibase_infra.runtime.models.model_runtime_tick.ModelRuntimeTick"
       description: "Periodic runtime tick for TTL expiration evaluation. Injected timestamp enables deterministic
         lifecycle checks."

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_tick.py
@@ -610,7 +610,7 @@ class HandlerMemoryTick:
     @property
     def category(self) -> EnumMessageCategory:
         """Return the message category this handler processes."""
-        return EnumMessageCategory.EVENT
+        return EnumMessageCategory.COMMAND
 
     @property
     def message_types(self) -> set[str]:

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -47,7 +47,32 @@ from omnimemory.runtime.contract_topics import (
 )
 
 # Dispatch handlers are lazy-imported to avoid pulling in omnibase_core.runtime
-# at package import time. Import from omnimemory.runtime.dispatch_handlers directly.
+# at package import time. Import from omnimemory.runtime.dispatch_handlers directly,
+# or access via __all__ (the symbols are provided by __getattr__ below).
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-import dispatch handler symbols on first access.
+
+    This avoids pulling omnibase_core.runtime into the module namespace at
+    package import time while still allowing ``from omnimemory.runtime import
+    create_memory_dispatch_engine`` to work.
+    """
+    _dispatch_symbols = {
+        "DISPATCH_ALIAS_ARCHIVE_MEMORY",
+        "DISPATCH_ALIAS_EXPIRE_MEMORY",
+        "DISPATCH_ALIAS_INTENT_CLASSIFIED",
+        "DISPATCH_ALIAS_INTENT_QUERY_REQUESTED",
+        "DISPATCH_ALIAS_RUNTIME_TICK",
+        "create_dispatch_callback",
+        "create_memory_dispatch_engine",
+    }
+    if name in _dispatch_symbols:
+        from omnimemory.runtime import dispatch_handlers
+
+        return getattr(dispatch_handlers, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Protocol adapters (ARCH-002)
@@ -61,4 +86,12 @@ __all__ = [
     "collect_all_publish_topics",
     "collect_publish_topics_for_dispatch",
     "collect_subscribe_topics_from_contracts",
+    # Dispatch handlers (lazy-imported via __getattr__)
+    "DISPATCH_ALIAS_ARCHIVE_MEMORY",
+    "DISPATCH_ALIAS_EXPIRE_MEMORY",
+    "DISPATCH_ALIAS_INTENT_CLASSIFIED",
+    "DISPATCH_ALIAS_INTENT_QUERY_REQUESTED",
+    "DISPATCH_ALIAS_RUNTIME_TICK",
+    "create_dispatch_callback",
+    "create_memory_dispatch_engine",
 ]

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -2,12 +2,13 @@
 # Copyright (c) 2025 OmniNode Team
 """OmniMemory Runtime Package.
 
-Provides contract-driven topic discovery and protocol adapters for the
-OmniMemory domain.
+Provides contract-driven topic discovery, protocol adapters, and dispatch
+handlers for the OmniMemory domain.
 
 This package contains:
     - Contract-driven topic discovery (contract_topics module)
     - Protocol adapters bridging infrastructure to handler protocols (adapters module)
+    - Dispatch handlers routing events through MessageDispatchEngine (dispatch_handlers module)
 
 Usage:
     from omnimemory.runtime.contract_topics import (
@@ -22,6 +23,11 @@ Usage:
         ProtocolEventBusPublish,
         ProtocolEventBusHealthCheck,
         ProtocolEventBusLifecycle,
+    )
+
+    from omnimemory.runtime.dispatch_handlers import (
+        create_memory_dispatch_engine,
+        create_dispatch_callback,
     )
 """
 
@@ -39,6 +45,9 @@ from omnimemory.runtime.contract_topics import (
     collect_publish_topics_for_dispatch,
     collect_subscribe_topics_from_contracts,
 )
+
+# Dispatch handlers are lazy-imported to avoid pulling in omnibase_core.runtime
+# at package import time. Import from omnimemory.runtime.dispatch_handlers directly.
 
 __all__ = [
     # Protocol adapters (ARCH-002)

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -102,7 +102,7 @@ DISPATCH_ALIAS_INTENT_QUERY_REQUESTED = (
 )
 """Dispatch-compatible alias for intent-query-requested canonical topic."""
 
-DISPATCH_ALIAS_RUNTIME_TICK = "omnimemory.commands.runtime-tick.v1"
+DISPATCH_ALIAS_RUNTIME_TICK = "onex.commands.omnimemory.runtime-tick.v1"
 """Dispatch-compatible alias for runtime-tick command topic."""
 
 DISPATCH_ALIAS_ARCHIVE_MEMORY = "onex.commands.omnimemory.archive-memory.v1"

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -516,7 +516,11 @@ def create_dispatch_callback(
     Args:
         engine: Frozen MessageDispatchEngine.
         dispatch_topic: Dispatch-compatible topic alias to pass to dispatch().
-        correlation_id: Optional fixed correlation ID for tracing.
+        correlation_id: Optional fixed correlation ID for tracing. Note that a
+            correlation_id found in the message payload takes precedence over
+            this value. Full precedence order (highest wins): payload
+            correlation_id > caller-provided correlation_id > auto-generated
+            UUID.
 
     Returns:
         Async callback compatible with event bus subscribe(on_message=...).
@@ -557,7 +561,14 @@ def create_dispatch_callback(
                     await msg.nack()
                 return
 
-            # Extract correlation_id from payload if available
+            # Extract correlation_id from payload if available.
+            # Precedence (highest wins):
+            #   1. payload correlation_id  (from the message body)
+            #   2. caller-provided fixed correlation_id  (passed to create_dispatch_callback)
+            #   3. auto-generated UUID  (uuid4 fallback)
+            # If the payload contains a valid UUID correlation_id, it overrides the
+            # caller-supplied value. If parsing fails, the current value (caller-
+            # supplied or auto-generated) is silently retained via suppress().
             payload_correlation_id = payload_dict.get("correlation_id")
             if payload_correlation_id:
                 with contextlib.suppress(ValueError, AttributeError):

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -26,10 +26,11 @@ Related:
 from __future__ import annotations
 
 import contextlib
+import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 from uuid import UUID, uuid4
 
 from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
@@ -186,7 +187,9 @@ def create_intent_classified_dispatch_handler(
 def create_intent_query_dispatch_handler(
     *,
     query_handler: ProtocolIntentQueryHandler,
-    publish_callback: Callable[[str, dict[str, object]], None] | None = None,
+    publish_callback: Callable[[str, dict[str, object]], Awaitable[None]]
+    | Callable[[str, dict[str, object]], None]
+    | None = None,
     publish_topic: str | None = None,
     correlation_id: UUID | None = None,
 ) -> Callable[
@@ -203,6 +206,7 @@ def create_intent_query_dispatch_handler(
     Args:
         query_handler: REQUIRED intent query handler instance.
         publish_callback: Optional callback for publishing response events.
+            Accepts both sync and async callables; async results are awaited.
         publish_topic: Full topic for intent query response events (from contract).
         correlation_id: Optional fixed correlation ID for tracing.
 
@@ -273,10 +277,12 @@ def create_intent_query_dispatch_handler(
         # Publish response if callback and topic are configured
         if publish_callback and publish_topic and hasattr(response, "model_dump"):
             try:
-                publish_callback(
+                publish_result = publish_callback(
                     publish_topic,
                     response.model_dump(mode="json"),
                 )
+                if inspect.isawaitable(publish_result):
+                    await publish_result
                 logger.debug(
                     "Published intent query response (topic=%s, query_id=%s)",
                     publish_topic,
@@ -358,7 +364,9 @@ def create_memory_dispatch_engine(
     *,
     intent_consumer: ProtocolIntentEventConsumer,
     intent_query_handler: ProtocolIntentQueryHandler,
-    publish_callback: Callable[[str, dict[str, object]], None] | None = None,
+    publish_callback: Callable[[str, dict[str, object]], Awaitable[None]]
+    | Callable[[str, dict[str, object]], None]
+    | None = None,
     publish_topics: dict[str, str] | None = None,
 ) -> MessageDispatchEngine:
     """Create and configure a MessageDispatchEngine for OmniMemory domain.
@@ -375,6 +383,7 @@ def create_memory_dispatch_engine(
         intent_consumer: REQUIRED intent event consumer handler.
         intent_query_handler: REQUIRED intent query handler.
         publish_callback: Optional callback for publishing response events.
+            Accepts both sync and async callables; async results are awaited.
         publish_topics: Optional mapping of handler name to publish topic.
             Keys: "intent_query". Values: full topic strings from contract
             event_bus.publish_topics.
@@ -561,6 +570,21 @@ def create_dispatch_callback(
                     await msg.nack()
                 return
 
+            # Guard: json.loads can return arrays, scalars, etc.
+            # Only dict payloads are valid for dispatch envelope wrapping.
+            if not isinstance(payload_dict, dict):
+                logger.warning(
+                    "Expected JSON object but got %s; nacking message on topic %s",
+                    type(payload_dict).__name__,
+                    dispatch_topic,
+                )
+                if hasattr(msg, "nack"):
+                    await msg.nack()
+                return
+
+            # Narrow the type from Any (json.loads return) to dict[str, object].
+            payload: dict[str, object] = cast(dict[str, object], payload_dict)
+
             # Extract correlation_id from payload if available.
             # Precedence (highest wins):
             #   1. payload correlation_id  (from the message body)
@@ -569,7 +593,7 @@ def create_dispatch_callback(
             # If the payload contains a valid UUID correlation_id, it overrides the
             # caller-supplied value. If parsing fails, the current value (caller-
             # supplied or auto-generated) is silently retained via suppress().
-            payload_correlation_id = payload_dict.get("correlation_id")
+            payload_correlation_id = payload.get("correlation_id")
             if payload_correlation_id:
                 with contextlib.suppress(ValueError, AttributeError):
                     msg_correlation_id = UUID(str(payload_correlation_id))
@@ -585,7 +609,7 @@ def create_dispatch_callback(
                     msg_correlation_id,
                 )
             envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
-                payload=payload_dict,
+                payload=payload,
                 correlation_id=msg_correlation_id,
                 metadata=ModelEnvelopeMetadata(
                     tags={

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -199,6 +199,11 @@ def create_intent_query_dispatch_handler(
 
     Returns:
         Async handler function with signature (envelope, context) -> str.
+
+    Note:
+        Response publishing is best-effort; publish failures are logged but do
+        not cause the handler to fail. The query is considered successful if
+        execute() completes without error.
     """
 
     async def _handle(
@@ -352,7 +357,7 @@ def create_memory_dispatch_engine(
     Creates the engine, registers all omnimemory domain handlers and routes,
     and freezes it. The engine is ready for dispatch after this call.
 
-    Registers 4 handlers covering 5 routes:
+    Registers 3 handlers covering 5 routes:
         1. intent-classified handler (1 route: intent-classified.v1 events)
         2. intent-query handler (1 route: intent-query-requested.v1 commands)
         3. lifecycle handler (3 routes: runtime-tick, archive, expire -- fail-fast)

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -55,7 +55,16 @@ logger = logging.getLogger(__name__)
 
 @runtime_checkable
 class ProtocolIntentEventConsumer(Protocol):
-    """Protocol for intent event consumer handler."""
+    """Protocol for intent event consumer handler.
+
+    Note on ``_handle_message`` naming:
+        The underscore-prefixed method name is intentional and mirrors the actual
+        implementation in omnibase_core's ``HandlerIntentEventConsumer``, where
+        ``_handle_message`` is the concrete method called by the base-class
+        ``on_message`` template.  Renaming it here would break structural typing
+        compatibility.  The ``# noqa: SLF001`` suppression on call-sites
+        acknowledges this cross-boundary private-method access.
+    """
 
     async def _handle_message(
         self, message: dict[str, object], *, retry_count: int = 0
@@ -93,8 +102,8 @@ DISPATCH_ALIAS_INTENT_QUERY_REQUESTED = (
 )
 """Dispatch-compatible alias for intent-query-requested canonical topic."""
 
-DISPATCH_ALIAS_RUNTIME_TICK = "onex.internal.runtime-tick.v1"
-"""Dispatch alias for runtime tick events (internal namespace, no conversion)."""
+DISPATCH_ALIAS_RUNTIME_TICK = "omnimemory.commands.runtime-tick.v1"
+"""Dispatch-compatible alias for runtime-tick command topic."""
 
 DISPATCH_ALIAS_ARCHIVE_MEMORY = "onex.commands.omnimemory.archive-memory.v1"
 """Dispatch-compatible alias for archive-memory command topic."""
@@ -438,9 +447,8 @@ def create_memory_dispatch_engine(
         node_kind=EnumNodeKind.ORCHESTRATOR,
         message_types=None,
     )
-    # Runtime-tick is an internal namespace topic. EnumMessageCategory.from_topic()
-    # may map onex.internal.* to COMMAND or None. Registered as COMMAND for
-    # consistency with the orchestrator command pattern.
+    # Runtime-tick uses .commands. segment so EnumMessageCategory.from_topic()
+    # returns COMMAND, consistent with the other lifecycle command routes.
     engine.register_route(
         ModelDispatchRoute(
             route_id="memory-lifecycle-tick-route",
@@ -558,6 +566,13 @@ def create_dispatch_callback(
             # Derive message category from dispatch_topic so EVENT topics
             # produce EVENT envelopes (not hard-coded COMMAND).
             topic_category = EnumMessageCategory.from_topic(dispatch_topic)
+            if topic_category is None:
+                logger.warning(
+                    "from_topic() returned None for dispatch_topic=%r; "
+                    "falling back to 'command' category (correlation_id=%s)",
+                    dispatch_topic,
+                    msg_correlation_id,
+                )
             envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
                 payload=payload_dict,
                 correlation_id=msg_correlation_id,

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -1,0 +1,620 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Dispatch bridge handlers for OmniMemory domain.
+
+This module provides bridge handlers that adapt between the MessageDispatchEngine
+handler signature and existing OmniMemory domain handlers. It also defines
+topic alias mappings needed because ONEX canonical topic naming uses ``.cmd.``
+and ``.evt.`` segments, which EnumMessageCategory.from_topic() does not yet
+recognize (it expects ``.commands.`` and ``.events.``).
+
+Design Decisions:
+    - Topic aliases are a temporary bridge until EnumMessageCategory.from_topic()
+      is updated to handle ``.cmd.`` / ``.evt.`` short forms.
+    - Bridge handlers adapt (envelope, context) -> existing handler interfaces.
+    - The dispatch engine is created per-plugin (not kernel-managed).
+    - message_types=None on handler registration accepts all message types in
+      the category -- correct when routing by topic, not type.
+    - Unimplemented dispatch routes raise RuntimeError to prevent silent data loss.
+
+Related:
+    - OMN-2215: Phase 4 -- MessageDispatchEngine integration for omnimemory
+    - OMN-934: MessageDispatchEngine implementation in omnibase_core
+    - omniintelligence/runtime/dispatch_handlers.py (reference implementation)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from uuid import UUID, uuid4
+
+from omnibase_core.enums.enum_execution_shape import EnumMessageCategory
+from omnibase_core.enums.enum_node_kind import EnumNodeKind
+from omnibase_core.models.core.model_envelope_metadata import ModelEnvelopeMetadata
+from omnibase_core.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_core.runtime.runtime_message_dispatch import MessageDispatchEngine
+
+if TYPE_CHECKING:
+    from omnibase_core.protocols.handler.protocol_handler_context import (
+        ProtocolHandlerContext,
+    )
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Dependency Protocols (structural typing for dispatch handler deps)
+# =============================================================================
+# Defined locally to avoid circular imports with handler modules.
+# These mirror the handler interfaces that the dispatch handlers delegate to.
+
+
+@runtime_checkable
+class ProtocolIntentEventConsumer(Protocol):
+    """Protocol for intent event consumer handler."""
+
+    async def _handle_message(
+        self, message: dict[str, object], *, retry_count: int = 0
+    ) -> None: ...
+
+
+@runtime_checkable
+class ProtocolIntentQueryHandler(Protocol):
+    """Protocol for intent query handler.
+
+    Matches HandlerIntentQuery.execute() signature.
+    """
+
+    async def execute(
+        self,
+        request: object,
+    ) -> object: ...
+
+
+# =============================================================================
+# Topic Alias Mapping
+# =============================================================================
+# ONEX canonical topic naming uses `.cmd.` for commands and `.evt.` for events.
+# MessageDispatchEngine.dispatch() uses EnumMessageCategory.from_topic() which
+# only recognizes `.commands.` and `.events.` segments. These aliases bridge
+# the naming gap until from_topic() is updated.
+#
+# Usage: when calling dispatch(), pass the alias instead of the raw topic.
+
+DISPATCH_ALIAS_INTENT_CLASSIFIED = "onex.events.omniintelligence.intent-classified.v1"
+"""Dispatch-compatible alias for intent-classified canonical topic."""
+
+DISPATCH_ALIAS_INTENT_QUERY_REQUESTED = (
+    "onex.commands.omnimemory.intent-query-requested.v1"
+)
+"""Dispatch-compatible alias for intent-query-requested canonical topic."""
+
+DISPATCH_ALIAS_RUNTIME_TICK = "onex.internal.runtime-tick.v1"
+"""Dispatch alias for runtime tick events (internal namespace, no conversion)."""
+
+DISPATCH_ALIAS_ARCHIVE_MEMORY = "onex.commands.omnimemory.archive-memory.v1"
+"""Dispatch-compatible alias for archive-memory command topic."""
+
+DISPATCH_ALIAS_EXPIRE_MEMORY = "onex.commands.omnimemory.expire-memory.v1"
+"""Dispatch-compatible alias for expire-memory command topic."""
+
+
+# =============================================================================
+# Bridge Handler: Intent Classified Event
+# =============================================================================
+
+
+def create_intent_classified_dispatch_handler(
+    *,
+    consumer: ProtocolIntentEventConsumer,
+    correlation_id: UUID | None = None,
+) -> Callable[
+    [ModelEventEnvelope[object], ProtocolHandlerContext],
+    Awaitable[str],
+]:
+    """Create a dispatch engine handler for intent-classified events.
+
+    Returns an async handler function compatible with MessageDispatchEngine's
+    handler signature. The handler extracts the payload from the envelope
+    and delegates to HandlerIntentEventConsumer._handle_message().
+
+    Args:
+        consumer: REQUIRED intent event consumer handler instance.
+        correlation_id: Optional fixed correlation ID for tracing.
+
+    Returns:
+        Async handler function with signature (envelope, context) -> str.
+    """
+
+    async def _handle(
+        envelope: ModelEventEnvelope[object],
+        context: ProtocolHandlerContext,
+    ) -> str:
+        """Bridge handler: envelope -> HandlerIntentEventConsumer._handle_message()."""
+        ctx_correlation_id = (
+            correlation_id or getattr(context, "correlation_id", None) or uuid4()
+        )
+
+        payload = envelope.payload
+
+        if not isinstance(payload, dict):
+            msg = (
+                f"Unexpected payload type {type(payload).__name__} "
+                f"for intent-classified event "
+                f"(correlation_id={ctx_correlation_id})"
+            )
+            logger.warning(msg)
+            raise ValueError(msg)
+
+        logger.info(
+            "Dispatching intent-classified event via MessageDispatchEngine "
+            "(correlation_id=%s)",
+            ctx_correlation_id,
+        )
+
+        await consumer._handle_message(payload, retry_count=0)  # noqa: SLF001
+
+        logger.info(
+            "Intent-classified event processed via dispatch engine "
+            "(correlation_id=%s)",
+            ctx_correlation_id,
+        )
+
+        return ""
+
+    return _handle
+
+
+# =============================================================================
+# Bridge Handler: Intent Query Requested
+# =============================================================================
+
+
+def create_intent_query_dispatch_handler(
+    *,
+    query_handler: ProtocolIntentQueryHandler,
+    publish_callback: Callable[[str, dict[str, object]], None] | None = None,
+    publish_topic: str | None = None,
+    correlation_id: UUID | None = None,
+) -> Callable[
+    [ModelEventEnvelope[object], ProtocolHandlerContext],
+    Awaitable[str],
+]:
+    """Create a dispatch engine handler for intent-query-requested events.
+
+    Returns an async handler function compatible with MessageDispatchEngine's
+    handler signature. The handler extracts the payload from the envelope,
+    validates it as a ModelIntentQueryRequestedEvent, delegates to
+    HandlerIntentQuery.execute(), and optionally publishes the response.
+
+    Args:
+        query_handler: REQUIRED intent query handler instance.
+        publish_callback: Optional callback for publishing response events.
+        publish_topic: Full topic for intent query response events (from contract).
+        correlation_id: Optional fixed correlation ID for tracing.
+
+    Returns:
+        Async handler function with signature (envelope, context) -> str.
+    """
+
+    async def _handle(
+        envelope: ModelEventEnvelope[object],
+        context: ProtocolHandlerContext,
+    ) -> str:
+        """Bridge handler: envelope -> HandlerIntentQuery.execute()."""
+        from omnimemory.nodes.intent_query_effect.models import (
+            ModelIntentQueryRequestedEvent,
+        )
+
+        ctx_correlation_id = (
+            correlation_id or getattr(context, "correlation_id", None) or uuid4()
+        )
+
+        payload = envelope.payload
+
+        # Parse payload into ModelIntentQueryRequestedEvent
+        if isinstance(payload, ModelIntentQueryRequestedEvent):
+            request = payload
+        elif isinstance(payload, dict):
+            try:
+                request = ModelIntentQueryRequestedEvent(**payload)
+            except Exception as e:
+                msg = (
+                    f"Failed to parse payload as ModelIntentQueryRequestedEvent: {e} "
+                    f"(correlation_id={ctx_correlation_id})"
+                )
+                logger.warning(msg)
+                raise ValueError(msg) from e
+        else:
+            msg = (
+                f"Unexpected payload type {type(payload).__name__} "
+                f"for intent-query-requested "
+                f"(correlation_id={ctx_correlation_id})"
+            )
+            logger.warning(msg)
+            raise ValueError(msg)
+
+        logger.info(
+            "Dispatching intent-query-requested via MessageDispatchEngine "
+            "(query_type=%s, query_id=%s, correlation_id=%s)",
+            request.query_type,
+            request.query_id,
+            ctx_correlation_id,
+        )
+
+        response = await query_handler.execute(request)
+
+        logger.info(
+            "Intent query processed via dispatch engine "
+            "(query_type=%s, query_id=%s, correlation_id=%s)",
+            request.query_type,
+            request.query_id,
+            ctx_correlation_id,
+        )
+
+        # Publish response if callback and topic are configured
+        if publish_callback and publish_topic and hasattr(response, "model_dump"):
+            try:
+                publish_callback(
+                    publish_topic,
+                    response.model_dump(mode="json"),
+                )
+                logger.debug(
+                    "Published intent query response (topic=%s, query_id=%s)",
+                    publish_topic,
+                    request.query_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to publish intent query response: %s "
+                    "(topic=%s, correlation_id=%s)",
+                    e,
+                    publish_topic,
+                    ctx_correlation_id,
+                )
+
+        return ""
+
+    return _handle
+
+
+# =============================================================================
+# Bridge Handler: Lifecycle Orchestrator (runtime-tick, archive, expire)
+# =============================================================================
+
+
+def create_lifecycle_dispatch_handler(
+    *,
+    correlation_id: UUID | None = None,
+) -> Callable[
+    [ModelEventEnvelope[object], ProtocolHandlerContext],
+    Awaitable[str],
+]:
+    """Create a fail-fast dispatch handler for lifecycle orchestrator topics.
+
+    This is a fail-fast handler that raises RuntimeError on every invocation
+    to prevent silent data loss. The full implementation will be wired when
+    the memory_lifecycle_orchestrator handler integration is complete.
+
+    Args:
+        correlation_id: Optional fixed correlation ID for tracing.
+
+    Returns:
+        Async handler function with signature (envelope, context) -> str.
+    """
+
+    async def _handle(
+        envelope: ModelEventEnvelope[object],
+        context: ProtocolHandlerContext,
+    ) -> str:
+        """Fail-fast handler: lifecycle orchestrator not yet wired."""
+        ctx_correlation_id = (
+            correlation_id or getattr(context, "correlation_id", None) or uuid4()
+        )
+
+        payload = envelope.payload
+        payload_keys: list[str] = []
+        if isinstance(payload, dict):
+            payload_keys = list(payload.keys())
+
+        logger.error(
+            "Lifecycle dispatch handler not wired; refusing to ack message "
+            "(correlation_id=%s, payload_keys=%s)",
+            ctx_correlation_id,
+            payload_keys,
+        )
+        raise RuntimeError(
+            f"Lifecycle dispatch handler not wired "
+            f"(correlation_id={ctx_correlation_id})"
+        )
+
+    return _handle
+
+
+# =============================================================================
+# Dispatch Engine Factory
+# =============================================================================
+
+
+def create_memory_dispatch_engine(
+    *,
+    intent_consumer: ProtocolIntentEventConsumer,
+    intent_query_handler: ProtocolIntentQueryHandler,
+    publish_callback: Callable[[str, dict[str, object]], None] | None = None,
+    publish_topics: dict[str, str] | None = None,
+) -> MessageDispatchEngine:
+    """Create and configure a MessageDispatchEngine for OmniMemory domain.
+
+    Creates the engine, registers all omnimemory domain handlers and routes,
+    and freezes it. The engine is ready for dispatch after this call.
+
+    Registers 4 handlers covering 5 routes:
+        1. intent-classified handler (1 route: intent-classified.v1 events)
+        2. intent-query handler (1 route: intent-query-requested.v1 commands)
+        3. lifecycle handler (3 routes: runtime-tick, archive, expire -- fail-fast)
+
+    Args:
+        intent_consumer: REQUIRED intent event consumer handler.
+        intent_query_handler: REQUIRED intent query handler.
+        publish_callback: Optional callback for publishing response events.
+        publish_topics: Optional mapping of handler name to publish topic.
+            Keys: "intent_query". Values: full topic strings from contract
+            event_bus.publish_topics.
+
+    Returns:
+        Frozen MessageDispatchEngine ready for dispatch.
+    """
+    topics = publish_topics or {}
+
+    engine = MessageDispatchEngine(
+        logger=logging.getLogger(f"{__name__}.dispatch_engine"),
+    )
+
+    # --- Handler 1: intent-classified events ---
+    intent_classified_handler = create_intent_classified_dispatch_handler(
+        consumer=intent_consumer,
+    )
+    engine.register_handler(
+        handler_id="memory-intent-classified-handler",
+        handler=intent_classified_handler,
+        category=EnumMessageCategory.EVENT,
+        node_kind=EnumNodeKind.EFFECT,
+        message_types=None,
+    )
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id="memory-intent-classified-route",
+            topic_pattern=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+            message_category=EnumMessageCategory.EVENT,
+            handler_id="memory-intent-classified-handler",
+            description=(
+                "Routes intent-classified events to "
+                "HandlerIntentEventConsumer for persistence."
+            ),
+        )
+    )
+
+    # --- Handler 2: intent-query-requested commands ---
+    intent_query_dispatch_handler = create_intent_query_dispatch_handler(
+        query_handler=intent_query_handler,
+        publish_callback=publish_callback,
+        publish_topic=topics.get("intent_query"),
+    )
+    engine.register_handler(
+        handler_id="memory-intent-query-handler",
+        handler=intent_query_dispatch_handler,
+        category=EnumMessageCategory.COMMAND,
+        node_kind=EnumNodeKind.EFFECT,
+        message_types=None,
+    )
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id="memory-intent-query-route",
+            topic_pattern=DISPATCH_ALIAS_INTENT_QUERY_REQUESTED,
+            message_category=EnumMessageCategory.COMMAND,
+            handler_id="memory-intent-query-handler",
+            description=(
+                "Routes intent-query-requested commands to "
+                "HandlerIntentQuery for query processing."
+            ),
+        )
+    )
+
+    # --- Handler 3: lifecycle orchestrator (fail-fast) ---
+    lifecycle_handler = create_lifecycle_dispatch_handler()
+    engine.register_handler(
+        handler_id="memory-lifecycle-handler",
+        handler=lifecycle_handler,
+        category=EnumMessageCategory.COMMAND,
+        node_kind=EnumNodeKind.ORCHESTRATOR,
+        message_types=None,
+    )
+    # Runtime-tick is an internal namespace topic. EnumMessageCategory.from_topic()
+    # may map onex.internal.* to COMMAND or None. Registered as COMMAND for
+    # consistency with the orchestrator command pattern.
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id="memory-lifecycle-tick-route",
+            topic_pattern=DISPATCH_ALIAS_RUNTIME_TICK,
+            message_category=EnumMessageCategory.COMMAND,
+            handler_id="memory-lifecycle-handler",
+            description="Routes runtime-tick to lifecycle orchestrator (fail-fast).",
+        )
+    )
+    # Route: archive-memory command
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id="memory-lifecycle-archive-route",
+            topic_pattern=DISPATCH_ALIAS_ARCHIVE_MEMORY,
+            message_category=EnumMessageCategory.COMMAND,
+            handler_id="memory-lifecycle-handler",
+            description=(
+                "Routes archive-memory commands to lifecycle orchestrator (fail-fast)."
+            ),
+        )
+    )
+    # Route: expire-memory command
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id="memory-lifecycle-expire-route",
+            topic_pattern=DISPATCH_ALIAS_EXPIRE_MEMORY,
+            message_category=EnumMessageCategory.COMMAND,
+            handler_id="memory-lifecycle-handler",
+            description=(
+                "Routes expire-memory commands to lifecycle orchestrator (fail-fast)."
+            ),
+        )
+    )
+
+    engine.freeze()
+
+    logger.info(
+        "Memory dispatch engine created and frozen (routes=%d, handlers=%d)",
+        engine.route_count,
+        engine.handler_count,
+    )
+
+    return engine
+
+
+# =============================================================================
+# Event Bus Callback Factory
+# =============================================================================
+
+
+def create_dispatch_callback(
+    engine: MessageDispatchEngine,
+    dispatch_topic: str,
+    *,
+    correlation_id: UUID | None = None,
+) -> Callable[[object], Awaitable[None]]:
+    """Create an event bus callback that routes messages through the dispatch engine.
+
+    The callback:
+    1. Deserializes the raw message value from bytes to dict
+    2. Wraps it in a ModelEventEnvelope with category derived from dispatch_topic
+    3. Calls engine.dispatch() with the dispatch-compatible topic alias
+    4. Acks the message on success, nacks on failure
+
+    Args:
+        engine: Frozen MessageDispatchEngine.
+        dispatch_topic: Dispatch-compatible topic alias to pass to dispatch().
+        correlation_id: Optional fixed correlation ID for tracing.
+
+    Returns:
+        Async callback compatible with event bus subscribe(on_message=...).
+    """
+
+    async def _on_message(msg: object) -> None:
+        """Event bus callback: raw message -> dispatch engine."""
+        msg_correlation_id = correlation_id or uuid4()
+
+        try:
+            # Extract raw value from message
+            if hasattr(msg, "value"):
+                raw_value = msg.value
+                if isinstance(raw_value, bytes | bytearray):
+                    payload_dict = json.loads(raw_value.decode("utf-8"))
+                elif isinstance(raw_value, str):
+                    payload_dict = json.loads(raw_value)
+                elif isinstance(raw_value, dict):
+                    payload_dict = raw_value
+                else:
+                    logger.warning(
+                        "Unexpected message value type %s (correlation_id=%s)",
+                        type(raw_value).__name__,
+                        msg_correlation_id,
+                    )
+                    if hasattr(msg, "nack"):
+                        await msg.nack()
+                    return
+            elif isinstance(msg, dict):
+                payload_dict = msg
+            else:
+                logger.warning(
+                    "Unexpected message type %s (correlation_id=%s)",
+                    type(msg).__name__,
+                    msg_correlation_id,
+                )
+                if hasattr(msg, "nack"):
+                    await msg.nack()
+                return
+
+            # Extract correlation_id from payload if available
+            payload_correlation_id = payload_dict.get("correlation_id")
+            if payload_correlation_id:
+                with contextlib.suppress(ValueError, AttributeError):
+                    msg_correlation_id = UUID(str(payload_correlation_id))
+
+            # Derive message category from dispatch_topic so EVENT topics
+            # produce EVENT envelopes (not hard-coded COMMAND).
+            topic_category = EnumMessageCategory.from_topic(dispatch_topic)
+            envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+                payload=payload_dict,
+                correlation_id=msg_correlation_id,
+                metadata=ModelEnvelopeMetadata(
+                    tags={
+                        "message_category": topic_category.value
+                        if topic_category
+                        else "command",
+                    },
+                ),
+            )
+
+            # Dispatch through the engine
+            result = await engine.dispatch(
+                topic=dispatch_topic,
+                envelope=envelope,
+            )
+
+            logger.debug(
+                "Dispatch result: status=%s, handler=%s, duration=%.2fms "
+                "(correlation_id=%s)",
+                result.status,
+                result.handler_id,
+                result.duration_ms,
+                msg_correlation_id,
+            )
+
+            # Gate ack/nack on dispatch status
+            if result.is_successful():
+                if hasattr(msg, "ack"):
+                    await msg.ack()
+            else:
+                logger.warning(
+                    "Dispatch failed (status=%s, error=%s), nacking message "
+                    "(correlation_id=%s)",
+                    result.status,
+                    result.error_message,
+                    msg_correlation_id,
+                )
+                if hasattr(msg, "nack"):
+                    await msg.nack()
+
+        except Exception:
+            logger.exception(
+                "Failed to dispatch message via engine (correlation_id=%s)",
+                msg_correlation_id,
+            )
+            if hasattr(msg, "nack"):
+                await msg.nack()
+
+    return _on_message
+
+
+__all__ = [
+    "DISPATCH_ALIAS_ARCHIVE_MEMORY",
+    "DISPATCH_ALIAS_EXPIRE_MEMORY",
+    "DISPATCH_ALIAS_INTENT_CLASSIFIED",
+    "DISPATCH_ALIAS_INTENT_QUERY_REQUESTED",
+    "DISPATCH_ALIAS_RUNTIME_TICK",
+    "create_dispatch_callback",
+    "create_intent_classified_dispatch_handler",
+    "create_intent_query_dispatch_handler",
+    "create_lifecycle_dispatch_handler",
+    "create_memory_dispatch_engine",
+]

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_tick.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_tick.py
@@ -350,7 +350,7 @@ class TestHandlerMemoryTickInitialization:
         handler = HandlerMemoryTick(container)
 
         assert handler.handler_id == "handler-memory-tick"
-        assert handler.category == EnumMessageCategory.EVENT
+        assert handler.category == EnumMessageCategory.COMMAND
         assert handler.message_types == {"ModelRuntimeTick"}
         assert handler.node_kind == EnumNodeKind.ORCHESTRATOR
 

--- a/tests/unit/runtime/test_contract_topics.py
+++ b/tests/unit/runtime/test_contract_topics.py
@@ -42,7 +42,7 @@ EXPECTED_MEMORY_RETRIEVAL_REQUESTED = (
 )
 
 # memory_lifecycle_orchestrator
-EXPECTED_RUNTIME_TICK = "onex.internal.runtime-tick.v1"
+EXPECTED_RUNTIME_TICK = "onex.cmd.omnimemory.runtime-tick.v1"
 EXPECTED_ARCHIVE_MEMORY = "onex.cmd.omnimemory.archive-memory.v1"
 EXPECTED_EXPIRE_MEMORY = "onex.cmd.omnimemory.expire-memory.v1"
 
@@ -97,6 +97,7 @@ EXPECTED_ALL_PUBLISH_TOPICS = {
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCollectSubscribeTopics:
     """Validate contract-driven subscribe topic collection."""
 
@@ -170,6 +171,7 @@ class TestCollectSubscribeTopics:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCollectPublishTopicsForDispatch:
     """Validate contract-driven publish topic collection for dispatch engine."""
 
@@ -245,6 +247,7 @@ class TestCollectPublishTopicsForDispatch:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCollectAllPublishTopics:
     """Validate full publish topic collection across all contracts."""
 
@@ -280,6 +283,7 @@ class TestCollectAllPublishTopics:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCanonicalTopicToDispatchAlias:
     """Validate canonical-to-dispatch topic conversion."""
 
@@ -304,7 +308,7 @@ class TestCanonicalTopicToDispatchAlias:
 
     def test_internal_topic_unchanged(self) -> None:
         """Internal topics without .cmd./.evt. pass through."""
-        topic = "onex.internal.runtime-tick.v1"
+        topic = "onex.internal.some-internal-event.v1"
         assert canonical_topic_to_dispatch_alias(topic) == topic
 
     @pytest.mark.parametrize(
@@ -327,6 +331,10 @@ class TestCanonicalTopicToDispatchAlias:
                 "onex.commands.omnimemory.expire-memory.v1",
             ),
             (
+                EXPECTED_RUNTIME_TICK,
+                "onex.commands.omnimemory.runtime-tick.v1",
+            ),
+            (
                 EXPECTED_INTENT_CLASSIFIED,
                 "onex.events.omniintelligence.intent-classified.v1",
             ),
@@ -346,6 +354,7 @@ class TestCanonicalTopicToDispatchAlias:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestDeriveDispatchKey:
     """Validate dispatch key derivation from package paths."""
 
@@ -386,6 +395,7 @@ class TestDeriveDispatchKey:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestNodePackageRegistry:
     """Validate that _OMNIMEMORY_EVENT_BUS_NODE_PACKAGES is complete."""
 
@@ -441,6 +451,7 @@ class TestNodePackageRegistry:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestNoHardcodedTopics:
     """Validate that hardcoded topic constants have been removed."""
 

--- a/tests/unit/runtime/test_dispatch_handlers.py
+++ b/tests/unit/runtime/test_dispatch_handlers.py
@@ -114,6 +114,7 @@ class _MockEventMessage:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestTopicAliases:
     """Verify topic alias constants are correctly formed."""
 
@@ -149,9 +150,9 @@ class TestTopicAliases:
         """Expire memory alias must contain .commands. segment."""
         assert ".commands." in DISPATCH_ALIAS_EXPIRE_MEMORY
 
-    def test_runtime_tick_alias_is_internal_namespace(self) -> None:
-        """Runtime tick alias must be in the internal namespace."""
-        assert "onex.internal." in DISPATCH_ALIAS_RUNTIME_TICK
+    def test_runtime_tick_alias_contains_commands_segment(self) -> None:
+        """Runtime tick alias must contain .commands. for from_topic() to work."""
+        assert ".commands." in DISPATCH_ALIAS_RUNTIME_TICK
 
 
 # =============================================================================
@@ -159,6 +160,7 @@ class TestTopicAliases:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCreateMemoryDispatchEngine:
     """Validate dispatch engine creation and configuration."""
 
@@ -219,6 +221,7 @@ class TestCreateMemoryDispatchEngine:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestIntentClassifiedDispatchHandler:
     """Validate the bridge handler for intent-classified events."""
 
@@ -336,6 +339,7 @@ class TestIntentClassifiedDispatchHandler:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestIntentQueryDispatchHandler:
     """Validate the bridge handler for intent-query-requested events."""
 
@@ -490,6 +494,7 @@ class TestIntentQueryDispatchHandler:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestLifecycleDispatchHandler:
     """Validate the fail-fast lifecycle dispatch handler."""
 
@@ -563,6 +568,7 @@ class TestLifecycleDispatchHandler:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCreateDispatchCallback:
     """Validate the event bus callback that bridges to the dispatch engine."""
 

--- a/tests/unit/runtime/test_dispatch_handlers.py
+++ b/tests/unit/runtime/test_dispatch_handlers.py
@@ -488,6 +488,51 @@ class TestIntentQueryDispatchHandler:
         with pytest.raises(ValueError, match="Failed to parse payload"):
             await handler(envelope, context)
 
+    @pytest.mark.asyncio
+    async def test_handler_awaits_async_publish_callback(
+        self,
+        sample_intent_query_payload: dict[str, object],
+        correlation_id: UUID,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Handler should await an async publish_callback without error."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        async_publish_callback = AsyncMock()
+        publish_topic = "dev.onex.evt.omnimemory.intent-query-response.v1"
+
+        handler = create_intent_query_dispatch_handler(
+            query_handler=mock_intent_query_handler,
+            publish_callback=async_publish_callback,
+            publish_topic=publish_topic,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=sample_intent_query_payload,
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "command"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        await handler(envelope, context)
+
+        async_publish_callback.assert_awaited_once()
+        call_args = async_publish_callback.call_args
+        assert call_args[0][0] == publish_topic
+        assert isinstance(call_args[0][1], dict)
+
 
 # =============================================================================
 # Tests: Lifecycle Dispatch Handler (fail-fast)
@@ -732,4 +777,31 @@ class TestCreateDispatchCallback:
         await callback(msg)
 
         assert msg._nacked, "Message should be nacked for unexpected value type"
+        assert not msg._acked
+
+    @pytest.mark.asyncio
+    async def test_callback_nacks_on_non_dict_json_payload(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should nack when JSON payload deserializes to a non-dict (e.g. array)."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        # JSON array is valid JSON but not a valid dispatch payload
+        msg = _MockEventMessage(
+            value=json.dumps([1, 2, 3]).encode("utf-8"),
+        )
+
+        await callback(msg)
+
+        assert msg._nacked, "Message should be nacked for non-dict JSON payload"
         assert not msg._acked

--- a/tests/unit/runtime/test_dispatch_handlers.py
+++ b/tests/unit/runtime/test_dispatch_handlers.py
@@ -1,0 +1,729 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for OmniMemory dispatch bridge handlers.
+
+Validates:
+    - Dispatch engine factory creates a frozen engine with correct routes/handlers
+    - Bridge handler for intent-classified events delegates to consumer
+    - Bridge handler for intent-query-requested events delegates to query handler
+    - Lifecycle handler raises RuntimeError (fail-fast, not wired)
+    - Event bus callback deserializes bytes, wraps in envelope, dispatches
+    - Event bus callback acks on success, nacks on failure
+    - Topic alias mapping is correct
+
+Related:
+    - OMN-2215: Phase 4 -- MessageDispatchEngine integration for omnimemory
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnimemory.runtime.dispatch_handlers import (
+    DISPATCH_ALIAS_ARCHIVE_MEMORY,
+    DISPATCH_ALIAS_EXPIRE_MEMORY,
+    DISPATCH_ALIAS_INTENT_CLASSIFIED,
+    DISPATCH_ALIAS_INTENT_QUERY_REQUESTED,
+    DISPATCH_ALIAS_RUNTIME_TICK,
+    create_dispatch_callback,
+    create_intent_classified_dispatch_handler,
+    create_intent_query_dispatch_handler,
+    create_lifecycle_dispatch_handler,
+    create_memory_dispatch_engine,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def correlation_id() -> UUID:
+    """Fixed correlation ID for deterministic tests."""
+    return UUID("12345678-1234-1234-1234-123456789abc")
+
+
+@pytest.fixture
+def mock_intent_consumer() -> MagicMock:
+    """Mock ProtocolIntentEventConsumer for dispatch handler tests."""
+    consumer = MagicMock()
+    consumer._handle_message = AsyncMock(return_value=None)
+    return consumer
+
+
+@pytest.fixture
+def mock_intent_query_handler() -> MagicMock:
+    """Mock ProtocolIntentQueryHandler for dispatch handler tests."""
+    handler = MagicMock()
+    mock_response = MagicMock()
+    mock_response.model_dump = MagicMock(return_value={"status": "success"})
+    handler.execute = AsyncMock(return_value=mock_response)
+    return handler
+
+
+@pytest.fixture
+def sample_intent_classified_payload() -> dict[str, object]:
+    """Sample intent-classified event payload."""
+    return {
+        "correlation_id": "12345678-1234-1234-1234-123456789abc",
+        "session_id": "test-session-001",
+        "intent_category": "debugging",
+        "confidence": 0.92,
+        "keywords": ["error", "traceback"],
+        "secondary_intents": [],
+        "timestamp_utc": "2025-01-15T10:30:00Z",
+    }
+
+
+@pytest.fixture
+def sample_intent_query_payload() -> dict[str, object]:
+    """Sample intent-query-requested event payload."""
+    return {
+        "query_id": "00000000-0000-0000-0000-000000000001",
+        "query_type": "distribution",
+        "correlation_id": "12345678-1234-1234-1234-123456789abc",
+    }
+
+
+@dataclass
+class _MockEventMessage:
+    """Mock event bus message implementing ProtocolEventMessage interface."""
+
+    topic: str = "onex.evt.omniintelligence.intent-classified.v1"
+    key: bytes | None = None
+    value: bytes = b"{}"
+    headers: dict[str, str] = field(default_factory=dict)
+
+    _acked: bool = False
+    _nacked: bool = False
+
+    async def ack(self) -> None:
+        self._acked = True
+
+    async def nack(self) -> None:
+        self._nacked = True
+
+
+# =============================================================================
+# Tests: Topic Alias Constants
+# =============================================================================
+
+
+class TestTopicAliases:
+    """Verify topic alias constants are correctly formed."""
+
+    def test_intent_classified_alias_contains_events_segment(self) -> None:
+        """Dispatch alias must contain .events. for from_topic() to work."""
+        assert ".events." in DISPATCH_ALIAS_INTENT_CLASSIFIED
+
+    def test_intent_classified_alias_references_omniintelligence(self) -> None:
+        """Intent classified alias must reference omniintelligence (source)."""
+        assert "omniintelligence" in DISPATCH_ALIAS_INTENT_CLASSIFIED
+
+    def test_intent_classified_alias_preserves_event_name(self) -> None:
+        """Alias must preserve the intent-classified event name."""
+        assert "intent-classified" in DISPATCH_ALIAS_INTENT_CLASSIFIED
+
+    def test_intent_query_alias_contains_commands_segment(self) -> None:
+        """Dispatch alias must contain .commands. for from_topic() to work."""
+        assert ".commands." in DISPATCH_ALIAS_INTENT_QUERY_REQUESTED
+
+    def test_intent_query_alias_references_omnimemory(self) -> None:
+        """Intent query alias must reference omnimemory domain."""
+        assert "omnimemory" in DISPATCH_ALIAS_INTENT_QUERY_REQUESTED
+
+    def test_intent_query_alias_preserves_event_name(self) -> None:
+        """Alias must preserve the intent-query-requested name."""
+        assert "intent-query-requested" in DISPATCH_ALIAS_INTENT_QUERY_REQUESTED
+
+    def test_archive_memory_alias_contains_commands_segment(self) -> None:
+        """Archive memory alias must contain .commands. segment."""
+        assert ".commands." in DISPATCH_ALIAS_ARCHIVE_MEMORY
+
+    def test_expire_memory_alias_contains_commands_segment(self) -> None:
+        """Expire memory alias must contain .commands. segment."""
+        assert ".commands." in DISPATCH_ALIAS_EXPIRE_MEMORY
+
+    def test_runtime_tick_alias_is_internal_namespace(self) -> None:
+        """Runtime tick alias must be in the internal namespace."""
+        assert "onex.internal." in DISPATCH_ALIAS_RUNTIME_TICK
+
+
+# =============================================================================
+# Tests: Dispatch Engine Factory
+# =============================================================================
+
+
+class TestCreateMemoryDispatchEngine:
+    """Validate dispatch engine creation and configuration."""
+
+    def test_engine_is_frozen(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Engine must be frozen after factory call."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+        assert engine.is_frozen
+
+    def test_engine_has_three_handlers(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """All 3 memory domain handlers must be registered."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+        assert engine.handler_count == 3
+
+    def test_engine_has_five_routes(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """All 5 memory domain routes must be registered."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+        assert engine.route_count == 5
+
+    def test_engine_accepts_publish_topics(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Engine factory should accept publish_topics without error."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+            publish_topics={
+                "intent_query": "dev.onex.evt.omnimemory.intent-query-response.v1",
+            },
+        )
+        assert engine.is_frozen
+
+
+# =============================================================================
+# Tests: Intent Classified Bridge Handler
+# =============================================================================
+
+
+class TestIntentClassifiedDispatchHandler:
+    """Validate the bridge handler for intent-classified events."""
+
+    @pytest.mark.asyncio
+    async def test_handler_delegates_to_consumer(
+        self,
+        sample_intent_classified_payload: dict[str, object],
+        correlation_id: UUID,
+        mock_intent_consumer: MagicMock,
+    ) -> None:
+        """Handler should delegate dict payload to consumer._handle_message()."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        handler = create_intent_classified_dispatch_handler(
+            consumer=mock_intent_consumer,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=sample_intent_classified_payload,
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "event"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        result = await handler(envelope, context)
+        assert isinstance(result, str)
+        mock_intent_consumer._handle_message.assert_called_once_with(
+            sample_intent_classified_payload, retry_count=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_raises_for_non_dict_payload(
+        self,
+        correlation_id: UUID,
+        mock_intent_consumer: MagicMock,
+    ) -> None:
+        """Handler should raise ValueError for non-dict payloads."""
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        handler = create_intent_classified_dispatch_handler(
+            consumer=mock_intent_consumer,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload="not a dict payload",
+            correlation_id=correlation_id,
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(ValueError, match="Unexpected payload type"):
+            await handler(envelope, context)
+
+    @pytest.mark.asyncio
+    async def test_handler_propagates_consumer_exception(
+        self,
+        sample_intent_classified_payload: dict[str, object],
+        correlation_id: UUID,
+        mock_intent_consumer: MagicMock,
+    ) -> None:
+        """Handler should propagate exceptions from consumer._handle_message()."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        mock_intent_consumer._handle_message = AsyncMock(
+            side_effect=RuntimeError("Storage failure")
+        )
+
+        handler = create_intent_classified_dispatch_handler(
+            consumer=mock_intent_consumer,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=sample_intent_classified_payload,
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "event"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(RuntimeError, match="Storage failure"):
+            await handler(envelope, context)
+
+
+# =============================================================================
+# Tests: Intent Query Bridge Handler
+# =============================================================================
+
+
+class TestIntentQueryDispatchHandler:
+    """Validate the bridge handler for intent-query-requested events."""
+
+    @pytest.mark.asyncio
+    async def test_handler_delegates_to_query_handler(
+        self,
+        sample_intent_query_payload: dict[str, object],
+        correlation_id: UUID,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Handler should parse payload and delegate to query_handler.execute()."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        handler = create_intent_query_dispatch_handler(
+            query_handler=mock_intent_query_handler,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=sample_intent_query_payload,
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "command"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        result = await handler(envelope, context)
+        assert isinstance(result, str)
+        mock_intent_query_handler.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handler_raises_for_non_dict_payload(
+        self,
+        correlation_id: UUID,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Handler should raise ValueError for non-dict payloads."""
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        handler = create_intent_query_dispatch_handler(
+            query_handler=mock_intent_query_handler,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=42,
+            correlation_id=correlation_id,
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(ValueError, match="Unexpected payload type"):
+            await handler(envelope, context)
+
+    @pytest.mark.asyncio
+    async def test_handler_publishes_response_when_configured(
+        self,
+        sample_intent_query_payload: dict[str, object],
+        correlation_id: UUID,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Handler should publish response when callback and topic are configured."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        publish_callback = MagicMock()
+        publish_topic = "dev.onex.evt.omnimemory.intent-query-response.v1"
+
+        handler = create_intent_query_dispatch_handler(
+            query_handler=mock_intent_query_handler,
+            publish_callback=publish_callback,
+            publish_topic=publish_topic,
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=sample_intent_query_payload,
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "command"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        await handler(envelope, context)
+        publish_callback.assert_called_once()
+        call_args = publish_callback.call_args
+        assert call_args[0][0] == publish_topic
+
+    @pytest.mark.asyncio
+    async def test_handler_raises_for_invalid_query_payload(
+        self,
+        correlation_id: UUID,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Handler should raise ValueError for dict payloads that fail validation."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.effect.model_effect_context import ModelEffectContext
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+
+        handler = create_intent_query_dispatch_handler(
+            query_handler=mock_intent_query_handler,
+            correlation_id=correlation_id,
+        )
+
+        # Missing required fields
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload={"invalid_field": "value"},
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "command"},
+            ),
+        )
+        context = ModelEffectContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(ValueError, match="Failed to parse payload"):
+            await handler(envelope, context)
+
+
+# =============================================================================
+# Tests: Lifecycle Dispatch Handler (fail-fast)
+# =============================================================================
+
+
+class TestLifecycleDispatchHandler:
+    """Validate the fail-fast lifecycle dispatch handler."""
+
+    @pytest.mark.asyncio
+    async def test_handler_raises_runtime_error(
+        self,
+        correlation_id: UUID,
+    ) -> None:
+        """Lifecycle handler must raise RuntimeError (not silently drop)."""
+        from omnibase_core.models.core.model_envelope_metadata import (
+            ModelEnvelopeMetadata,
+        )
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+        from omnibase_core.models.orchestrator.model_orchestrator_context import (
+            ModelOrchestratorContext,
+        )
+
+        handler = create_lifecycle_dispatch_handler(
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload={"tick_type": "scheduled"},
+            correlation_id=correlation_id,
+            metadata=ModelEnvelopeMetadata(
+                tags={"message_category": "command"},
+            ),
+        )
+        context = ModelOrchestratorContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(RuntimeError, match="Lifecycle dispatch handler not wired"):
+            await handler(envelope, context)
+
+    @pytest.mark.asyncio
+    async def test_handler_includes_correlation_id_in_error(
+        self,
+        correlation_id: UUID,
+    ) -> None:
+        """RuntimeError message must include correlation_id for debugging."""
+        from omnibase_core.models.events.model_event_envelope import (
+            ModelEventEnvelope,
+        )
+        from omnibase_core.models.orchestrator.model_orchestrator_context import (
+            ModelOrchestratorContext,
+        )
+
+        handler = create_lifecycle_dispatch_handler(
+            correlation_id=correlation_id,
+        )
+
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload={"action": "archive"},
+            correlation_id=correlation_id,
+        )
+        context = ModelOrchestratorContext(
+            correlation_id=correlation_id,
+            envelope_id=uuid4(),
+        )
+
+        with pytest.raises(RuntimeError, match=str(correlation_id)):
+            await handler(envelope, context)
+
+
+# =============================================================================
+# Tests: Event Bus Dispatch Callback
+# =============================================================================
+
+
+class TestCreateDispatchCallback:
+    """Validate the event bus callback that bridges to the dispatch engine."""
+
+    @pytest.mark.asyncio
+    async def test_callback_dispatches_json_message_and_acks(
+        self,
+        sample_intent_classified_payload: dict[str, object],
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should deserialize bytes, dispatch, and ack on success."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        msg = _MockEventMessage(
+            value=json.dumps(sample_intent_classified_payload).encode("utf-8"),
+        )
+
+        await callback(msg)
+
+        assert msg._acked, "Message should be acked after successful dispatch"
+        assert not msg._nacked
+
+    @pytest.mark.asyncio
+    async def test_callback_nacks_on_invalid_json(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should nack the message if JSON parsing fails."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        msg = _MockEventMessage(
+            value=b"not valid json {{{",
+        )
+
+        await callback(msg)
+
+        assert msg._nacked, "Message should be nacked on parse failure"
+        assert not msg._acked
+
+    @pytest.mark.asyncio
+    async def test_callback_handles_dict_message(
+        self,
+        sample_intent_classified_payload: dict[str, object],
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should handle plain dict messages (inmemory event bus)."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        metrics_before = engine.get_structured_metrics()
+
+        # InMemoryEventBus may pass dicts directly
+        await callback(sample_intent_classified_payload)
+
+        metrics_after = engine.get_structured_metrics()
+        assert metrics_after.total_dispatches == metrics_before.total_dispatches + 1
+
+    @pytest.mark.asyncio
+    async def test_callback_extracts_correlation_id_from_payload(
+        self,
+        sample_intent_classified_payload: dict[str, object],
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should extract correlation_id from payload if present."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        msg = _MockEventMessage(
+            value=json.dumps(sample_intent_classified_payload).encode("utf-8"),
+        )
+
+        await callback(msg)
+        assert msg._acked
+
+    @pytest.mark.asyncio
+    async def test_callback_nacks_on_dispatch_failure(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should nack when dispatch result indicates failure."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        # Use a topic with no matching route to trigger dispatch failure
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic="onex.commands.nonexistent.topic.v1",
+        )
+
+        msg = _MockEventMessage(
+            value=json.dumps(
+                {
+                    "query_type": "distribution",
+                    "query_id": "test-query",
+                }
+            ).encode("utf-8"),
+        )
+
+        await callback(msg)
+
+        assert msg._nacked, "Message should be nacked on dispatch failure"
+        assert not msg._acked
+
+    @pytest.mark.asyncio
+    async def test_callback_nacks_on_unexpected_value_type(
+        self,
+        mock_intent_consumer: MagicMock,
+        mock_intent_query_handler: MagicMock,
+    ) -> None:
+        """Callback should nack when message value is an unexpected type."""
+        engine = create_memory_dispatch_engine(
+            intent_consumer=mock_intent_consumer,
+            intent_query_handler=mock_intent_query_handler,
+        )
+
+        callback = create_dispatch_callback(
+            engine=engine,
+            dispatch_topic=DISPATCH_ALIAS_INTENT_CLASSIFIED,
+        )
+
+        # Message with integer value (unexpected)
+        msg = _MockEventMessage()
+        msg.value = 12345  # type: ignore[assignment]
+
+        await callback(msg)
+
+        assert msg._nacked, "Message should be nacked for unexpected value type"
+        assert not msg._acked


### PR DESCRIPTION
## Summary

Routes all incoming Kafka events through `MessageDispatchEngine`, replacing manual routing patterns. Mirrors omniintelligence's `runtime/dispatch_handlers.py` (PRs #80-82, #86).

### Changes

- **Created** `src/omnimemory/runtime/dispatch_handlers.py` — 5 dispatch aliases, 3 bridge handler factories, engine factory, callback factory
- **Updated** `src/omnimemory/runtime/__init__.py` — exposed dispatch handler exports
- **Created** `tests/unit/runtime/test_dispatch_handlers.py` — 28 unit tests across 6 test classes

### Architecture

Registers 3 handlers covering 5 routes in a frozen `MessageDispatchEngine`:
1. **intent-classified handler** (EVENT, EFFECT) — delegates to `ProtocolIntentEventConsumer`
2. **intent-query handler** (COMMAND, EFFECT) — delegates to `ProtocolIntentQueryHandler` with optional publish
3. **lifecycle handler** (COMMAND, ORCHESTRATOR) — fail-fast `RuntimeError` stub for runtime-tick, archive-memory, expire-memory (prevents silent data loss until wired)

### Ack/Nack Gating

Dispatch callback acks on success, nacks on failure — no silent drops.

### Closes

OMN-2215

## Test Plan

- [x] 28 new dispatch handler tests passing
- [x] 268 total unit tests passing
- [x] mypy --strict clean on all changed files
- [x] All 19 pre-commit hooks passing
- [x] Local review passed (0 blocking issues, iteration 1/3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dispatch handlers surface: factories to build per-plugin dispatch engines and handlers for intent-classified, intent-query, and lifecycle messages; public dispatch aliases exposed.
  * Runtime-tick topic now uses the command namespace for consistent command routing.

* **Refactor**
  * HandlerMemoryTick category changed to command semantics.

* **Tests**
  * Added comprehensive unit tests covering dispatch engine creation, handler delegation, routing, publish paths, and ack/nack behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->