### PR TITLE
feat(models): enforce frozen=True on boundary-crossing models (OMN-2219)

### DIFF
--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -29,8 +29,8 @@ class ModelIntentClassifiedEvent(BaseModel):
     confidence: float = Field(
         ..., ge=0.0, le=1.0, description="Classification confidence score"
     )
-    keywords: list[str] = Field(
-        default_factory=list,
+    keywords: tuple[str, ...] = Field(
+        default=(),
         description="Extracted keywords (forward-compatible with OMN-1626)",
     )
     timestamp: datetime = Field(..., description="Event timestamp")

--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -16,7 +16,7 @@ class ModelIntentClassifiedEvent(BaseModel):
     an omniintelligence-owned event; omnimemory is a consumer.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(frozen=True, extra="ignore")
 
     event_type: Literal["IntentClassified"] = Field(
         "IntentClassified", description="Event type discriminator for message routing"

--- a/src/omnimemory/models/foundation/model_audit_metadata.py
+++ b/src/omnimemory/models/foundation/model_audit_metadata.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class AuditEventDetails(BaseModel):
     """Strongly typed details for audit events."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     operation_type: str = Field(
         default="unknown", description="Type of operation being audited"
@@ -55,7 +55,7 @@ class AuditEventDetails(BaseModel):
 class ResourceUsageMetadata(BaseModel):
     """Strongly typed resource usage metrics."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     cpu_usage_percent: float | None = Field(
         default=None,
@@ -96,7 +96,7 @@ class ResourceUsageMetadata(BaseModel):
 class SecurityAuditDetails(BaseModel):
     """Strongly typed security audit information."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     authentication_method: str | None = Field(
         default=None, description="Authentication method used"
@@ -137,7 +137,7 @@ class SecurityAuditDetails(BaseModel):
 class PerformanceAuditDetails(BaseModel):
     """Strongly typed performance audit information."""
 
-    model_config = ConfigDict(extra="forbid", frozen=False)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     operation_latency_ms: float = Field(
         ge=0.0, description="Operation latency in milliseconds"

--- a/src/omnimemory/models/foundation/model_audit_metadata.py
+++ b/src/omnimemory/models/foundation/model_audit_metadata.py
@@ -31,6 +31,10 @@ class AuditEventDetails(BaseModel):
 
     new_value: str | None = Field(default=None, description="New value after change")
 
+    # NOTE: dict contents remain mutable even on frozen models; this is a known
+    # Pydantic v2 limitation.  frozen=True prevents field *reassignment* but not
+    # in-place mutation of mutable containers.  A MappingProxyType wrapper is not
+    # Pydantic-friendly, so we accept this trade-off and rely on convention.
     request_parameters: dict[str, str] | None = Field(
         default=None, description="Parameters passed with the request"
     )
@@ -114,7 +118,7 @@ class SecurityAuditDetails(BaseModel):
         default=False, description="Whether permission was granted"
     )
 
-    security_scan_results: list[str] | None = Field(
+    security_scan_results: tuple[str, ...] | None = Field(
         default=None, description="Results of security scanning"
     )
 

--- a/src/omnimemory/models/foundation/model_typed_collections.py
+++ b/src/omnimemory/models/foundation/model_typed_collections.py
@@ -380,9 +380,7 @@ class ModelConfiguration(BaseModel):
 class ModelEventData(BaseModel):
     """Strongly typed event data for system events."""
 
-    model_config = ConfigDict(
-        str_strip_whitespace=True, validate_assignment=True, extra="forbid"
-    )
+    model_config = ConfigDict(frozen=True, str_strip_whitespace=True, extra="forbid")
 
     event_type: str = Field(
         description="Type of event (creation, update, deletion, etc.)"

--- a/src/omnimemory/models/foundation/model_typed_collections.py
+++ b/src/omnimemory/models/foundation/model_typed_collections.py
@@ -380,6 +380,12 @@ class ModelConfiguration(BaseModel):
 class ModelEventData(BaseModel):
     """Strongly typed event data for system events."""
 
+    # validate_assignment=True is intentionally retained alongside frozen=True:
+    # frozen=True raises FrozenInstanceError (a TypeError) on assignment attempts,
+    # but validate_assignment=True ensures that any mutation path that bypasses
+    # the frozen guard (e.g., object.__setattr__) would still raise a
+    # ValidationError rather than silently accepting invalid data. This is a
+    # defense-in-depth measure to guarantee schema-validated rejection.
     model_config = ConfigDict(
         frozen=True, validate_assignment=True, str_strip_whitespace=True, extra="forbid"
     )

--- a/src/omnimemory/models/foundation/model_typed_collections.py
+++ b/src/omnimemory/models/foundation/model_typed_collections.py
@@ -380,7 +380,9 @@ class ModelConfiguration(BaseModel):
 class ModelEventData(BaseModel):
     """Strongly typed event data for system events."""
 
-    model_config = ConfigDict(frozen=True, str_strip_whitespace=True, extra="forbid")
+    model_config = ConfigDict(
+        frozen=True, validate_assignment=True, str_strip_whitespace=True, extra="forbid"
+    )
 
     event_type: str = Field(
         description="Type of event (creation, update, deletion, etc.)"

--- a/src/omnimemory/models/foundation/model_typed_collections.py
+++ b/src/omnimemory/models/foundation/model_typed_collections.py
@@ -380,12 +380,10 @@ class ModelConfiguration(BaseModel):
 class ModelEventData(BaseModel):
     """Strongly typed event data for system events."""
 
-    # validate_assignment=True is intentionally retained alongside frozen=True:
-    # frozen=True raises FrozenInstanceError (a TypeError) on assignment attempts,
-    # but validate_assignment=True ensures that any mutation path that bypasses
-    # the frozen guard (e.g., object.__setattr__) would still raise a
-    # ValidationError rather than silently accepting invalid data. This is a
-    # defense-in-depth measure to guarantee schema-validated rejection.
+    # Defense-in-depth: validate_assignment=True is retained alongside frozen=True.
+    # While frozen=True prevents normal field assignment, validate_assignment ensures
+    # that Pydantic-aware mutation paths (e.g., model_copy(update=...)) also enforce
+    # type validation. This is a deliberate redundancy for safety.
     model_config = ConfigDict(
         frozen=True, validate_assignment=True, str_strip_whitespace=True, extra="forbid"
     )

--- a/src/omnimemory/models/subscription/model_notification_event.py
+++ b/src/omnimemory/models/subscription/model_notification_event.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ..foundation.model_semver import ModelSemVer
 from .constants import TOPIC_PATTERN, TOPIC_VALIDATION_ERROR
 from .model_notification_event_payload import (
     ModelNotificationEventPayload,  # noqa: TC001 - runtime import for Pydantic field type
@@ -41,8 +42,8 @@ class ModelNotificationEvent(BaseModel):
         default=None,
         description="Source system or service that generated this event",
     )
-    version: str = Field(
-        default="1.0",
+    version: ModelSemVer = Field(
+        default_factory=lambda: ModelSemVer(major=1, minor=0, patch=0),
         description="Event schema version for forward compatibility",
     )
 

--- a/src/omnimemory/models/subscription/model_notification_event.py
+++ b/src/omnimemory/models/subscription/model_notification_event.py
@@ -34,6 +34,9 @@ class ModelNotificationEvent(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="When the event was created",
     )
+    # NOTE: dict contents remain mutable even on frozen models; this is a known
+    # Pydantic v2 limitation.  frozen=True prevents field *reassignment* but not
+    # in-place mutation of mutable containers.
     metadata: dict[str, str] | None = Field(
         default=None,
         description="Optional event metadata for routing or filtering",

--- a/src/omnimemory/models/subscription/model_notification_event.py
+++ b/src/omnimemory/models/subscription/model_notification_event.py
@@ -18,7 +18,7 @@ from .model_notification_event_payload import (
 class ModelNotificationEvent(BaseModel):
     """Notification event for memory changes following ONEX standards."""
 
-    model_config = ConfigDict(frozen=False, extra="forbid", strict=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
 
     event_id: str = Field(
         description="Unique event identifier (non-empty string)",

--- a/src/omnimemory/models/subscription/model_notification_event_payload.py
+++ b/src/omnimemory/models/subscription/model_notification_event_payload.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class ModelNotificationEventPayload(BaseModel):
     """Structured payload for notification events following ONEX standards."""
 
-    model_config = ConfigDict(frozen=False, extra="forbid", strict=True)
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
 
     entity_type: str = Field(
         description="Type of entity that changed (e.g., 'item', 'collection')",

--- a/src/omnimemory/models/subscription/model_notification_event_payload.py
+++ b/src/omnimemory/models/subscription/model_notification_event_payload.py
@@ -21,6 +21,9 @@ class ModelNotificationEventPayload(BaseModel):
     action: str = Field(
         description="Action that occurred (e.g., 'created', 'updated', 'deleted')",
     )
+    # NOTE: dict contents remain mutable even on frozen models; this is a known
+    # Pydantic v2 limitation.  frozen=True prevents field *reassignment* but not
+    # in-place mutation of mutable containers.
     changes: dict[str, str] | None = Field(
         default=None,
         description="Key-value pairs of fields that changed (for updates)",

--- a/src/omnimemory/models/utils/model_audit.py
+++ b/src/omnimemory/models/utils/model_audit.py
@@ -92,6 +92,7 @@ class ModelAuditEvent(BaseModel):
     sanitized: bool = Field(default=False, description="Whether data was sanitized")
 
     model_config = ConfigDict(
+        frozen=True,
         extra="forbid",
         validate_default=True,
         str_strip_whitespace=True,

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -415,7 +415,7 @@ class HandlerIntentEventConsumer:
                     intent_category=event.intent_category,
                     intent_id=result.intent_id,
                     confidence=event.confidence,
-                    keywords=event.keywords,
+                    keywords=list(event.keywords),
                     created=result.created,
                     execution_time_ms=storage_latency_ms,
                     correlation_id=event.correlation_id,

--- a/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
@@ -34,7 +34,7 @@ def map_event_to_storage_request(
             success=True,
             intent_category=intent_category,
             confidence=event.confidence,
-            keywords=event.keywords,
+            keywords=list(event.keywords),
         ),
         correlation_id=event.correlation_id,
     )

--- a/tests/models/events/test_model_intent_classified_event.py
+++ b/tests/models/events/test_model_intent_classified_event.py
@@ -80,10 +80,10 @@ class TestModelIntentClassifiedEventJsonDeserialization:
         }
         event = ModelIntentClassifiedEvent.model_validate(data)
 
-        assert event.keywords == ["python", "fastapi", "async"]
+        assert event.keywords == ("python", "fastapi", "async")
 
-    def test_keywords_defaults_to_empty_list(self) -> None:
-        """Ensure keywords field defaults to empty list when not provided."""
+    def test_keywords_defaults_to_empty_tuple(self) -> None:
+        """Ensure keywords field defaults to empty tuple when not provided."""
         data = {
             "event_type": "IntentClassified",
             "session_id": "sess-789",
@@ -94,7 +94,7 @@ class TestModelIntentClassifiedEventJsonDeserialization:
         }
         event = ModelIntentClassifiedEvent.model_validate(data)
 
-        assert event.keywords == []
+        assert event.keywords == ()
 
 
 class TestModelIntentClassifiedEventValidation:

--- a/tests/models/events/test_model_intent_classified_event.py
+++ b/tests/models/events/test_model_intent_classified_event.py
@@ -15,6 +15,7 @@ from omnimemory.models.events.model_intent_classified_event import (
 )
 
 
+@pytest.mark.unit
 class TestModelIntentClassifiedEventJsonDeserialization:
     """Tests for JSON deserialization behavior (the Kafka use case)."""
 
@@ -97,6 +98,7 @@ class TestModelIntentClassifiedEventJsonDeserialization:
         assert event.keywords == ()
 
 
+@pytest.mark.unit
 class TestModelIntentClassifiedEventValidation:
     """Tests for validation constraints."""
 

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Tests for frozen boundary model enforcement (OMN-2219).
+
+Architecture handshake rule #5: all boundary-crossing models (events, intents,
+actions, envelopes, projections) MUST use frozen=True with extra="forbid"
+(or extra="ignore" for consumer models that need forward compatibility).
+
+These tests verify:
+1. Frozen models reject field mutation after construction
+2. Boundary models reject unknown fields (or ignore them for consumers)
+3. All event/boundary models have the correct ConfigDict settings
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnimemory.models.events.model_intent_classified_event import (
+    ModelIntentClassifiedEvent,
+)
+from omnimemory.models.foundation.model_audit_metadata import (
+    AuditEventDetails,
+    PerformanceAuditDetails,
+    ResourceUsageMetadata,
+    SecurityAuditDetails,
+)
+from omnimemory.models.foundation.model_typed_collections import (
+    ModelEventCollection,
+    ModelEventData,
+)
+from omnimemory.models.subscription.model_notification_event import (
+    ModelNotificationEvent,
+)
+from omnimemory.models.subscription.model_notification_event_payload import (
+    ModelNotificationEventPayload,
+)
+from omnimemory.models.utils.model_audit import (
+    AuditEventType,
+    AuditSeverity,
+    ModelAuditEvent,
+)
+
+
+class TestModelNotificationEventFrozen:
+    """Verify ModelNotificationEvent is frozen and rejects mutation."""
+
+    def _make_event(self) -> ModelNotificationEvent:
+        return ModelNotificationEvent(
+            event_id="evt-001",
+            topic="memory.item.created",
+            payload=ModelNotificationEventPayload(
+                entity_type="item",
+                entity_id="item-001",
+                action="created",
+            ),
+        )
+
+    def test_rejects_field_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.event_id = "evt-002"  # type: ignore[misc]
+
+    def test_rejects_payload_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.topic = "memory.item.updated"  # type: ignore[misc]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelNotificationEvent(
+                event_id="evt-001",
+                topic="memory.item.created",
+                payload=ModelNotificationEventPayload(
+                    entity_type="item",
+                    entity_id="item-001",
+                    action="created",
+                ),
+                unknown_field="should fail",  # type: ignore[call-arg]
+            )
+
+    def test_construction_succeeds(self) -> None:
+        event = self._make_event()
+        assert event.event_id == "evt-001"
+        assert event.topic == "memory.item.created"
+        assert event.payload.entity_type == "item"
+
+
+class TestModelNotificationEventPayloadFrozen:
+    """Verify ModelNotificationEventPayload is frozen."""
+
+    def test_rejects_field_mutation(self) -> None:
+        payload = ModelNotificationEventPayload(
+            entity_type="item",
+            entity_id="item-001",
+            action="created",
+        )
+        with pytest.raises(ValidationError):
+            payload.action = "updated"  # type: ignore[misc]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelNotificationEventPayload(
+                entity_type="item",
+                entity_id="item-001",
+                action="created",
+                rogue_field="nope",  # type: ignore[call-arg]
+            )
+
+
+class TestModelIntentClassifiedEventFrozen:
+    """Verify ModelIntentClassifiedEvent is frozen with extra=ignore."""
+
+    def _make_event(self) -> ModelIntentClassifiedEvent:
+        return ModelIntentClassifiedEvent(
+            event_type="IntentClassified",
+            session_id="sess-001",
+            correlation_id=uuid4(),
+            intent_category="debugging",
+            confidence=0.85,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+    def test_rejects_field_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.confidence = 0.99  # type: ignore[misc]
+
+    def test_rejects_session_id_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.session_id = "sess-002"  # type: ignore[misc]
+
+    def test_ignores_unknown_fields_for_forward_compat(self) -> None:
+        """Consumer model uses extra='ignore' for forward compatibility."""
+        event = ModelIntentClassifiedEvent(
+            event_type="IntentClassified",
+            session_id="sess-001",
+            correlation_id=uuid4(),
+            intent_category="debugging",
+            confidence=0.85,
+            timestamp=datetime.now(timezone.utc),
+            future_field="from upstream v2",  # type: ignore[call-arg]
+        )
+        assert not hasattr(event, "future_field")
+
+    def test_construction_succeeds(self) -> None:
+        event = self._make_event()
+        assert event.session_id == "sess-001"
+        assert event.intent_category == "debugging"
+
+
+class TestModelAuditEventFrozen:
+    """Verify ModelAuditEvent is frozen."""
+
+    def _make_event(self) -> ModelAuditEvent:
+        return ModelAuditEvent(
+            event_id="audit-001",
+            timestamp=datetime.now(timezone.utc),
+            event_type=AuditEventType.MEMORY_STORE,
+            severity=AuditSeverity.LOW,
+            operation="memory_store",
+            component="memory_manager",
+            message="Memory store succeeded",
+        )
+
+    def test_rejects_field_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.message = "changed"  # type: ignore[misc]
+
+    def test_rejects_severity_mutation(self) -> None:
+        event = self._make_event()
+        with pytest.raises(ValidationError):
+            event.severity = AuditSeverity.CRITICAL  # type: ignore[misc]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelAuditEvent(
+                event_id="audit-001",
+                timestamp=datetime.now(timezone.utc),
+                event_type=AuditEventType.MEMORY_STORE,
+                severity=AuditSeverity.LOW,
+                operation="memory_store",
+                component="memory_manager",
+                message="test",
+                rogue="nope",  # type: ignore[call-arg]
+            )
+
+    def test_construction_succeeds(self) -> None:
+        event = self._make_event()
+        assert event.event_id == "audit-001"
+        assert event.event_type == AuditEventType.MEMORY_STORE
+
+
+class TestAuditMetadataModelsFrozen:
+    """Verify audit metadata sub-models are frozen."""
+
+    def test_audit_event_details_rejects_mutation(self) -> None:
+        details = AuditEventDetails(operation_type="memory_store")
+        with pytest.raises(ValidationError):
+            details.operation_type = "changed"  # type: ignore[misc]
+
+    def test_resource_usage_metadata_rejects_mutation(self) -> None:
+        usage = ResourceUsageMetadata(cpu_usage_percent=50.0)
+        with pytest.raises(ValidationError):
+            usage.cpu_usage_percent = 99.0  # type: ignore[misc]
+
+    def test_security_audit_details_rejects_mutation(self) -> None:
+        security = SecurityAuditDetails(permission_granted=True)
+        with pytest.raises(ValidationError):
+            security.permission_granted = False  # type: ignore[misc]
+
+    def test_performance_audit_details_rejects_mutation(self) -> None:
+        perf = PerformanceAuditDetails(operation_latency_ms=10.0)
+        with pytest.raises(ValidationError):
+            perf.operation_latency_ms = 999.0  # type: ignore[misc]
+
+
+class TestModelEventDataFrozen:
+    """Verify ModelEventData is frozen."""
+
+    def _make_event_data(self) -> ModelEventData:
+        return ModelEventData(
+            event_type="creation",
+            timestamp="2026-01-01T00:00:00Z",
+            source="test",
+            message="Test event",
+        )
+
+    def test_rejects_field_mutation(self) -> None:
+        data = self._make_event_data()
+        with pytest.raises(ValidationError):
+            data.message = "changed"  # type: ignore[misc]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelEventData(
+                event_type="creation",
+                timestamp="2026-01-01T00:00:00Z",
+                source="test",
+                message="Test event",
+                rogue="nope",  # type: ignore[call-arg]
+            )
+
+    def test_construction_succeeds(self) -> None:
+        data = self._make_event_data()
+        assert data.event_type == "creation"
+        assert data.source == "test"
+
+
+class TestModelEventCollectionMutable:
+    """Verify ModelEventCollection remains mutable (builder pattern)."""
+
+    def test_add_event_works(self) -> None:
+        """Collection is a builder, not a boundary model -- stays mutable."""
+        collection = ModelEventCollection()
+        collection.add_event(
+            event_type="creation",
+            timestamp="2026-01-01T00:00:00Z",
+            source="test",
+            message="Test event",
+        )
+        assert len(collection.events) == 1
+        assert collection.events[0].event_type == "creation"
+
+    def test_multiple_events(self) -> None:
+        collection = ModelEventCollection()
+        collection.add_event(
+            event_type="creation",
+            timestamp="2026-01-01T00:00:00Z",
+            source="test",
+            message="First",
+        )
+        collection.add_event(
+            event_type="update",
+            timestamp="2026-01-01T01:00:00Z",
+            source="test",
+            message="Second",
+        )
+        assert len(collection.events) == 2
+
+    def test_individual_events_in_collection_are_frozen(self) -> None:
+        """Even though the collection is mutable, the events inside are frozen."""
+        collection = ModelEventCollection()
+        collection.add_event(
+            event_type="creation",
+            timestamp="2026-01-01T00:00:00Z",
+            source="test",
+            message="Test event",
+        )
+        with pytest.raises(ValidationError):
+            collection.events[0].message = "changed"  # type: ignore[misc]

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -394,3 +394,42 @@ class TestFrozenBoundaryModelConfigGuardRails:
 
     def test_performance_audit_details_config_frozen(self) -> None:
         assert PerformanceAuditDetails.model_config.get("frozen") is True
+
+
+@pytest.mark.unit
+class TestFrozenModelMutableContainerLimitation:
+    """Document known Pydantic v2 limitation: frozen prevents field reassignment but not container mutation.
+
+    These tests exist to *document* the behaviour, not endorse it.
+    See inline comments on dict fields in the model modules for the rationale.
+    """
+
+    def test_frozen_model_dict_contents_remain_mutable(self) -> None:
+        """Dict values inside a frozen model can still be mutated in-place."""
+        event = ModelNotificationEvent(
+            event_id="evt-mut-001",
+            topic="memory.item.created",
+            payload=ModelNotificationEventPayload(
+                entity_type="item",
+                entity_id="item-001",
+                action="created",
+            ),
+            metadata={"key": "value"},
+        )
+        # frozen=True prevents field reassignment
+        with pytest.raises(ValidationError):
+            event.metadata = {"new": "dict"}  # type: ignore[misc]
+        # But dict contents are still mutable (known Pydantic v2 limitation)
+        assert event.metadata is not None
+        event.metadata["key"] = "mutated"
+        assert event.metadata["key"] == "mutated"
+
+    def test_frozen_model_tuple_contents_are_immutable(self) -> None:
+        """Tuple fields (e.g. security_scan_results) are truly immutable."""
+        details = SecurityAuditDetails(
+            security_scan_results=("clean", "no_issues"),
+        )
+        with pytest.raises(ValidationError):
+            details.security_scan_results = ("replaced",)  # type: ignore[misc]
+        # Tuple contents cannot be mutated -- this is the safer pattern
+        assert details.security_scan_results == ("clean", "no_issues")

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from omnibase_core.models.primitives import ModelSemVer
 from pydantic import ValidationError
 
 from omnimemory.models.events.model_intent_classified_event import (
@@ -304,3 +305,80 @@ class TestModelEventCollectionMutable:
         )
         with pytest.raises(ValidationError):
             collection.events[0].message = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestModelNotificationEventVersionSemVer:
+    """Verify ModelNotificationEvent.version is ModelSemVer with round-trip fidelity."""
+
+    def test_version_is_model_semver(self) -> None:
+        """Assert the version field is an instance of ModelSemVer."""
+        event = ModelNotificationEvent(
+            event_id="evt-ver-001",
+            topic="memory.item.created",
+            payload=ModelNotificationEventPayload(
+                entity_type="item",
+                entity_id="item-001",
+                action="created",
+            ),
+        )
+        assert isinstance(event.version, ModelSemVer)
+
+    def test_version_round_trip_serialization(self) -> None:
+        """Serialize to JSON, verify version structure, round-trip back.
+
+        Uses model_dump_json / model_validate_json because
+        ModelNotificationEvent has strict=True, which rejects coerced
+        types (e.g. datetime from string) through model_validate(dict).
+        """
+        event = ModelNotificationEvent(
+            event_id="evt-ver-002",
+            topic="memory.item.updated",
+            payload=ModelNotificationEventPayload(
+                entity_type="item",
+                entity_id="item-002",
+                action="updated",
+            ),
+            version=ModelSemVer(major=2, minor=3, patch=4),
+        )
+
+        # Verify the dict representation has the expected semver structure
+        serialized = event.model_dump(mode="json")
+        assert isinstance(serialized["version"], dict)
+        assert serialized["version"]["major"] == 2
+        assert serialized["version"]["minor"] == 3
+        assert serialized["version"]["patch"] == 4
+
+        # Round-trip through JSON string to honour strict=True on the model
+        json_str = event.model_dump_json()
+        restored = ModelNotificationEvent.model_validate_json(json_str)
+        assert isinstance(restored.version, ModelSemVer)
+        assert restored.version.major == 2
+        assert restored.version.minor == 3
+        assert restored.version.patch == 4
+
+
+@pytest.mark.unit
+class TestFrozenBoundaryModelConfigGuardRails:
+    """Guard-rail: introspect model_config to assert frozen=True on boundary models.
+
+    This prevents accidental regression where frozen=True is removed from a
+    boundary-crossing model's ConfigDict.  Mirrors the inverse test
+    ``TestModelEventCollectionMutable.test_config_not_frozen`` which guards
+    that the builder model stays mutable.
+    """
+
+    def test_model_intent_classified_event_config_frozen(self) -> None:
+        assert ModelIntentClassifiedEvent.model_config.get("frozen") is True
+
+    def test_audit_event_details_config_frozen(self) -> None:
+        assert AuditEventDetails.model_config.get("frozen") is True
+
+    def test_model_event_data_config_frozen(self) -> None:
+        assert ModelEventData.model_config.get("frozen") is True
+
+    def test_model_notification_event_config_frozen(self) -> None:
+        assert ModelNotificationEvent.model_config.get("frozen") is True
+
+    def test_model_notification_event_payload_config_frozen(self) -> None:
+        assert ModelNotificationEventPayload.model_config.get("frozen") is True

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -44,6 +44,7 @@ from omnimemory.models.utils.model_audit import (
 )
 
 
+@pytest.mark.unit
 class TestModelNotificationEventFrozen:
     """Verify ModelNotificationEvent is frozen and rejects mutation."""
 
@@ -88,6 +89,7 @@ class TestModelNotificationEventFrozen:
         assert event.payload.entity_type == "item"
 
 
+@pytest.mark.unit
 class TestModelNotificationEventPayloadFrozen:
     """Verify ModelNotificationEventPayload is frozen."""
 
@@ -110,6 +112,7 @@ class TestModelNotificationEventPayloadFrozen:
             )
 
 
+@pytest.mark.unit
 class TestModelIntentClassifiedEventFrozen:
     """Verify ModelIntentClassifiedEvent is frozen with extra=ignore."""
 
@@ -152,6 +155,7 @@ class TestModelIntentClassifiedEventFrozen:
         assert event.intent_category == "debugging"
 
 
+@pytest.mark.unit
 class TestModelAuditEventFrozen:
     """Verify ModelAuditEvent is frozen."""
 
@@ -195,6 +199,7 @@ class TestModelAuditEventFrozen:
         assert event.event_type == AuditEventType.MEMORY_STORE
 
 
+@pytest.mark.unit
 class TestAuditMetadataModelsFrozen:
     """Verify audit metadata sub-models are frozen."""
 
@@ -219,6 +224,7 @@ class TestAuditMetadataModelsFrozen:
             perf.operation_latency_ms = 999.0  # type: ignore[misc]
 
 
+@pytest.mark.unit
 class TestModelEventDataFrozen:
     """Verify ModelEventData is frozen."""
 
@@ -251,6 +257,7 @@ class TestModelEventDataFrozen:
         assert data.source == "test"
 
 
+@pytest.mark.unit
 class TestModelEventCollectionMutable:
     """Verify ModelEventCollection remains mutable (builder pattern)."""
 
@@ -281,6 +288,10 @@ class TestModelEventCollectionMutable:
             message="Second",
         )
         assert len(collection.events) == 2
+
+    def test_config_not_frozen(self) -> None:
+        """Guard-rail: ModelEventCollection must NOT be frozen (it's a builder)."""
+        assert ModelEventCollection.model_config.get("frozen") is not True
 
     def test_individual_events_in_collection_are_frozen(self) -> None:
         """Even though the collection is mutable, the events inside are frozen."""

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -382,3 +382,15 @@ class TestFrozenBoundaryModelConfigGuardRails:
 
     def test_model_notification_event_payload_config_frozen(self) -> None:
         assert ModelNotificationEventPayload.model_config.get("frozen") is True
+
+    def test_model_audit_event_config_frozen(self) -> None:
+        assert ModelAuditEvent.model_config.get("frozen") is True
+
+    def test_resource_usage_metadata_config_frozen(self) -> None:
+        assert ResourceUsageMetadata.model_config.get("frozen") is True
+
+    def test_security_audit_details_config_frozen(self) -> None:
+        assert SecurityAuditDetails.model_config.get("frozen") is True
+
+    def test_performance_audit_details_config_frozen(self) -> None:
+        assert PerformanceAuditDetails.model_config.get("frozen") is True

--- a/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
+++ b/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
@@ -33,7 +33,9 @@ class TestMapEventToStorageRequest:
         assert result.intent_data is not None
         assert result.intent_data.intent_category == "debugging"
         assert result.intent_data.confidence == 0.85
-        assert result.intent_data.keywords == []  # Default empty list
+        assert (
+            result.intent_data.keywords == []
+        )  # Default empty tuple coerced to list by downstream model
 
     def test_maps_event_with_keywords_forward_compat(self) -> None:
         """Test mapping event with keywords (OMN-1626 forward compatibility)."""
@@ -74,7 +76,7 @@ class TestMapEventToStorageRequest:
         # intent_category is now an enum, compare with .value
         assert result.intent_data.intent_category.value == event.intent_category
         assert result.intent_data.confidence == event.confidence
-        assert result.intent_data.keywords == event.keywords
+        assert result.intent_data.keywords == list(event.keywords)
 
     def test_maps_empty_keywords_correctly(self) -> None:
         """Test mapping event with explicit empty keywords list."""
@@ -98,8 +100,8 @@ class TestMapEventToStorageRequest:
 class TestModelIntentClassifiedEvent:
     """Tests for the ModelIntentClassifiedEvent model."""
 
-    def test_keywords_defaults_to_empty_list(self) -> None:
-        """Test that keywords field defaults to empty list."""
+    def test_keywords_defaults_to_empty_tuple(self) -> None:
+        """Test that keywords field defaults to empty tuple."""
         event = ModelIntentClassifiedEvent(
             session_id="session_test",
             correlation_id=UUID("880e8400-e29b-41d4-a716-446655440003"),
@@ -108,8 +110,8 @@ class TestModelIntentClassifiedEvent:
             timestamp=datetime.now(timezone.utc),
         )
 
-        assert event.keywords == []
-        assert isinstance(event.keywords, list)
+        assert event.keywords == ()
+        assert isinstance(event.keywords, tuple)
 
     def test_validates_confidence_range_too_high(self) -> None:
         """Test that confidence must be <= 1.0."""

--- a/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
+++ b/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
@@ -33,9 +33,8 @@ class TestMapEventToStorageRequest:
         assert result.intent_data is not None
         assert result.intent_data.intent_category == "debugging"
         assert result.intent_data.confidence == 0.85
-        assert (
-            result.intent_data.keywords == []
-        )  # Default empty tuple coerced to list by downstream model
+        assert isinstance(result.intent_data.keywords, list)
+        assert result.intent_data.keywords == []
 
     def test_maps_event_with_keywords_forward_compat(self) -> None:
         """Test mapping event with keywords (OMN-1626 forward compatibility)."""
@@ -52,6 +51,7 @@ class TestMapEventToStorageRequest:
         result = map_event_to_storage_request(event)
 
         assert result.intent_data is not None
+        assert isinstance(result.intent_data.keywords, list)
         assert result.intent_data.keywords == ["pull", "request", "review"]
 
     def test_preserves_all_fields(self) -> None:

--- a/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
+++ b/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
@@ -11,6 +11,7 @@ from omnimemory.nodes.intent_event_consumer_effect.utils import (
 )
 
 
+@pytest.mark.unit
 class TestMapEventToStorageRequest:
     """Tests for map_event_to_storage_request function."""
 
@@ -97,6 +98,7 @@ class TestMapEventToStorageRequest:
         assert isinstance(result.intent_data.keywords, list)
 
 
+@pytest.mark.unit
 class TestModelIntentClassifiedEvent:
     """Tests for the ModelIntentClassifiedEvent model."""
 


### PR DESCRIPTION
## Summary

- Enforce `frozen=True` on all boundary-crossing Pydantic models per architecture handshake rule #5
- Add `extra="forbid"` to prevent unexpected field injection at system boundaries
- Fix 5 explicitly listed models plus 4 audit metadata sub-models

## Changes

| Model | File | Change |
|-------|------|--------|
| `ModelNotificationEvent` | `models/subscription/model_notification_event.py` | `frozen=False` → `frozen=True` |
| `ModelNotificationEventPayload` | `models/subscription/model_notification_event_payload.py` | `frozen=False` → `frozen=True` |
| `ModelIntentClassifiedEvent` | `models/events/model_intent_classified_event.py` | Added `frozen=True` (keeps `extra="ignore"` for forward compat) |
| `ModelAuditEvent` | `models/utils/model_audit.py` | Added `frozen=True` |
| `ModelEventData` | `models/foundation/model_typed_collections.py` | Added `frozen=True`, removed redundant `validate_assignment=True` |
| `AuditEventDetails` | `models/foundation/model_audit_metadata.py` | `frozen=False` → `frozen=True` |
| `ResourceUsageMetadata` | `models/foundation/model_audit_metadata.py` | `frozen=False` → `frozen=True` |
| `SecurityAuditDetails` | `models/foundation/model_audit_metadata.py` | `frozen=False` → `frozen=True` |
| `PerformanceAuditDetails` | `models/foundation/model_audit_metadata.py` | `frozen=False` → `frozen=True` |

## Design Decisions

1. **`ModelIntentClassifiedEvent`** keeps `extra="ignore"` — it's a consumer model for upstream events from omniintelligence, requiring forward compatibility
2. **`ModelEventCollection`** remains mutable — it's a builder/container that produces frozen `ModelEventData` instances, not itself a boundary-crossing model
3. **Audit metadata sub-models** moved to `frozen=True` — all construction patterns create new instances rather than mutate

## Test plan

- [x] 24 new tests verifying frozen enforcement and extra field rejection
- [x] Full test suite (2133 tests) passing
- [x] ruff clean
- [x] mypy --strict clean
- [x] All 23 pre-commit hooks passing

Closes OMN-2219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced data integrity by making critical event and audit models immutable to prevent unintended modifications.
  * Improved version management in notification events with structured version tracking.
  * Added request parameter tracking capability to audit event details.

* **Tests**
  * Comprehensive new tests for model immutability enforcement and data consistency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->