### PR TITLE
feat(runtime): Add wire model registration & entry point declaration (OMN-2217)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ memory-profiler = "^0.61.0"
 docker = "^7.1.0"
 types-pyyaml = "^6.0.12.20250915"
 
+[tool.poetry.plugins."onex.domain_plugins"]
+memory = "omnimemory.runtime.plugin:PluginMemory"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -111,6 +111,8 @@ def __getattr__(name: str) -> object:
     _message_type_symbols = {
         "EXPECTED_MESSAGE_TYPE_COUNT",
         "MEMORY_DOMAIN",
+        "get_registration_metrics",
+        "is_registry_ready",
         "register_memory_message_types",
     }
     if name in _message_type_symbols:
@@ -157,5 +159,7 @@ __all__ = [
     # Message type registration (lazy-imported via __getattr__)
     "EXPECTED_MESSAGE_TYPE_COUNT",
     "MEMORY_DOMAIN",
+    "get_registration_metrics",
+    "is_registry_ready",
     "register_memory_message_types",
 ]

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -57,11 +57,11 @@ from omnimemory.runtime.contract_topics import (
 
 
 def __getattr__(name: str) -> object:
-    """Lazy-import dispatch handler symbols on first access.
+    """Lazy-import runtime symbols on first access.
 
-    This avoids pulling omnibase_core.runtime into the module namespace at
-    package import time while still allowing ``from omnimemory.runtime import
-    create_memory_dispatch_engine`` to work.
+    This avoids pulling heavier modules into the namespace at package import
+    time while still allowing direct imports of dispatch, plugin, wiring,
+    introspection, and message-type registration symbols.
     """
     _dispatch_symbols = {
         "DISPATCH_ALIAS_ARCHIVE_MEMORY",

--- a/src/omnimemory/runtime/__init__.py
+++ b/src/omnimemory/runtime/__init__.py
@@ -108,6 +108,16 @@ def __getattr__(name: str) -> object:
 
         return getattr(introspection, name)
 
+    _message_type_symbols = {
+        "EXPECTED_MESSAGE_TYPE_COUNT",
+        "MEMORY_DOMAIN",
+        "register_memory_message_types",
+    }
+    if name in _message_type_symbols:
+        from omnimemory.runtime import message_type_registration
+
+        return getattr(message_type_registration, name)
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -144,4 +154,8 @@ __all__ = [
     "publish_memory_introspection",
     "publish_memory_shutdown",
     "reset_introspection_guard",
+    # Message type registration (lazy-imported via __getattr__)
+    "EXPECTED_MESSAGE_TYPE_COUNT",
+    "MEMORY_DOMAIN",
+    "register_memory_message_types",
 ]

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -110,6 +110,24 @@ def get_registration_metrics() -> dict[str, int]:
         }
 
 
+def _reset_for_testing() -> None:
+    """Reset all module-level observability globals to their initial state.
+
+    This function is intended **exclusively for test fixtures** that need a
+    clean slate between test cases.  It acquires ``_registry_lock`` and
+    resets ``_registry_ready``, ``_registered_count``, and
+    ``_registration_failure_count`` to their default values.
+
+    Production code should never call this function.
+    """
+    global _registry_ready, _registered_count, _registration_failure_count  # noqa: PLW0603
+
+    with _registry_lock:
+        _registry_ready = False
+        _registered_count = 0
+        _registration_failure_count = 0
+
+
 def register_memory_message_types(
     registry: RegistryMessageType,
 ) -> list[str]:
@@ -293,7 +311,7 @@ def register_memory_message_types(
 
     except Exception:
         with _registry_lock:
-            _registration_failure_count += 1
+            _registration_failure_count = 1
             _registry_ready = False
             failure_count_snapshot = _registration_failure_count
         logger.exception(
@@ -325,6 +343,7 @@ def register_memory_message_types(
 __all__ = [
     "EXPECTED_MESSAGE_TYPE_COUNT",
     "MEMORY_DOMAIN",
+    "_reset_for_testing",
     "get_registration_metrics",
     "is_registry_ready",
     "register_memory_message_types",

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -128,6 +128,7 @@ def register_memory_message_types(
     # a previous failure does not report stale readiness.
     with _registry_lock:
         _registry_ready = False
+        _registered_count = 0
         _registration_failure_count = 0
 
     registered: list[str] = []

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -22,6 +22,13 @@ Observability:
     - ``_registered_count`` / ``_registration_failure_count`` track metrics
     - ``is_registry_ready()`` exposes readiness for health checks
 
+Thread-safety:
+    This module is designed to be called **once** during single-threaded plugin
+    startup.  The ``_registry_lock`` protects individual reads and writes to
+    the module-level observability globals, but it does NOT serialize the entire
+    ``register_memory_message_types`` operation.  Concurrent calls from
+    multiple threads are **not supported** and will produce undefined results.
+
 Related:
     - OMN-2217: Phase 6 -- Wire model registration & entry point declaration
     - OMN-937: Central Message Type Registry implementation
@@ -36,6 +43,9 @@ from typing import TYPE_CHECKING
 from omnibase_infra.enums import EnumMessageCategory
 
 if TYPE_CHECKING:
+    # Annotation-only import: the concrete RegistryMessageType instance is
+    # passed in at runtime by the caller (plugin.py), so no runtime import
+    # is needed here.
     from omnibase_infra.runtime.registry import RegistryMessageType
 
 logger = logging.getLogger(__name__)
@@ -105,6 +115,9 @@ def register_memory_message_types(
 
     The registry is NOT frozen by this function.  The caller is responsible
     for calling ``registry.freeze()`` after all domains have registered.
+
+    .. note:: This function is **not thread-safe** for concurrent callers.
+       It is designed to be invoked once during single-threaded plugin startup.
 
     On success the module-level readiness flag is set to ``True`` and the
     ``_registered_count`` counter is updated.  On failure the readiness flag

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -139,6 +139,9 @@ def register_memory_message_types(
     # Reset readiness and failure counter at the start of each registration
     # attempt so that metrics reflect the last call only, and a retry after
     # a previous failure does not report stale readiness.
+    # Lock protects reader functions (is_registry_ready, get_registered_count,
+    # etc.) from seeing partially-written globals.  This does NOT make the
+    # function safe for concurrent callers -- see module docstring.
     with _registry_lock:
         _registry_ready = False
         _registered_count = 0

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -64,13 +64,20 @@ _registry_ready: bool = False
 """Module-level readiness flag.  True after successful registration."""
 
 _registered_count: int = 0
-"""Number of message types successfully registered in the last call."""
+"""Number of message types successfully registered in the most recent call.
+
+Reset to ``0`` at the start of each invocation of
+``register_memory_message_types``, so this reflects only the most recent
+call, not a cumulative total across multiple invocations.
+"""
 
 _registration_failure_count: int = 0
-"""Count of failed calls to register_memory_message_types (call-level, not per-type).
+"""Failure indicator for the most recent call to ``register_memory_message_types``.
 
-Incremented once per failed invocation of the function, regardless of how many
-individual type registrations succeeded before the error."""
+Set to ``1`` if the last call failed, ``0`` if it succeeded (or if no call
+has been made yet).  Reset at the start of each invocation, so this reflects
+only the most recent call, not a cumulative total.
+"""
 
 _registry_lock = threading.Lock()
 """Guards concurrent access to _registry_ready, _registered_count,
@@ -122,10 +129,12 @@ def register_memory_message_types(
     .. note:: This function is **not thread-safe** for concurrent callers.
        It is designed to be invoked once during single-threaded plugin startup.
 
-    On success the module-level readiness flag is set to ``True`` and the
-    ``_registered_count`` counter is updated.  On failure the readiness flag
-    is set to ``False``, ``_registration_failure_count`` is incremented once
-    per failed call (call-level, not per-type), and the exception is re-raised.
+    On success the module-level readiness flag is set to ``True`` and
+    ``_registered_count`` is set to the number of types registered.  On
+    failure the readiness flag is set to ``False`` and
+    ``_registration_failure_count`` is set to ``1``.  Both counters are
+    reset at the start of each invocation, so they always reflect the
+    outcome of the most recent call only.
 
     Args:
         registry: An unfrozen RegistryMessageType instance.

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -17,6 +17,11 @@ Design:
     - ``category`` follows topic naming: ``.cmd.`` -> COMMAND, ``.evt.`` -> EVENT
     - Consumed events from external domains use EVENT category
 
+Observability:
+    - ``_registry_ready`` module-level flag tracks registration readiness
+    - ``_registered_count`` / ``_registration_failure_count`` track metrics
+    - ``is_registry_ready()`` exposes readiness for health checks
+
 Related:
     - OMN-2217: Phase 6 -- Wire model registration & entry point declaration
     - OMN-937: Central Message Type Registry implementation
@@ -41,6 +46,42 @@ MEMORY_DOMAIN = "memory"
 # Used in tests and validate_startup logging.
 EXPECTED_MESSAGE_TYPE_COUNT = 10
 
+# ---------------------------------------------------------------------------
+# Observability: readiness flag and metric counters
+# ---------------------------------------------------------------------------
+_registry_ready: bool = False
+"""Module-level readiness flag.  True after successful registration."""
+
+_registered_count: int = 0
+"""Number of message types successfully registered in the last call."""
+
+_registration_failure_count: int = 0
+"""Number of registration failures encountered in the last call."""
+
+
+def is_registry_ready() -> bool:
+    """Return whether the memory message type registry is ready.
+
+    This function is intended for health-check integrations.  It returns
+    ``True`` only after ``register_memory_message_types`` has completed
+    successfully (i.e., all expected types registered without error).
+    """
+    return _registry_ready
+
+
+def get_registration_metrics() -> dict[str, int]:
+    """Return current registration metrics for observability.
+
+    Returns:
+        Dict with ``registered_count``, ``failure_count``, and
+        ``expected_count`` keys.
+    """
+    return {
+        "registered_count": _registered_count,
+        "failure_count": _registration_failure_count,
+        "expected_count": EXPECTED_MESSAGE_TYPE_COUNT,
+    }
+
 
 def register_memory_message_types(
     registry: RegistryMessageType,
@@ -58,6 +99,11 @@ def register_memory_message_types(
     The registry is NOT frozen by this function.  The caller is responsible
     for calling ``registry.freeze()`` after all domains have registered.
 
+    On success the module-level readiness flag is set to ``True`` and the
+    ``_registered_count`` counter is updated.  On failure the readiness flag
+    is set to ``False``, ``_registration_failure_count`` is incremented, and
+    the exception is re-raised.
+
     Args:
         registry: An unfrozen RegistryMessageType instance.
 
@@ -68,140 +114,164 @@ def register_memory_message_types(
         ModelOnexError: If registry is already frozen.
         MessageTypeRegistryError: If any registration fails validation.
     """
+    global _registry_ready, _registered_count, _registration_failure_count  # noqa: PLW0603
+
+    # Reset readiness at the start of each registration attempt so that a
+    # retry after a previous failure does not report stale readiness.
+    _registry_ready = False
+
     registered: list[str] = []
 
-    # =========================================================================
-    # Consumed Kafka Event (from omniintelligence) -- EVENT category
-    # =========================================================================
+    try:
+        # =====================================================================
+        # Consumed Kafka Event (from omniintelligence) -- EVENT category
+        # =====================================================================
 
-    # 1. Intent classification event consumed from omniintelligence
-    registry.register_simple(
-        message_type="ModelIntentClassifiedEvent",
-        handler_id="intent_event_consumer_effect",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description=(
-            "Intent classification event consumed from omniintelligence "
-            "for memory storage"
-        ),
-    )
-    registered.append("ModelIntentClassifiedEvent")
+        # 1. Intent classification event consumed from omniintelligence
+        registry.register_simple(
+            message_type="ModelIntentClassifiedEvent",
+            handler_id="intent_event_consumer_effect",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description=(
+                "Intent classification event consumed from omniintelligence "
+                "for memory storage"
+            ),
+        )
+        registered.append("ModelIntentClassifiedEvent")
 
-    # =========================================================================
-    # Intent Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
-    # =========================================================================
+        # =====================================================================
+        # Intent Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
+        # =====================================================================
 
-    # 2. Intent storage request (command input)
-    registry.register_simple(
-        message_type="ModelIntentStorageRequest",
-        handler_id="intent_storage_effect",
-        category=EnumMessageCategory.COMMAND,
-        domain=MEMORY_DOMAIN,
-        description="Intent storage request command input",
-    )
-    registered.append("ModelIntentStorageRequest")
+        # 2. Intent storage request (command input)
+        registry.register_simple(
+            message_type="ModelIntentStorageRequest",
+            handler_id="intent_storage_effect",
+            category=EnumMessageCategory.COMMAND,
+            domain=MEMORY_DOMAIN,
+            description="Intent storage request command input",
+        )
+        registered.append("ModelIntentStorageRequest")
 
-    # 3. Intent storage response (event output)
-    registry.register_simple(
-        message_type="ModelIntentStorageResponse",
-        handler_id="intent_storage_effect",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description="Intent storage response event output",
-    )
-    registered.append("ModelIntentStorageResponse")
+        # 3. Intent storage response (event output)
+        registry.register_simple(
+            message_type="ModelIntentStorageResponse",
+            handler_id="intent_storage_effect",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description="Intent storage response event output",
+        )
+        registered.append("ModelIntentStorageResponse")
 
-    # =========================================================================
-    # Memory Retrieval Effect -- COMMAND/EVENT
-    # =========================================================================
+        # =====================================================================
+        # Memory Retrieval Effect -- COMMAND/EVENT
+        # =====================================================================
 
-    # 4. Memory retrieval request (command input)
-    registry.register_simple(
-        message_type="ModelMemoryRetrievalRequest",
-        handler_id="memory_retrieval_effect",
-        category=EnumMessageCategory.COMMAND,
-        domain=MEMORY_DOMAIN,
-        description="Memory retrieval request command consumed from Kafka",
-    )
-    registered.append("ModelMemoryRetrievalRequest")
+        # 4. Memory retrieval request (command input)
+        registry.register_simple(
+            message_type="ModelMemoryRetrievalRequest",
+            handler_id="memory_retrieval_effect",
+            category=EnumMessageCategory.COMMAND,
+            domain=MEMORY_DOMAIN,
+            description="Memory retrieval request command consumed from Kafka",
+        )
+        registered.append("ModelMemoryRetrievalRequest")
 
-    # 5. Memory retrieval response (event output)
-    registry.register_simple(
-        message_type="ModelMemoryRetrievalResponse",
-        handler_id="memory_retrieval_effect",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description="Memory retrieval response event output",
-    )
-    registered.append("ModelMemoryRetrievalResponse")
+        # 5. Memory retrieval response (event output)
+        registry.register_simple(
+            message_type="ModelMemoryRetrievalResponse",
+            handler_id="memory_retrieval_effect",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description="Memory retrieval response event output",
+        )
+        registered.append("ModelMemoryRetrievalResponse")
 
-    # =========================================================================
-    # Memory Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
-    # =========================================================================
+        # =====================================================================
+        # Memory Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
+        # =====================================================================
 
-    # 6. Memory storage request (command input)
-    registry.register_simple(
-        message_type="ModelMemoryStorageRequest",
-        handler_id="memory_storage_effect",
-        category=EnumMessageCategory.COMMAND,
-        domain=MEMORY_DOMAIN,
-        description="Memory storage CRUD request command input",
-    )
-    registered.append("ModelMemoryStorageRequest")
+        # 6. Memory storage request (command input)
+        registry.register_simple(
+            message_type="ModelMemoryStorageRequest",
+            handler_id="memory_storage_effect",
+            category=EnumMessageCategory.COMMAND,
+            domain=MEMORY_DOMAIN,
+            description="Memory storage CRUD request command input",
+        )
+        registered.append("ModelMemoryStorageRequest")
 
-    # 7. Memory storage response (event output)
-    registry.register_simple(
-        message_type="ModelMemoryStorageResponse",
-        handler_id="memory_storage_effect",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description="Memory storage CRUD response event output",
-    )
-    registered.append("ModelMemoryStorageResponse")
+        # 7. Memory storage response (event output)
+        registry.register_simple(
+            message_type="ModelMemoryStorageResponse",
+            handler_id="memory_storage_effect",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description="Memory storage CRUD response event output",
+        )
+        registered.append("ModelMemoryStorageResponse")
 
-    # =========================================================================
-    # Agent Coordinator Orchestrator -- COMMAND/EVENT
-    # =========================================================================
+        # =====================================================================
+        # Agent Coordinator Orchestrator -- COMMAND/EVENT
+        # =====================================================================
 
-    # 8. Agent coordinator request (command input)
-    registry.register_simple(
-        message_type="ModelAgentCoordinatorRequest",
-        handler_id="agent_coordinator_orchestrator",
-        category=EnumMessageCategory.COMMAND,
-        domain=MEMORY_DOMAIN,
-        description=(
-            "Agent coordinator request for subscription management "
-            "and notification dispatch"
-        ),
-    )
-    registered.append("ModelAgentCoordinatorRequest")
+        # 8. Agent coordinator request (command input)
+        registry.register_simple(
+            message_type="ModelAgentCoordinatorRequest",
+            handler_id="agent_coordinator_orchestrator",
+            category=EnumMessageCategory.COMMAND,
+            domain=MEMORY_DOMAIN,
+            description=(
+                "Agent coordinator request for subscription management "
+                "and notification dispatch"
+            ),
+        )
+        registered.append("ModelAgentCoordinatorRequest")
 
-    # 9. Agent coordinator response (event output)
-    registry.register_simple(
-        message_type="ModelAgentCoordinatorResponse",
-        handler_id="agent_coordinator_orchestrator",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description="Agent coordinator response with operation result",
-    )
-    registered.append("ModelAgentCoordinatorResponse")
+        # 9. Agent coordinator response (event output)
+        registry.register_simple(
+            message_type="ModelAgentCoordinatorResponse",
+            handler_id="agent_coordinator_orchestrator",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description="Agent coordinator response with operation result",
+        )
+        registered.append("ModelAgentCoordinatorResponse")
 
-    # 10. Notification event (published by coordinator to Kafka)
-    registry.register_simple(
-        message_type="ModelNotificationEvent",
-        handler_id="agent_coordinator_orchestrator",
-        category=EnumMessageCategory.EVENT,
-        domain=MEMORY_DOMAIN,
-        description=(
-            "Notification event published to Kafka for cross-agent "
-            "memory change notifications"
-        ),
-    )
-    registered.append("ModelNotificationEvent")
+        # 10. Notification event (published by coordinator to Kafka)
+        registry.register_simple(
+            message_type="ModelNotificationEvent",
+            handler_id="agent_coordinator_orchestrator",
+            category=EnumMessageCategory.EVENT,
+            domain=MEMORY_DOMAIN,
+            description=(
+                "Notification event published to Kafka for cross-agent "
+                "memory change notifications"
+            ),
+        )
+        registered.append("ModelNotificationEvent")
+
+    except Exception:
+        _registration_failure_count += 1
+        _registry_ready = False
+        logger.exception(
+            "Memory message type registration failed " "(registered=%d, failures=%d)",
+            len(registered),
+            _registration_failure_count,
+        )
+        raise
+
+    # Update metrics on success
+    _registered_count = len(registered)
+    _registry_ready = True
 
     logger.info(
-        "Registered %d memory message types with RegistryMessageType",
-        len(registered),
+        "Registered %d memory message types with RegistryMessageType "
+        "(ready=%s, failures=%d)",
+        _registered_count,
+        _registry_ready,
+        _registration_failure_count,
     )
 
     return registered
@@ -210,5 +280,7 @@ def register_memory_message_types(
 __all__ = [
     "EXPECTED_MESSAGE_TYPE_COUNT",
     "MEMORY_DOMAIN",
+    "get_registration_metrics",
+    "is_registry_ready",
     "register_memory_message_types",
 ]

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -268,7 +268,7 @@ def register_memory_message_types(
             _registry_ready = False
             failure_count_snapshot = _registration_failure_count
         logger.exception(
-            "Memory message type registration failed " "(registered=%d, failures=%d)",
+            "Memory message type registration failed (registered=%d, failures=%d)",
             len(registered),
             failure_count_snapshot,
         )

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -30,6 +30,7 @@ Related:
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING
 
 from omnibase_infra.enums import EnumMessageCategory
@@ -58,6 +59,10 @@ _registered_count: int = 0
 _registration_failure_count: int = 0
 """Number of registration failures encountered in the last call."""
 
+_registry_lock = threading.Lock()
+"""Guards concurrent access to _registry_ready, _registered_count,
+and _registration_failure_count."""
+
 
 def is_registry_ready() -> bool:
     """Return whether the memory message type registry is ready.
@@ -66,7 +71,8 @@ def is_registry_ready() -> bool:
     ``True`` only after ``register_memory_message_types`` has completed
     successfully (i.e., all expected types registered without error).
     """
-    return _registry_ready
+    with _registry_lock:
+        return _registry_ready
 
 
 def get_registration_metrics() -> dict[str, int]:
@@ -76,11 +82,12 @@ def get_registration_metrics() -> dict[str, int]:
         Dict with ``registered_count``, ``failure_count``, and
         ``expected_count`` keys.
     """
-    return {
-        "registered_count": _registered_count,
-        "failure_count": _registration_failure_count,
-        "expected_count": EXPECTED_MESSAGE_TYPE_COUNT,
-    }
+    with _registry_lock:
+        return {
+            "registered_count": _registered_count,
+            "failure_count": _registration_failure_count,
+            "expected_count": EXPECTED_MESSAGE_TYPE_COUNT,
+        }
 
 
 def register_memory_message_types(
@@ -116,9 +123,12 @@ def register_memory_message_types(
     """
     global _registry_ready, _registered_count, _registration_failure_count  # noqa: PLW0603
 
-    # Reset readiness at the start of each registration attempt so that a
-    # retry after a previous failure does not report stale readiness.
-    _registry_ready = False
+    # Reset readiness and failure counter at the start of each registration
+    # attempt so that metrics reflect the last call only, and a retry after
+    # a previous failure does not report stale readiness.
+    with _registry_lock:
+        _registry_ready = False
+        _registration_failure_count = 0
 
     registered: list[str] = []
 
@@ -253,25 +263,31 @@ def register_memory_message_types(
         registered.append("ModelNotificationEvent")
 
     except Exception:
-        _registration_failure_count += 1
-        _registry_ready = False
+        with _registry_lock:
+            _registration_failure_count += 1
+            _registry_ready = False
+            failure_count_snapshot = _registration_failure_count
         logger.exception(
             "Memory message type registration failed " "(registered=%d, failures=%d)",
             len(registered),
-            _registration_failure_count,
+            failure_count_snapshot,
         )
         raise
 
     # Update metrics on success
-    _registered_count = len(registered)
-    _registry_ready = True
+    with _registry_lock:
+        _registered_count = len(registered)
+        _registry_ready = True
+        count_snapshot = _registered_count
+        ready_snapshot = _registry_ready
+        failure_snapshot = _registration_failure_count
 
     logger.info(
         "Registered %d memory message types with RegistryMessageType "
         "(ready=%s, failures=%d)",
-        _registered_count,
-        _registry_ready,
-        _registration_failure_count,
+        count_snapshot,
+        ready_snapshot,
+        failure_snapshot,
     )
 
     return registered

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Memory domain message type registration.
+
+Registers all memory wire models (Kafka event payloads, command inputs, and
+response envelopes) with ``RegistryMessageType``.  This enables type-based
+envelope routing and startup validation for the memory domain.
+
+The registration list is intentionally explicit rather than derived from
+contract YAML files.  Contract-driven discovery is acceptable as a future
+enhancement, but an explicit list keeps the registration deterministic and
+auditable.
+
+Design:
+    - All registrations use ``domain="memory"``
+    - ``handler_id`` matches the node directory name
+    - ``category`` follows topic naming: ``.cmd.`` -> COMMAND, ``.evt.`` -> EVENT
+    - Consumed events from external domains use EVENT category
+
+Related:
+    - OMN-2217: Phase 6 -- Wire model registration & entry point declaration
+    - OMN-937: Central Message Type Registry implementation
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from omnibase_infra.enums import EnumMessageCategory
+
+if TYPE_CHECKING:
+    from omnibase_infra.runtime.registry import RegistryMessageType
+
+logger = logging.getLogger(__name__)
+
+MEMORY_DOMAIN = "memory"
+"""Owning domain for all memory message types."""
+
+# Total number of unique message types registered.
+# Used in tests and validate_startup logging.
+EXPECTED_MESSAGE_TYPE_COUNT = 10
+
+
+def register_memory_message_types(
+    registry: RegistryMessageType,
+) -> list[str]:
+    """Register all memory wire models with the message type registry.
+
+    This function registers 10 message types spanning:
+    - 1 consumed Kafka event (intent classification from omniintelligence)
+    - 3 Kafka command models (effect node inputs)
+    - 3 Kafka event/response models (effect node outputs)
+    - 1 notification event model (published by orchestrator)
+    - 1 orchestrator command model (coordinator input)
+    - 1 orchestrator response model (coordinator output)
+
+    The registry is NOT frozen by this function.  The caller is responsible
+    for calling ``registry.freeze()`` after all domains have registered.
+
+    Args:
+        registry: An unfrozen RegistryMessageType instance.
+
+    Returns:
+        List of registered message type names (for logging).
+
+    Raises:
+        ModelOnexError: If registry is already frozen.
+        MessageTypeRegistryError: If any registration fails validation.
+    """
+    registered: list[str] = []
+
+    # =========================================================================
+    # Consumed Kafka Event (from omniintelligence) -- EVENT category
+    # =========================================================================
+
+    # 1. Intent classification event consumed from omniintelligence
+    registry.register_simple(
+        message_type="ModelIntentClassifiedEvent",
+        handler_id="intent_event_consumer_effect",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description=(
+            "Intent classification event consumed from omniintelligence "
+            "for memory storage"
+        ),
+    )
+    registered.append("ModelIntentClassifiedEvent")
+
+    # =========================================================================
+    # Intent Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
+    # =========================================================================
+
+    # 2. Intent storage request (command input)
+    registry.register_simple(
+        message_type="ModelIntentStorageRequest",
+        handler_id="intent_storage_effect",
+        category=EnumMessageCategory.COMMAND,
+        domain=MEMORY_DOMAIN,
+        description="Intent storage request command input",
+    )
+    registered.append("ModelIntentStorageRequest")
+
+    # 3. Intent storage response (event output)
+    registry.register_simple(
+        message_type="ModelIntentStorageResponse",
+        handler_id="intent_storage_effect",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description="Intent storage response event output",
+    )
+    registered.append("ModelIntentStorageResponse")
+
+    # =========================================================================
+    # Memory Retrieval Effect -- COMMAND/EVENT
+    # =========================================================================
+
+    # 4. Memory retrieval request (command input)
+    registry.register_simple(
+        message_type="ModelMemoryRetrievalRequest",
+        handler_id="memory_retrieval_effect",
+        category=EnumMessageCategory.COMMAND,
+        domain=MEMORY_DOMAIN,
+        description="Memory retrieval request command consumed from Kafka",
+    )
+    registered.append("ModelMemoryRetrievalRequest")
+
+    # 5. Memory retrieval response (event output)
+    registry.register_simple(
+        message_type="ModelMemoryRetrievalResponse",
+        handler_id="memory_retrieval_effect",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description="Memory retrieval response event output",
+    )
+    registered.append("ModelMemoryRetrievalResponse")
+
+    # =========================================================================
+    # Memory Storage Effect (orchestrator-invoked) -- COMMAND/EVENT
+    # =========================================================================
+
+    # 6. Memory storage request (command input)
+    registry.register_simple(
+        message_type="ModelMemoryStorageRequest",
+        handler_id="memory_storage_effect",
+        category=EnumMessageCategory.COMMAND,
+        domain=MEMORY_DOMAIN,
+        description="Memory storage CRUD request command input",
+    )
+    registered.append("ModelMemoryStorageRequest")
+
+    # 7. Memory storage response (event output)
+    registry.register_simple(
+        message_type="ModelMemoryStorageResponse",
+        handler_id="memory_storage_effect",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description="Memory storage CRUD response event output",
+    )
+    registered.append("ModelMemoryStorageResponse")
+
+    # =========================================================================
+    # Agent Coordinator Orchestrator -- COMMAND/EVENT
+    # =========================================================================
+
+    # 8. Agent coordinator request (command input)
+    registry.register_simple(
+        message_type="ModelAgentCoordinatorRequest",
+        handler_id="agent_coordinator_orchestrator",
+        category=EnumMessageCategory.COMMAND,
+        domain=MEMORY_DOMAIN,
+        description=(
+            "Agent coordinator request for subscription management "
+            "and notification dispatch"
+        ),
+    )
+    registered.append("ModelAgentCoordinatorRequest")
+
+    # 9. Agent coordinator response (event output)
+    registry.register_simple(
+        message_type="ModelAgentCoordinatorResponse",
+        handler_id="agent_coordinator_orchestrator",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description="Agent coordinator response with operation result",
+    )
+    registered.append("ModelAgentCoordinatorResponse")
+
+    # 10. Notification event (published by coordinator to Kafka)
+    registry.register_simple(
+        message_type="ModelNotificationEvent",
+        handler_id="agent_coordinator_orchestrator",
+        category=EnumMessageCategory.EVENT,
+        domain=MEMORY_DOMAIN,
+        description=(
+            "Notification event published to Kafka for cross-agent "
+            "memory change notifications"
+        ),
+    )
+    registered.append("ModelNotificationEvent")
+
+    logger.info(
+        "Registered %d memory message types with RegistryMessageType",
+        len(registered),
+    )
+
+    return registered
+
+
+__all__ = [
+    "EXPECTED_MESSAGE_TYPE_COUNT",
+    "MEMORY_DOMAIN",
+    "register_memory_message_types",
+]

--- a/src/omnimemory/runtime/message_type_registration.py
+++ b/src/omnimemory/runtime/message_type_registration.py
@@ -67,7 +67,10 @@ _registered_count: int = 0
 """Number of message types successfully registered in the last call."""
 
 _registration_failure_count: int = 0
-"""Number of registration failures encountered in the last call."""
+"""Count of failed calls to register_memory_message_types (call-level, not per-type).
+
+Incremented once per failed invocation of the function, regardless of how many
+individual type registrations succeeded before the error."""
 
 _registry_lock = threading.Lock()
 """Guards concurrent access to _registry_ready, _registered_count,
@@ -121,8 +124,8 @@ def register_memory_message_types(
 
     On success the module-level readiness flag is set to ``True`` and the
     ``_registered_count`` counter is updated.  On failure the readiness flag
-    is set to ``False``, ``_registration_failure_count`` is incremented, and
-    the exception is re-raised.
+    is set to ``False``, ``_registration_failure_count`` is incremented once
+    per failed call (call-level, not per-type), and the exception is re-raised.
 
     Args:
         registry: An unfrozen RegistryMessageType instance.

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -71,6 +71,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from omnibase_core.protocols.event_bus.protocol_event_bus import ProtocolEventBus
     from omnibase_core.runtime.runtime_message_dispatch import MessageDispatchEngine
+    from omnibase_infra.runtime.registry import RegistryMessageType
 
     from omnimemory.runtime.introspection import MemoryNodeIntrospectionProxy
 
@@ -138,9 +139,15 @@ class PluginMemory:
         self._shutdown_in_progress: bool = False
         self._services_registered: list[str] = []
         self._dispatch_engine: MessageDispatchEngine | None = None
+        self._message_type_registry: RegistryMessageType | None = None
         self._event_bus: ProtocolEventBus | None = None
         self._introspection_nodes: list[str] = []
         self._introspection_proxies: list[MemoryNodeIntrospectionProxy] = []
+
+    @property
+    def message_type_registry(self) -> RegistryMessageType | None:
+        """Return the message type registry (for external access)."""
+        return self._message_type_registry
 
     @property
     def plugin_id(self) -> str:
@@ -197,8 +204,43 @@ class PluginMemory:
         correlation_id = config.correlation_id
 
         try:
-            # Memory plugin has no dedicated initialization work;
-            # handlers use container-injected adapters for storage.
+            resources_created: list[str] = []
+
+            # Register memory message types (OMN-2217)
+            # NOTE: This creates a plugin-local registry for the memory
+            # domain only.  Cross-domain validation requires a kernel-level
+            # shared registry (future enhancement).
+            from omnibase_infra.runtime.registry import RegistryMessageType
+
+            from omnimemory.runtime.message_type_registration import (
+                register_memory_message_types,
+            )
+
+            registry = RegistryMessageType()
+            registered_types = register_memory_message_types(registry)
+            registry.freeze()
+
+            # Validate startup -- log warnings but do not fail init
+            warnings = registry.validate_startup()
+            if warnings:
+                for warning in warnings:
+                    logger.warning(
+                        "Message type registry warning: %s (correlation_id=%s)",
+                        warning,
+                        correlation_id,
+                    )
+
+            self._message_type_registry = registry
+            resources_created.append("message_type_registry")
+
+            logger.info(
+                "Memory message type registry created and frozen "
+                "(types=%d, warnings=%d, correlation_id=%s)",
+                len(registered_types),
+                len(warnings),
+                correlation_id,
+            )
+
             duration = time.time() - start_time
 
             logger.info(
@@ -210,7 +252,7 @@ class PluginMemory:
                 plugin_id=self.plugin_id,
                 success=True,
                 message="Memory plugin initialized",
-                resources_created=[],
+                resources_created=resources_created,
                 duration_seconds=duration,
             )
 
@@ -667,6 +709,7 @@ class PluginMemory:
 
         self._services_registered = []
         self._dispatch_engine = None
+        self._message_type_registry = None
         self._event_bus = None
         self._introspection_nodes = []
         self._introspection_proxies = []

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -210,6 +210,7 @@ class PluginMemory:
             # NOTE: This creates a plugin-local registry for the memory
             # domain only.  Cross-domain validation requires a kernel-level
             # shared registry (future enhancement).
+            # TODO(OMN-2217): Track kernel-level shared registry for cross-domain validation
             from omnibase_infra.runtime.registry import RegistryMessageType
 
             from omnimemory.runtime.message_type_registration import (

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -210,7 +210,7 @@ class PluginMemory:
             # NOTE: This creates a plugin-local registry for the memory
             # domain only.  Cross-domain validation requires a kernel-level
             # shared registry (future enhancement).
-            # TODO(OMN-2217): Track kernel-level shared registry for cross-domain validation
+            # TODO: Kernel-level shared registry for cross-domain duplicate detection (future enhancement)
             from omnibase_infra.runtime.registry import RegistryMessageType
 
             from omnimemory.runtime.message_type_registration import (

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -210,7 +210,7 @@ class PluginMemory:
             # NOTE: This creates a plugin-local registry for the memory
             # domain only.  Cross-domain validation requires a kernel-level
             # shared registry (future enhancement).
-            # TODO: Kernel-level shared registry for cross-domain duplicate detection (future enhancement)
+            # NOTE: Cross-domain duplicate detection requires a kernel-level shared registry (future enhancement).
             from omnibase_infra.runtime.registry import RegistryMessageType
 
             from omnimemory.runtime.message_type_registration import (

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -207,10 +207,9 @@ class PluginMemory:
             resources_created: list[str] = []
 
             # Register memory message types (OMN-2217)
-            # NOTE: This creates a plugin-local registry for the memory
-            # domain only.  Cross-domain validation requires a kernel-level
-            # shared registry (future enhancement).
-            # NOTE: Cross-domain duplicate detection requires a kernel-level shared registry (future enhancement).
+            # NOTE: This creates a plugin-local registry for the memory domain
+            # only.  Cross-domain validation and duplicate detection require a
+            # kernel-level shared registry (future enhancement).
             from omnibase_infra.runtime.registry import RegistryMessageType
 
             from omnimemory.runtime.message_type_registration import (

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -632,7 +632,7 @@ class PluginMemory:
         Returns:
             Result indicating cleanup success/failure.
         """
-        # Guard against concurrent shutdown calls
+        # Re-entrancy guard (not concurrency-safe; class is single-threaded per docstring)
         if self._shutdown_in_progress:
             return ModelDomainPluginResult.skipped(
                 plugin_id=self.plugin_id,

--- a/tests/integration/test_entry_point_discovery.py
+++ b/tests/integration/test_entry_point_discovery.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for entry point discovery.
+
+Validates that PluginMemory is discoverable via ``importlib.metadata.entry_points()``
+using the ``onex.domain_plugins`` group.  This requires the package to be installed
+(``poetry install``) so that the entry point metadata is written.
+
+Related:
+    - OMN-2217: Phase 6 -- Wire model registration & entry point declaration
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+import pytest
+from omnibase_infra.runtime.protocol_domain_plugin import ProtocolDomainPlugin
+
+from omnimemory.runtime.plugin import PluginMemory
+
+
+@pytest.mark.integration
+class TestEntryPointDiscovery:
+    """Validate that PluginMemory is discoverable via entry_points."""
+
+    def test_entry_point_discoverable(self) -> None:
+        """Entry point 'memory' must exist in onex.domain_plugins group."""
+        eps = entry_points(group="onex.domain_plugins")
+        names = [ep.name for ep in eps]
+        assert "memory" in names, (
+            f"'memory' not found in onex.domain_plugins entry points. "
+            f"Found: {names}"
+        )
+
+    def test_entry_point_loads_plugin_class(self) -> None:
+        """Loading the entry point must return the PluginMemory class."""
+        eps = entry_points(group="onex.domain_plugins")
+        matches = [ep for ep in eps if ep.name == "memory"]
+        assert matches, "No 'memory' entry point found"
+        loaded = matches[0].load()
+        assert loaded is PluginMemory, f"Expected PluginMemory class, got {loaded!r}"
+
+    def test_entry_point_plugin_satisfies_protocol(self) -> None:
+        """Instantiating the loaded class must satisfy ProtocolDomainPlugin."""
+        eps = entry_points(group="onex.domain_plugins")
+        matches = [ep for ep in eps if ep.name == "memory"]
+        assert matches, "No 'memory' entry point found"
+        cls = matches[0].load()
+        plugin = cls()
+        assert isinstance(
+            plugin, ProtocolDomainPlugin
+        ), f"Instance of {cls.__name__} does not satisfy ProtocolDomainPlugin"
+        assert plugin.plugin_id == "memory"

--- a/tests/unit/runtime/conftest.py
+++ b/tests/unit/runtime/conftest.py
@@ -8,11 +8,33 @@ types used across plugin and wiring tests.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
 from uuid import uuid4
 
 import pytest
+
+import omnimemory.runtime.message_type_registration as _mtr_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_observability_globals() -> Iterator[None]:
+    """Reset module-level observability state before each test.
+
+    Without this reset the globals (_registry_ready, _registered_count,
+    _registration_failure_count) persist across tests.  Under parallel
+    execution (pytest-xdist) or reordered collection this causes flaky
+    assertions that depend on "clean slate" state.
+    """
+    with _mtr_module._registry_lock:
+        _mtr_module._registry_ready = False
+        _mtr_module._registered_count = 0
+        _mtr_module._registration_failure_count = 0
+    yield
+    with _mtr_module._registry_lock:
+        _mtr_module._registry_ready = False
+        _mtr_module._registered_count = 0
+        _mtr_module._registration_failure_count = 0
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/runtime/conftest.py
+++ b/tests/unit/runtime/conftest.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 import pytest
 
-import omnimemory.runtime.message_type_registration as _mtr_module
+from omnimemory.runtime.message_type_registration import _reset_for_testing
 
 
 @pytest.fixture(autouse=True)
@@ -26,15 +26,9 @@ def _reset_observability_globals() -> Iterator[None]:
     execution (pytest-xdist) or reordered collection this causes flaky
     assertions that depend on "clean slate" state.
     """
-    with _mtr_module._registry_lock:
-        _mtr_module._registry_ready = False
-        _mtr_module._registered_count = 0
-        _mtr_module._registration_failure_count = 0
+    _reset_for_testing()
     yield
-    with _mtr_module._registry_lock:
-        _mtr_module._registry_ready = False
-        _mtr_module._registered_count = 0
-        _mtr_module._registration_failure_count = 0
+    _reset_for_testing()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for memory message type registration.
+
+Validates:
+    - All 10 memory message types are registered
+    - Registration happens correctly with proper categories and domains
+    - Registry is queryable after freeze via has_message_type() and get_entry()
+    - Registration after freeze() raises ModelOnexError
+    - validate_startup() returns no errors for a clean registry
+
+Related:
+    - OMN-2217: Phase 6 -- Wire model registration & entry point declaration
+    - OMN-937: Central Message Type Registry implementation
+"""
+
+from __future__ import annotations
+
+import pytest
+from omnibase_core.models.errors import ModelOnexError
+from omnibase_infra.enums import EnumMessageCategory
+from omnibase_infra.runtime.registry import RegistryMessageType
+
+from omnimemory.runtime.message_type_registration import (
+    EXPECTED_MESSAGE_TYPE_COUNT,
+    MEMORY_DOMAIN,
+    register_memory_message_types,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def registry() -> RegistryMessageType:
+    """Create a fresh, unfrozen RegistryMessageType."""
+    return RegistryMessageType()
+
+
+@pytest.fixture
+def frozen_registry(registry: RegistryMessageType) -> RegistryMessageType:
+    """Create a registry with all memory types registered and frozen."""
+    register_memory_message_types(registry)
+    registry.freeze()
+    return registry
+
+
+# =============================================================================
+# Registration Count
+# =============================================================================
+
+
+class TestRegistrationCount:
+    """Verify correct number of message types registered."""
+
+    def test_returns_expected_registered_types(
+        self, registry: RegistryMessageType
+    ) -> None:
+        """register_memory_message_types returns expected number of type names."""
+        registered = register_memory_message_types(registry)
+        assert len(registered) == EXPECTED_MESSAGE_TYPE_COUNT
+
+    def test_registry_has_expected_entries(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Frozen registry contains exactly the expected number of entries."""
+        assert frozen_registry.entry_count == EXPECTED_MESSAGE_TYPE_COUNT
+
+    def test_expected_count_constant_matches(self) -> None:
+        """EXPECTED_MESSAGE_TYPE_COUNT constant is 10."""
+        assert EXPECTED_MESSAGE_TYPE_COUNT == 10
+
+
+# =============================================================================
+# has_message_type Queries
+# =============================================================================
+
+
+class TestHasMessageType:
+    """Verify all registered types are discoverable via has_message_type."""
+
+    ALL_MESSAGE_TYPES = [
+        # Consumed Kafka event
+        "ModelIntentClassifiedEvent",
+        # Intent storage effect
+        "ModelIntentStorageRequest",
+        "ModelIntentStorageResponse",
+        # Memory retrieval effect
+        "ModelMemoryRetrievalRequest",
+        "ModelMemoryRetrievalResponse",
+        # Memory storage effect
+        "ModelMemoryStorageRequest",
+        "ModelMemoryStorageResponse",
+        # Agent coordinator orchestrator
+        "ModelAgentCoordinatorRequest",
+        "ModelAgentCoordinatorResponse",
+        "ModelNotificationEvent",
+    ]
+
+    @pytest.mark.parametrize("message_type", ALL_MESSAGE_TYPES)
+    def test_has_message_type(
+        self, frozen_registry: RegistryMessageType, message_type: str
+    ) -> None:
+        """Each registered type is discoverable via has_message_type."""
+        assert frozen_registry.has_message_type(
+            message_type
+        ), f"Message type '{message_type}' should be registered"
+
+    def test_unregistered_type_not_found(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Unregistered type returns False."""
+        assert not frozen_registry.has_message_type("NonExistentType")
+
+
+# =============================================================================
+# get_entry Queries
+# =============================================================================
+
+
+class TestGetEntry:
+    """Verify entry details are correct for all registered types."""
+
+    def test_all_entries_have_memory_domain(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Every registered entry has owning_domain='memory'."""
+        for msg_type in TestHasMessageType.ALL_MESSAGE_TYPES:
+            entry = frozen_registry.get_entry(msg_type)
+            assert entry is not None, f"Entry for {msg_type} should exist"
+            assert entry.domain_constraint.owning_domain == MEMORY_DOMAIN
+
+    def test_all_entries_are_enabled(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Every registered entry is enabled."""
+        for msg_type in TestHasMessageType.ALL_MESSAGE_TYPES:
+            entry = frozen_registry.get_entry(msg_type)
+            assert entry is not None
+            assert entry.enabled is True
+
+    def test_all_entries_have_descriptions(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Every registered entry has a non-empty description."""
+        for msg_type in TestHasMessageType.ALL_MESSAGE_TYPES:
+            entry = frozen_registry.get_entry(msg_type)
+            assert entry is not None
+            assert entry.description is not None
+            assert len(entry.description) > 0
+
+
+# =============================================================================
+# Category Validation
+# =============================================================================
+
+
+class TestCategoryAssignment:
+    """Verify correct EnumMessageCategory assignment per type."""
+
+    EVENT_TYPES = [
+        "ModelIntentClassifiedEvent",
+        "ModelIntentStorageResponse",
+        "ModelMemoryRetrievalResponse",
+        "ModelMemoryStorageResponse",
+        "ModelAgentCoordinatorResponse",
+        "ModelNotificationEvent",
+    ]
+
+    COMMAND_TYPES = [
+        "ModelIntentStorageRequest",
+        "ModelMemoryRetrievalRequest",
+        "ModelMemoryStorageRequest",
+        "ModelAgentCoordinatorRequest",
+    ]
+
+    @pytest.mark.parametrize("message_type", EVENT_TYPES)
+    def test_event_category(
+        self, frozen_registry: RegistryMessageType, message_type: str
+    ) -> None:
+        """Event types have EVENT allowed category."""
+        entry = frozen_registry.get_entry(message_type)
+        assert entry is not None
+        assert EnumMessageCategory.EVENT in entry.allowed_categories
+
+    @pytest.mark.parametrize("message_type", COMMAND_TYPES)
+    def test_command_category(
+        self, frozen_registry: RegistryMessageType, message_type: str
+    ) -> None:
+        """Command types have COMMAND allowed category."""
+        entry = frozen_registry.get_entry(message_type)
+        assert entry is not None
+        assert EnumMessageCategory.COMMAND in entry.allowed_categories
+
+
+# =============================================================================
+# Handler ID Validation
+# =============================================================================
+
+
+class TestHandlerIds:
+    """Verify handler_id assignments match node directory names."""
+
+    HANDLER_MAP = {
+        "ModelIntentClassifiedEvent": ("intent_event_consumer_effect",),
+        "ModelIntentStorageRequest": ("intent_storage_effect",),
+        "ModelIntentStorageResponse": ("intent_storage_effect",),
+        "ModelMemoryRetrievalRequest": ("memory_retrieval_effect",),
+        "ModelMemoryRetrievalResponse": ("memory_retrieval_effect",),
+        "ModelMemoryStorageRequest": ("memory_storage_effect",),
+        "ModelMemoryStorageResponse": ("memory_storage_effect",),
+        "ModelAgentCoordinatorRequest": ("agent_coordinator_orchestrator",),
+        "ModelAgentCoordinatorResponse": ("agent_coordinator_orchestrator",),
+        "ModelNotificationEvent": ("agent_coordinator_orchestrator",),
+    }
+
+    @pytest.mark.parametrize(
+        ("message_type", "expected_handlers"),
+        list(HANDLER_MAP.items()),
+    )
+    def test_handler_id(
+        self,
+        frozen_registry: RegistryMessageType,
+        message_type: str,
+        expected_handlers: tuple[str, ...],
+    ) -> None:
+        """Handler IDs match the expected node directory names."""
+        entry = frozen_registry.get_entry(message_type)
+        assert entry is not None
+        for handler_id in expected_handlers:
+            assert handler_id in entry.handler_ids, (
+                f"Expected handler '{handler_id}' for '{message_type}', "
+                f"got {entry.handler_ids}"
+            )
+
+
+# =============================================================================
+# Freeze Enforcement
+# =============================================================================
+
+
+class TestFreezeEnforcement:
+    """Verify registration after freeze raises ModelOnexError."""
+
+    def test_registration_after_freeze_raises(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Calling register_simple after freeze raises ModelOnexError."""
+        with pytest.raises(ModelOnexError):
+            frozen_registry.register_simple(
+                message_type="ShouldFail",
+                handler_id="test-handler",
+                category=EnumMessageCategory.EVENT,
+                domain="test",
+            )
+
+    def test_register_function_after_freeze_raises(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Calling register_memory_message_types on frozen registry raises."""
+        with pytest.raises(ModelOnexError):
+            register_memory_message_types(frozen_registry)
+
+
+# =============================================================================
+# Startup Validation
+# =============================================================================
+
+
+class TestStartupValidation:
+    """Verify validate_startup() on a clean memory registry."""
+
+    def test_no_validation_errors(self, frozen_registry: RegistryMessageType) -> None:
+        """validate_startup() returns empty list (no errors)."""
+        errors = frozen_registry.validate_startup()
+        assert errors == [], f"Expected no validation errors, got: {errors}"
+
+    def test_validation_with_available_handlers(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """validate_startup with all handler IDs available returns no errors."""
+        all_handler_ids = {
+            "intent_event_consumer_effect",
+            "intent_storage_effect",
+            "memory_retrieval_effect",
+            "memory_storage_effect",
+            "agent_coordinator_orchestrator",
+        }
+        errors = frozen_registry.validate_startup(
+            available_handler_ids=all_handler_ids,
+        )
+        assert errors == [], f"Expected no validation errors, got: {errors}"
+
+    def test_validation_missing_handler_reports_error(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """validate_startup reports missing handlers when subset provided."""
+        partial_handlers = {"intent_event_consumer_effect"}
+        errors = frozen_registry.validate_startup(
+            available_handler_ids=partial_handlers,
+        )
+        assert len(errors) > 0, "Expected validation errors for missing handlers"
+
+
+# =============================================================================
+# Registry Properties
+# =============================================================================
+
+
+class TestRegistryProperties:
+    """Verify registry metadata after memory registration."""
+
+    def test_is_frozen(self, frozen_registry: RegistryMessageType) -> None:
+        """Registry is frozen after registration."""
+        assert frozen_registry.is_frozen
+
+    def test_handler_count(self, frozen_registry: RegistryMessageType) -> None:
+        """Registry tracks the correct number of unique handlers."""
+        # 5 unique handler IDs across all 10 registrations
+        assert frozen_registry.handler_count == 5
+
+    def test_domain_count(self, frozen_registry: RegistryMessageType) -> None:
+        """Registry tracks exactly 1 domain (memory)."""
+        assert frozen_registry.domain_count == 1
+
+    def test_memory_domain_constant(self) -> None:
+        """MEMORY_DOMAIN is 'memory'."""
+        assert MEMORY_DOMAIN == "memory"

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -53,6 +53,7 @@ def frozen_registry(registry: RegistryMessageType) -> RegistryMessageType:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestRegistrationCount:
     """Verify correct number of message types registered."""
 
@@ -79,6 +80,7 @@ class TestRegistrationCount:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestHasMessageType:
     """Verify all registered types are discoverable via has_message_type."""
 
@@ -121,6 +123,7 @@ class TestHasMessageType:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestGetEntry:
     """Verify entry details are correct for all registered types."""
 
@@ -158,6 +161,7 @@ class TestGetEntry:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestCategoryAssignment:
     """Verify correct EnumMessageCategory assignment per type."""
 
@@ -201,6 +205,7 @@ class TestCategoryAssignment:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestHandlerIds:
     """Verify handler_id assignments match node directory names."""
 
@@ -241,6 +246,7 @@ class TestHandlerIds:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestFreezeEnforcement:
     """Verify registration after freeze raises ModelOnexError."""
 
@@ -269,6 +275,7 @@ class TestFreezeEnforcement:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestStartupValidation:
     """Verify validate_startup() on a clean memory registry."""
 
@@ -309,6 +316,7 @@ class TestStartupValidation:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestRegistryProperties:
     """Verify registry metadata after memory registration."""
 
@@ -335,6 +343,7 @@ class TestRegistryProperties:
 # =============================================================================
 
 
+@pytest.mark.unit
 class TestRegistrationObservability:
     """Verify readiness flag and metric counters after registration."""
 
@@ -349,9 +358,9 @@ class TestRegistrationObservability:
         metrics = get_registration_metrics()
         assert metrics["registered_count"] == EXPECTED_MESSAGE_TYPE_COUNT
         assert metrics["expected_count"] == EXPECTED_MESSAGE_TYPE_COUNT
-        # failure_count is cumulative across the process so we only check
-        # it is non-negative (other tests may have triggered failures).
-        assert metrics["failure_count"] >= 0
+        # failure_count is reset at the start of each call, so a successful
+        # registration always reports zero failures.
+        assert metrics["failure_count"] == 0
 
     def test_readiness_false_after_failure(
         self, frozen_registry: RegistryMessageType
@@ -364,9 +373,8 @@ class TestRegistrationObservability:
     def test_failure_count_increments(
         self, frozen_registry: RegistryMessageType
     ) -> None:
-        """Failure counter increments on registration error."""
-        before = get_registration_metrics()["failure_count"]
+        """Failure counter is 1 after a single failed registration call."""
         with pytest.raises(ModelOnexError):
             register_memory_message_types(frozen_registry)
         after = get_registration_metrics()["failure_count"]
-        assert after == before + 1
+        assert after == 1

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -24,6 +24,8 @@ from omnibase_infra.runtime.registry import RegistryMessageType
 from omnimemory.runtime.message_type_registration import (
     EXPECTED_MESSAGE_TYPE_COUNT,
     MEMORY_DOMAIN,
+    get_registration_metrics,
+    is_registry_ready,
     register_memory_message_types,
 )
 
@@ -327,3 +329,45 @@ class TestRegistryProperties:
     def test_memory_domain_constant(self) -> None:
         """MEMORY_DOMAIN is 'memory'."""
         assert MEMORY_DOMAIN == "memory"
+
+
+# =============================================================================
+# Observability: Readiness & Metrics
+# =============================================================================
+
+
+class TestRegistrationObservability:
+    """Verify readiness flag and metric counters after registration."""
+
+    def test_is_ready_after_success(self, registry: RegistryMessageType) -> None:
+        """is_registry_ready() returns True after successful registration."""
+        register_memory_message_types(registry)
+        assert is_registry_ready() is True
+
+    def test_metrics_after_success(self, registry: RegistryMessageType) -> None:
+        """get_registration_metrics() reports correct counts after success."""
+        register_memory_message_types(registry)
+        metrics = get_registration_metrics()
+        assert metrics["registered_count"] == EXPECTED_MESSAGE_TYPE_COUNT
+        assert metrics["expected_count"] == EXPECTED_MESSAGE_TYPE_COUNT
+        # failure_count is cumulative across the process so we only check
+        # it is non-negative (other tests may have triggered failures).
+        assert metrics["failure_count"] >= 0
+
+    def test_readiness_false_after_failure(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """is_registry_ready() returns False after a failed registration attempt."""
+        with pytest.raises(ModelOnexError):
+            register_memory_message_types(frozen_registry)
+        assert is_registry_ready() is False
+
+    def test_failure_count_increments(
+        self, frozen_registry: RegistryMessageType
+    ) -> None:
+        """Failure counter increments on registration error."""
+        before = get_registration_metrics()["failure_count"]
+        with pytest.raises(ModelOnexError):
+            register_memory_message_types(frozen_registry)
+        after = get_registration_metrics()["failure_count"]
+        assert after == before + 1

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -21,6 +21,7 @@ from omnibase_core.models.errors import ModelOnexError
 from omnibase_infra.enums import EnumMessageCategory
 from omnibase_infra.runtime.registry import RegistryMessageType
 
+import omnimemory.runtime.message_type_registration as _mtr_module
 from omnimemory.runtime.message_type_registration import (
     EXPECTED_MESSAGE_TYPE_COUNT,
     MEMORY_DOMAIN,
@@ -346,6 +347,20 @@ class TestRegistryProperties:
 @pytest.mark.unit
 class TestRegistrationObservability:
     """Verify readiness flag and metric counters after registration."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_observability_globals(self) -> None:
+        """Reset module-level observability state before each test.
+
+        Without this reset the globals (_registry_ready, _registered_count,
+        _registration_failure_count) persist across tests.  Under parallel
+        execution (pytest-xdist) or reordered collection this causes flaky
+        assertions that depend on "clean slate" state.
+        """
+        with _mtr_module._registry_lock:
+            _mtr_module._registry_ready = False
+            _mtr_module._registered_count = 0
+            _mtr_module._registration_failure_count = 0
 
     def test_is_ready_after_success(self, registry: RegistryMessageType) -> None:
         """is_registry_ready() returns True after successful registration."""

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -21,7 +21,6 @@ from omnibase_core.models.errors import ModelOnexError
 from omnibase_infra.enums import EnumMessageCategory
 from omnibase_infra.runtime.registry import RegistryMessageType
 
-import omnimemory.runtime.message_type_registration as _mtr_module
 from omnimemory.runtime.message_type_registration import (
     EXPECTED_MESSAGE_TYPE_COUNT,
     MEMORY_DOMAIN,
@@ -347,20 +346,6 @@ class TestRegistryProperties:
 @pytest.mark.unit
 class TestRegistrationObservability:
     """Verify readiness flag and metric counters after registration."""
-
-    @pytest.fixture(autouse=True)
-    def _reset_observability_globals(self) -> None:
-        """Reset module-level observability state before each test.
-
-        Without this reset the globals (_registry_ready, _registered_count,
-        _registration_failure_count) persist across tests.  Under parallel
-        execution (pytest-xdist) or reordered collection this causes flaky
-        assertions that depend on "clean slate" state.
-        """
-        with _mtr_module._registry_lock:
-            _mtr_module._registry_ready = False
-            _mtr_module._registered_count = 0
-            _mtr_module._registration_failure_count = 0
 
     def test_is_ready_after_success(self, registry: RegistryMessageType) -> None:
         """is_registry_ready() returns True after successful registration."""

--- a/tests/unit/runtime/test_message_type_registration.py
+++ b/tests/unit/runtime/test_message_type_registration.py
@@ -230,11 +230,10 @@ class TestHandlerIds:
         """Handler IDs match the expected node directory names."""
         entry = frozen_registry.get_entry(message_type)
         assert entry is not None
-        for handler_id in expected_handlers:
-            assert handler_id in entry.handler_ids, (
-                f"Expected handler '{handler_id}' for '{message_type}', "
-                f"got {entry.handler_ids}"
-            )
+        assert set(entry.handler_ids) == set(expected_handlers), (
+            f"Expected handlers {expected_handlers} for '{message_type}', "
+            f"got {entry.handler_ids}"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Register all 10 omnimemory boundary-crossing wire models (events, commands, responses) with `RegistryMessageType` during `PluginMemory.initialize()`
- Declare `onex.domain_plugins` entry point in `pyproject.toml` for kernel auto-discovery
- Add comprehensive unit tests (46) and integration tests (3) for registration and entry point discovery

## Changes

| File | Description |
|------|-------------|
| `src/omnimemory/runtime/message_type_registration.py` | New module: registers 10 message types across 5 handler IDs |
| `src/omnimemory/runtime/plugin.py` | Wire registry creation, freeze, and validation into `PluginMemory.initialize()` |
| `src/omnimemory/runtime/__init__.py` | Lazy-import support for new registration symbols |
| `pyproject.toml` | `[tool.poetry.plugins."onex.domain_plugins"]` entry point |
| `tests/unit/runtime/test_message_type_registration.py` | 46 unit tests |
| `tests/integration/test_entry_point_discovery.py` | 3 integration tests |

## Registered Wire Models

| Message Type | Handler ID | Category |
|---|---|---|
| `ModelIntentClassifiedEvent` | `intent_event_consumer_effect` | EVENT |
| `ModelIntentStorageRequest` | `intent_storage_effect` | COMMAND |
| `ModelIntentStorageResponse` | `intent_storage_effect` | EVENT |
| `ModelMemoryRetrievalRequest` | `memory_retrieval_effect` | COMMAND |
| `ModelMemoryRetrievalResponse` | `memory_retrieval_effect` | EVENT |
| `ModelMemoryStorageRequest` | `memory_storage_effect` | COMMAND |
| `ModelMemoryStorageResponse` | `memory_storage_effect` | EVENT |
| `ModelAgentCoordinatorRequest` | `agent_coordinator_orchestrator` | COMMAND |
| `ModelAgentCoordinatorResponse` | `agent_coordinator_orchestrator` | EVENT |
| `ModelNotificationEvent` | `agent_coordinator_orchestrator` | EVENT |

## Test plan

- [x] 46 unit tests covering registration count, category validation, handler IDs, freeze enforcement, startup validation
- [x] 3 integration tests verifying entry point discovery via `importlib.metadata.entry_points()`
- [x] Full regression: 398/398 unit tests passing
- [x] mypy strict, ruff lint, ruff format, pre-commit hooks all passing

Closes OMN-2217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory domain plugin is registered and discoverable via the application's plugin system.
  * Runtime exposes memory message-type registration APIs and registers 10 memory-related message types.
  * Public observability: readiness checks and registration metrics for memory message types.

* **Tests**
  * Added integration tests for plugin discovery.
  * Added comprehensive unit tests validating registration, freeze/startup behavior, readiness, and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->