### PR TITLE
feat(ci): Add Kafka import lint guard for ARCH-002 enforcement (OMN-1750)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
   # onex-validation | validate-secrets                  | python scripts/validation/validate_secrets.py src/
   # onex-validation | validate-naming-conventions       | python scripts/validation/validate_naming.py src/
   # onex-validation | validate-http-imports             | python scripts/validation/validate_http_imports.py src/
+  # onex-validation | validate-kafka-imports            | python scripts/validation/validate_kafka_imports.py src/
   #
   # IMPORTANT: When modifying any CI step, update the corresponding hook in .pre-commit-config.yaml
   #
@@ -280,6 +281,11 @@ jobs:
       - name: Validate HTTP import boundary
         run: poetry run python scripts/validation/validate_http_imports.py src/
 
+      # SYNC: Pre-commit hook 'validate-kafka-imports' at pre-commit stage
+      # Enforces ARCH-002 - runtime owns all Kafka plumbing, nodes use EventBus SPI
+      - name: Validate Kafka import boundary (ARCH-002)
+        run: poetry run python scripts/validation/validate_kafka_imports.py src/
+
       - name: ONEX validation summary
         if: always()
         run: |
@@ -293,6 +299,7 @@ jobs:
           echo "- Secret detection" >> $GITHUB_STEP_SUMMARY
           echo "- Naming conventions" >> $GITHUB_STEP_SUMMARY
           echo "- HTTP import boundary enforcement" >> $GITHUB_STEP_SUMMARY
+          echo "- Kafka import boundary enforcement (ARCH-002)" >> $GITHUB_STEP_SUMMARY
 
   # Phase 1 - Architecture Handshake Verification
   check-handshake:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -279,6 +279,9 @@ repos:
         args: ['src/']
         language: python
         pass_filenames: false
+        # NOTE: This filter is coupled to ENFORCED_PATHS in the script
+        # (scripts/validation/validate_kafka_imports.py). If ENFORCED_PATHS
+        # changes, update this pattern to match so the hook triggers correctly.
         files: ^src/omnimemory/nodes/.*\.py$
         exclude: ^tests/.*\.py$
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@
 # validate-secrets                  | onex-validation          | python scripts/validation/validate_secrets.py src/
 # validate-naming-conventions       | onex-validation          | python scripts/validation/validate_naming.py src/
 # validate-http-imports             | onex-validation          | python scripts/validation/validate_http_imports.py src/
+# validate-kafka-imports            | onex-validation          | python scripts/validation/validate_kafka_imports.py src/
 # validate-model-locations          | onex-validation          | python scripts/validation/validate_model_locations.py src/
 #
 # IMPORTANT: When modifying any hook, update the corresponding CI job in .github/workflows/test.yml
@@ -266,6 +267,19 @@ repos:
         language: python
         pass_filenames: false
         files: ^src/.*\.py$
+        exclude: ^tests/.*\.py$
+        stages: [pre-commit]
+
+      # Kafka Import Boundary Enforcement (ARCH-002)
+      # Ensures direct Kafka consumer imports do not appear in nodes/
+      # Nodes must use the EventBus SPI from the runtime layer
+      - id: validate-kafka-imports
+        name: ONEX Kafka Import Boundary Enforcement (ARCH-002)
+        entry: python scripts/validation/validate_kafka_imports.py
+        args: ['src/']
+        language: python
+        pass_filenames: false
+        files: ^src/omnimemory/nodes/.*\.py$
         exclude: ^tests/.*\.py$
         stages: [pre-commit]
 

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""ONEX Kafka Import Boundary Enforcement (ARCH-002).
+
+Ensures that direct Kafka consumer imports (AIOKafkaConsumer, KafkaConsumer,
+aiokafka, kafka-python) do not appear in src/omnimemory/nodes/. This enforces
+ARCH-002: "Runtime owns all Kafka plumbing".
+
+Nodes must consume events through the abstract EventBus SPI provided by the
+runtime layer, never by instantiating Kafka consumers directly.
+
+Exemption Annotation:
+    If a file legitimately needs a direct Kafka import in nodes/ (rare),
+    add a comment with the explicit exemption annotation on the SAME LINE
+    as the import:
+
+        from aiokafka import AIOKafkaConsumer  # omnimemory-kafka-exempt: <reason>
+
+    This annotation is intentionally specific to prevent accidental matches.
+
+Usage:
+    python scripts/validation/validate_kafka_imports.py src/omnimemory/nodes/
+    python scripts/validation/validate_kafka_imports.py src/
+
+Added for OMN-1750: CI Kafka import lint guard (ARCH-002 enforcement)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# Configure logging - default to WARNING so scripts are quiet unless debugging
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+
+class Violation(NamedTuple):
+    """A validation violation."""
+
+    file: str
+    line: int
+    message: str
+
+
+# Kafka consumer import patterns to detect
+KAFKA_IMPORT_PATTERNS = [
+    (
+        # from aiokafka import AIOKafkaConsumer (or any other import)
+        re.compile(r"^from\s+aiokafka\b"),
+        "Direct 'from aiokafka' import found - use EventBus SPI instead (ARCH-002)",
+    ),
+    (
+        # import aiokafka
+        re.compile(r"^import\s+aiokafka\b"),
+        "Direct 'import aiokafka' found - use EventBus SPI instead (ARCH-002)",
+    ),
+    (
+        # from kafka import KafkaConsumer (or any other import)
+        re.compile(r"^from\s+kafka\b"),
+        "Direct 'from kafka' import found - use EventBus SPI instead (ARCH-002)",
+    ),
+    (
+        # import kafka
+        re.compile(r"^import\s+kafka\b"),
+        "Direct 'import kafka' found - use EventBus SPI instead (ARCH-002)",
+    ),
+    (
+        # from confluent_kafka import Consumer (or any other import)
+        re.compile(r"^from\s+confluent_kafka\b"),
+        "Direct 'from confluent_kafka' import found - use EventBus SPI instead (ARCH-002)",
+    ),
+    (
+        # import confluent_kafka
+        re.compile(r"^import\s+confluent_kafka\b"),
+        "Direct 'import confluent_kafka' found - use EventBus SPI instead (ARCH-002)",
+    ),
+]
+
+# Only scan nodes/ directory - ARCH-002 applies to node code specifically
+# The runtime layer (which IS allowed to use Kafka directly) lives elsewhere.
+ENFORCED_PATHS = [
+    "nodes/",
+]
+
+# Skip patterns (lines that should be ignored)
+SKIP_PATTERNS = [
+    # TYPE_CHECKING blocks are fine (type hints only, not runtime)
+    re.compile(r"if\s+TYPE_CHECKING"),
+    # Explicit Kafka boundary exemption annotation
+    # Format: # omnimemory-kafka-exempt: <reason>
+    re.compile(r"#\s*omnimemory-kafka-exempt:", re.IGNORECASE),
+]
+
+
+def is_in_enforced_path(filepath: Path) -> bool:
+    """Check if the file path is within an enforced directory for Kafka lint."""
+    filepath_posix = filepath.as_posix()
+    for enforced in ENFORCED_PATHS:
+        if f"/{enforced}" in filepath_posix or filepath_posix.startswith(enforced):
+            return True
+    return False
+
+
+def validate_file(filepath: Path) -> list[Violation]:
+    """Validate a single Python file for Kafka import violations."""
+    # Only enforce in nodes/ directory
+    if not is_in_enforced_path(filepath):
+        return []
+
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except PermissionError:
+        logging.warning("Permission denied reading file: %s", filepath)
+        return []
+    except FileNotFoundError:
+        logging.warning("File not found (possibly deleted during scan): %s", filepath)
+        return []
+    except OSError as e:
+        logging.warning("OS error reading file %s: %s", filepath, e)
+        return []
+    except UnicodeDecodeError as e:
+        logging.warning("Unicode decode error in file %s: %s", filepath, e)
+        return []
+
+    violations: list[Violation] = []
+    in_type_checking_block = False
+    indent_level = 0
+
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+
+        # Track TYPE_CHECKING blocks (imports there are fine)
+        if "if TYPE_CHECKING" in line:
+            in_type_checking_block = True
+            indent_level = len(line) - len(line.lstrip())
+            continue
+
+        # Exit TYPE_CHECKING block when indentation decreases
+        if in_type_checking_block and stripped and not stripped.startswith("#"):
+            current_indent = len(line) - len(line.lstrip())
+            if current_indent <= indent_level:
+                in_type_checking_block = False
+
+        # Skip if in TYPE_CHECKING block
+        if in_type_checking_block:
+            continue
+
+        # Skip if line matches skip patterns
+        if any(skip.search(line) for skip in SKIP_PATTERNS):
+            continue
+
+        # Check for Kafka import patterns
+        for pattern, message in KAFKA_IMPORT_PATTERNS:
+            if pattern.search(stripped):
+                violations.append(
+                    Violation(
+                        str(filepath),
+                        line_num,
+                        f"{message}. "
+                        f"Nodes must use the EventBus SPI from the runtime layer.",
+                    )
+                )
+                break  # Only one violation per line
+
+    return violations
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enforce ARCH-002 Kafka import boundary - detect direct Kafka "
+            "consumer imports in nodes/"
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["src/"],
+        help="Files or directories to check",
+    )
+    args = parser.parse_args()
+
+    files_to_check: list[Path] = []
+
+    for path_str in args.paths:
+        path = Path(path_str)
+        if path.is_file() and path.suffix == ".py":
+            files_to_check.append(path)
+        elif path.is_dir():
+            files_to_check.extend(path.rglob("*.py"))
+        else:
+            logging.warning("Skipping invalid path: %s", path)
+
+    all_violations: list[Violation] = []
+    for filepath in files_to_check:
+        violations = validate_file(filepath)
+        all_violations.extend(violations)
+
+    if all_violations:
+        print(f"Found {len(all_violations)} Kafka import boundary violation(s):")
+        print()
+        for v in all_violations:
+            print(f"  {v.file}:{v.line}:")
+            print(f"    {v.message}")
+            print()
+        print("ARCH-002: Runtime owns all Kafka plumbing.")
+        print("Nodes must use the EventBus SPI (event_bus.subscribe/publish)")
+        print("instead of importing Kafka clients directly.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -195,6 +195,9 @@ def main() -> int:
         else:
             logging.warning("Skipping invalid path: %s", path)
 
+    # Sort for deterministic output across runs
+    files_to_check = sorted(set(files_to_check))
+
     all_violations: list[Violation] = []
     for filepath in files_to_check:
         violations = validate_file(filepath)

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -140,7 +140,13 @@ def validate_file(filepath: Path) -> list[Violation]:
             indent_level = len(line) - len(line.lstrip())
             continue
 
-        # Exit TYPE_CHECKING block when indentation decreases
+        # Exit TYPE_CHECKING block when indentation decreases.
+        # Known limitation: this heuristic does not handle `else:` or `elif`
+        # clauses at the same indent level following the TYPE_CHECKING block
+        # (e.g., `if TYPE_CHECKING: ... else: ...`). Those would be incorrectly
+        # treated as exiting the block. This is acceptable for the current use
+        # case, which only involves simple module-level TYPE_CHECKING guards
+        # with no else/elif branches.
         if in_type_checking_block and stripped and not stripped.startswith("#"):
             current_indent = len(line) - len(line.lstrip())
             if current_indent <= indent_level:

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -45,7 +45,12 @@ class Violation(NamedTuple):
     message: str
 
 
-# Kafka consumer import patterns to detect
+# Kafka consumer import patterns to detect.
+# Each regex uses \b (word boundary) after the package name to prevent false
+# positives on prefixed names like `kafka_utils` or `aiokafka_wrapper` (where
+# `_` is a word character so \b does NOT match), while still catching dotted
+# submodule imports like `kafka.errors` (where `.` is NOT a word character so
+# \b DOES match).
 KAFKA_IMPORT_PATTERNS = [
     (
         # from aiokafka import AIOKafkaConsumer (or any other import)
@@ -225,6 +230,10 @@ def main() -> int:
         print("instead of importing Kafka clients directly.")
         return 1
 
+    print(
+        f"No Kafka import violations found. "
+        f"Checked {len(files_to_check)} file(s)."
+    )
     return 0
 
 

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -140,13 +140,15 @@ def validate_file(filepath: Path) -> list[Violation]:
             indent_level = len(line) - len(line.lstrip())
             continue
 
-        # Exit TYPE_CHECKING block when indentation decreases.
-        # Known limitation: this heuristic does not handle `else:` or `elif`
-        # clauses at the same indent level following the TYPE_CHECKING block
-        # (e.g., `if TYPE_CHECKING: ... else: ...`). Those would be incorrectly
-        # treated as exiting the block. This is acceptable for the current use
-        # case, which only involves simple module-level TYPE_CHECKING guards
-        # with no else/elif branches.
+        # Exit TYPE_CHECKING block when indentation returns to the same level.
+        # This correctly handles the common `if TYPE_CHECKING: ... else: ...`
+        # pattern: the `else:` branch contains runtime imports that SHOULD be
+        # checked, so exiting the TYPE_CHECKING block here is the right
+        # behavior. The only theoretical limitation is a contrived `else:`
+        # branch that itself contains only type-checking-time imports, but
+        # that pattern does not occur in practice and would be a code smell
+        # regardless. This trade-off keeps the heuristic simple and correct
+        # for all real-world usage.
         if in_type_checking_block and stripped and not stripped.startswith("#"):
             current_indent = len(line) - len(line.lstrip())
             if current_indent <= indent_level:

--- a/scripts/validation/validate_kafka_imports.py
+++ b/scripts/validation/validate_kafka_imports.py
@@ -79,16 +79,18 @@ KAFKA_IMPORT_PATTERNS = [
     ),
 ]
 
-# Only scan nodes/ directory - ARCH-002 applies to node code specifically
+# Only scan omnimemory/nodes/ directory - ARCH-002 applies to node code specifically.
 # The runtime layer (which IS allowed to use Kafka directly) lives elsewhere.
+# Using the fully-qualified path avoids false positives on other packages' nodes/.
 ENFORCED_PATHS = [
-    "nodes/",
+    "omnimemory/nodes/",
 ]
+
+# Pattern to detect TYPE_CHECKING guard blocks (both bare and qualified forms)
+TYPE_CHECKING_GUARD = re.compile(r"^\s*(?:if|elif)\s+(?:typing\.)?TYPE_CHECKING\b")
 
 # Skip patterns (lines that should be ignored)
 SKIP_PATTERNS = [
-    # TYPE_CHECKING blocks are fine (type hints only, not runtime)
-    re.compile(r"if\s+TYPE_CHECKING"),
     # Explicit Kafka boundary exemption annotation
     # Format: # omnimemory-kafka-exempt: <reason>
     re.compile(r"#\s*omnimemory-kafka-exempt:", re.IGNORECASE),
@@ -133,7 +135,7 @@ def validate_file(filepath: Path) -> list[Violation]:
         stripped = line.strip()
 
         # Track TYPE_CHECKING blocks (imports there are fine)
-        if "if TYPE_CHECKING" in line:
+        if TYPE_CHECKING_GUARD.search(line):
             in_type_checking_block = True
             indent_level = len(line) - len(line.lstrip())
             continue

--- a/tests/unit/test_validate_kafka_imports.py
+++ b/tests/unit/test_validate_kafka_imports.py
@@ -119,6 +119,61 @@ class TestNoKafkaImports:
 
 
 @pytest.mark.unit
+class TestAllKafkaLibraryPatterns:
+    """All six Kafka import patterns must produce violations, not just aiokafka."""
+
+    @pytest.mark.parametrize(
+        ("source", "expected_fragment"),
+        [
+            pytest.param(
+                "import aiokafka\n",
+                "aiokafka",
+                id="import-aiokafka",
+            ),
+            pytest.param(
+                "from confluent_kafka import Consumer\n",
+                "confluent_kafka",
+                id="from-confluent_kafka",
+            ),
+            pytest.param(
+                "from kafka.errors import KafkaError\n",
+                "kafka",
+                id="from-kafka-submodule",
+            ),
+        ],
+    )
+    def test_library_pattern_produces_violation(
+        self,
+        tmp_path: Path,
+        source: str,
+        expected_fragment: str,
+    ) -> None:
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert len(violations) == 1
+        assert expected_fragment in violations[0].message
+        assert violations[0].line == 1
+
+
+@pytest.mark.unit
+class TestOutsideEnforcedPath:
+    """Files outside ``omnimemory/nodes/`` must be ignored regardless of content."""
+
+    def test_kafka_import_outside_nodes_is_ignored(self, tmp_path: Path) -> None:
+        utils_dir = tmp_path / "omnimemory" / "utils"
+        utils_dir.mkdir(parents=True, exist_ok=True)
+        target = utils_dir / "kafka_helper.py"
+        target.write_text(
+            "from aiokafka import AIOKafkaConsumer\n",
+            encoding="utf-8",
+        )
+        violations = validate_file(target)
+
+        assert violations == []
+
+
+@pytest.mark.unit
 class TestElseBlockAfterTypeChecking:
     """Kafka imports in an ``else:`` block after ``if TYPE_CHECKING:`` are
     runtime imports and must produce a violation."""

--- a/tests/unit/test_validate_kafka_imports.py
+++ b/tests/unit/test_validate_kafka_imports.py
@@ -37,7 +37,9 @@ _spec.loader.exec_module(_module)
 validate_file = _module.validate_file
 
 
-def _write_node_file(tmp_path: Path, content: str) -> Path:
+def _write_node_file(
+    tmp_path: Path, content: str, filename: str = "example_node.py"
+) -> Path:
     """Write content into a file under a fake ``omnimemory/nodes/`` tree.
 
     ``validate_file`` only checks files whose path contains
@@ -48,7 +50,7 @@ def _write_node_file(tmp_path: Path, content: str) -> Path:
     """
     node_dir = tmp_path / "omnimemory" / "nodes"
     node_dir.mkdir(parents=True, exist_ok=True)
-    target = node_dir / "example_node.py"
+    target = node_dir / filename
     target.write_text(content, encoding="utf-8")
     return target
 
@@ -139,6 +141,16 @@ class TestAllKafkaLibraryPatterns:
                 "from kafka.errors import KafkaError\n",
                 "kafka",
                 id="from-kafka-submodule",
+            ),
+            pytest.param(
+                "import kafka\n",
+                "kafka",
+                id="import-kafka",
+            ),
+            pytest.param(
+                "import confluent_kafka\n",
+                "confluent_kafka",
+                id="import-confluent_kafka",
             ),
         ],
     )

--- a/tests/unit/test_validate_kafka_imports.py
+++ b/tests/unit/test_validate_kafka_imports.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for the Kafka import lint guard (ARCH-002 enforcement).
+
+Tests validate that ``validate_file`` from
+``scripts/validation/validate_kafka_imports.py`` correctly detects direct
+Kafka imports inside the enforced ``omnimemory/nodes/`` directory, respects
+``TYPE_CHECKING`` guards, honours the ``omnimemory-kafka-exempt`` annotation,
+and ignores files with no Kafka imports.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import ``validate_file`` from the validation script.
+# ``scripts/`` is not a Python package, so we load the module by file path.
+# ---------------------------------------------------------------------------
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "validation"
+    / "validate_kafka_imports.py"
+)
+_spec = importlib.util.spec_from_file_location("validate_kafka_imports", _SCRIPT_PATH)
+assert _spec is not None
+assert _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _module
+_spec.loader.exec_module(_module)
+
+validate_file = _module.validate_file
+
+
+def _write_node_file(tmp_path: Path, content: str) -> Path:
+    """Write content into a file under a fake ``omnimemory/nodes/`` tree.
+
+    ``validate_file`` only checks files whose path contains
+    ``omnimemory/nodes/``, so the helper creates that directory structure
+    inside ``tmp_path``.
+
+    Returns the path to the created ``.py`` file.
+    """
+    node_dir = tmp_path / "omnimemory" / "nodes"
+    node_dir.mkdir(parents=True, exist_ok=True)
+    target = node_dir / "example_node.py"
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+@pytest.mark.unit
+class TestDirectKafkaImportViolation:
+    """A bare ``from aiokafka import ...`` must produce a violation."""
+
+    def test_from_aiokafka_import(self, tmp_path: Path) -> None:
+        source = "from aiokafka import AIOKafkaConsumer\n"
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert len(violations) == 1
+        assert "aiokafka" in violations[0].message
+        assert violations[0].line == 1
+
+
+@pytest.mark.unit
+class TestTypeCheckingGuardAllowed:
+    """Kafka imports inside ``if TYPE_CHECKING:`` must not produce violations."""
+
+    def test_import_inside_type_checking_block(self, tmp_path: Path) -> None:
+        source = (
+            "from __future__ import annotations\n"
+            "from typing import TYPE_CHECKING\n"
+            "\n"
+            "if TYPE_CHECKING:\n"
+            "    from aiokafka import AIOKafkaConsumer\n"
+        )
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert violations == []
+
+
+@pytest.mark.unit
+class TestExemptAnnotationSkipped:
+    """Lines with ``# omnimemory-kafka-exempt:`` must be skipped."""
+
+    def test_exempt_annotation_suppresses_violation(self, tmp_path: Path) -> None:
+        source = (
+            "from aiokafka import AIOKafkaConsumer"
+            "  # omnimemory-kafka-exempt: needed for bridge layer\n"
+        )
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert violations == []
+
+
+@pytest.mark.unit
+class TestNoKafkaImports:
+    """A file with no Kafka imports at all must produce no violations."""
+
+    def test_clean_file(self, tmp_path: Path) -> None:
+        source = (
+            "from __future__ import annotations\n"
+            "import os\n"
+            "\n"
+            "def hello() -> str:\n"
+            "    return 'world'\n"
+        )
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert violations == []
+
+
+@pytest.mark.unit
+class TestElseBlockAfterTypeChecking:
+    """Kafka imports in an ``else:`` block after ``if TYPE_CHECKING:`` are
+    runtime imports and must produce a violation."""
+
+    def test_else_branch_is_runtime(self, tmp_path: Path) -> None:
+        source = (
+            "from typing import TYPE_CHECKING\n"
+            "\n"
+            "if TYPE_CHECKING:\n"
+            "    from aiokafka import AIOKafkaConsumer\n"
+            "else:\n"
+            "    from aiokafka import AIOKafkaConsumer\n"
+        )
+        filepath = _write_node_file(tmp_path, source)
+        violations = validate_file(filepath)
+
+        assert len(violations) == 1
+        assert violations[0].line == 6
+        assert "aiokafka" in violations[0].message


### PR DESCRIPTION
## Summary

- Add CI and pre-commit validation preventing direct Kafka consumer imports (`aiokafka`, `kafka`, `confluent_kafka`) in `src/omnimemory/nodes/`
- Enforces ARCH-002: "Runtime owns all Kafka plumbing" — node/handler code must not directly instantiate Kafka consumers
- Follows established `validate_http_imports.py` pattern with exemption annotations and `TYPE_CHECKING` block awareness

## Changes

| File | Change |
|------|--------|
| `scripts/validation/validate_kafka_imports.py` | New validation script detecting direct Kafka imports in nodes |
| `.github/workflows/test.yml` | Added CI step in `onex-validation` job |
| `.pre-commit-config.yaml` | Added `validate-kafka-imports` pre-commit hook |

## Design Decisions

- **Integrated into existing `onex-validation` job** rather than a standalone workflow — avoids CI sprawl and follows established pattern
- **Supports `# omnimemory-kafka-exempt: <reason>`** annotation for rare legitimate exemptions
- **Respects `TYPE_CHECKING` blocks** — type-only imports are allowed
- **Detects all 3 major Kafka client libraries**: aiokafka, kafka-python, confluent_kafka

## Test plan

- [x] Script validates clean against current `src/omnimemory/nodes/` (no violations)
- [x] Script detects all 4 violation patterns (AIOKafkaConsumer, KafkaConsumer, import aiokafka, confluent_kafka)
- [x] Exemption annotations correctly suppress findings
- [x] TYPE_CHECKING blocks correctly excluded
- [x] Files outside `nodes/` correctly ignored
- [x] mypy strict, ruff lint/format all pass
- [x] Full test suite: 1608 passed, 157 skipped
- [x] Pre-commit hooks pass

Closes OMN-1750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated validation tool to detect and report disallowed Kafka imports within the enforced code paths.
  * Integrated the check into pre-commit so violations are caught locally before commits.
  * Added CI validation that runs this check and surfaces results in the validation summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->