### PR TITLE
feat(utils): add safe_db_url_display utility for credential masking (OMN-2220)

### DIFF
--- a/src/omnimemory/utils/__init__.py
+++ b/src/omnimemory/utils/__init__.py
@@ -9,6 +9,7 @@ This package provides common utilities used across the OmniMemory system:
 - Health checking with comprehensive dependency monitoring
 - Performance monitoring helpers
 - Common validation patterns
+- Database URL display utilities for safe credential masking
 """
 
 from ..models.utils.model_concurrency import ModelConnectionPoolConfig
@@ -26,6 +27,7 @@ from .concurrency import (
     with_fair_semaphore,
     with_priority_lock,
 )
+from .db_url import safe_db_url_display
 from .error_sanitizer import (
     ErrorSanitizer,
     SanitizationLevel,
@@ -174,6 +176,8 @@ __all__ = [
     "ModelPIIPatternConfig",
     "PIIDetector",
     "PIIType",
+    # Database URL display
+    "safe_db_url_display",
     # Error Sanitization
     "SanitizationLevel",
     "ErrorSanitizer",

--- a/src/omnimemory/utils/db_url.py
+++ b/src/omnimemory/utils/db_url.py
@@ -12,7 +12,12 @@ credential masking across all omni repositories.
 
 from __future__ import annotations
 
+import logging
 import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK = "(unparseable URL)"
 
 
 def safe_db_url_display(url: str) -> str:
@@ -37,9 +42,17 @@ def safe_db_url_display(url: str) -> str:
         # A valid database URL must have a scheme starting with "postgres"
         # (covers both "postgresql" and "postgres").
         if not parsed.scheme.startswith("postgres"):
-            return "(unparseable URL)"
+            logger.warning(
+                "Rejected non-PostgreSQL DB URL scheme",
+                extra={"scheme": parsed.scheme},
+            )
+            return _FALLBACK
 
         host = parsed.hostname or "unknown"
+        # Wrap IPv6 addresses in brackets to avoid ambiguous host:port output
+        # (e.g. "::1:5432/db" is ambiguous without brackets).
+        if ":" in host:
+            host = f"[{host}]"
         port = parsed.port
         database = (parsed.path or "").lstrip("/")
         if port and database:
@@ -50,7 +63,8 @@ def safe_db_url_display(url: str) -> str:
             return f"{host}/{database}"
         return host
     except Exception:
-        return "(unparseable URL)"
+        logger.exception("Failed to parse DB URL for display")
+        return _FALLBACK
 
 
 __all__ = ["safe_db_url_display"]

--- a/src/omnimemory/utils/db_url.py
+++ b/src/omnimemory/utils/db_url.py
@@ -62,8 +62,8 @@ def safe_db_url_display(url: str) -> str:
         if database:
             return f"{host}/{database}"
         return host
-    except Exception:
-        logger.warning("Failed to parse DB URL for display")
+    except Exception as exc:
+        logger.warning("Failed to parse DB URL for display: %s", type(exc).__name__)
         return _FALLBACK
 
 

--- a/src/omnimemory/utils/db_url.py
+++ b/src/omnimemory/utils/db_url.py
@@ -63,7 +63,7 @@ def safe_db_url_display(url: str) -> str:
             return f"{host}/{database}"
         return host
     except Exception:
-        logger.exception("Failed to parse DB URL for display")
+        logger.warning("Failed to parse DB URL for display")
         return _FALLBACK
 
 

--- a/src/omnimemory/utils/db_url.py
+++ b/src/omnimemory/utils/db_url.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Database URL display utilities.
+
+Provides safe display formatting for database connection URLs by stripping
+credentials while preserving host, port, and database information for
+logging and error messages.
+
+This mirrors the omniintelligence pattern (OMN-2059) for consistent
+credential masking across all omni repositories.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+
+def safe_db_url_display(url: str) -> str:
+    """Extract hostname:port/database from a database URL, stripping credentials.
+
+    Uses urllib.parse.urlparse for safe parsing instead of fragile string
+    splitting.  Validates that the URL scheme starts with ``postgres`` to
+    avoid misleading output for non-database URLs (e.g. ``https://``).
+
+    Args:
+        url: A postgresql:// connection URL, possibly containing credentials.
+
+    Returns:
+        A display-safe string in the form ``host:port/database`` (or as much
+        as can be extracted).  Falls back to ``"(unparseable URL)"`` if parsing
+        fails or the URL is not a PostgreSQL URL.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+
+        # Reject non-PostgreSQL URLs to avoid misleading display output.
+        # A valid database URL must have a scheme starting with "postgres"
+        # (covers both "postgresql" and "postgres").
+        if not parsed.scheme.startswith("postgres"):
+            return "(unparseable URL)"
+
+        host = parsed.hostname or "unknown"
+        port = parsed.port
+        database = (parsed.path or "").lstrip("/")
+        if port and database:
+            return f"{host}:{port}/{database}"
+        if port:
+            return f"{host}:{port}"
+        if database:
+            return f"{host}/{database}"
+        return host
+    except Exception:
+        return "(unparseable URL)"
+
+
+__all__ = ["safe_db_url_display"]

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Tests for database URL display utilities.
+
+Validates that safe_db_url_display() correctly strips credentials from
+PostgreSQL connection URLs while preserving host, port, and database
+information for safe logging and error messages.
+"""
+
+from __future__ import annotations
+
+from omnimemory.utils.db_url import safe_db_url_display
+
+
+class TestSafeDbUrlDisplay:
+    """Tests for safe_db_url_display()."""
+
+    def test_full_url_strips_credentials(self) -> None:
+        """Test that user:password are stripped from a full PostgreSQL URL."""
+        url = "postgresql://myuser:secret_password@dbhost:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432/mydb"
+        assert "myuser" not in result
+        assert "secret_password" not in result
+
+    def test_url_without_password(self) -> None:
+        """Test URL with user but no password."""
+        url = "postgresql://myuser@dbhost:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432/mydb"
+        assert "myuser" not in result
+
+    def test_url_without_credentials(self) -> None:
+        """Test URL with no credentials at all."""
+        url = "postgresql://dbhost:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432/mydb"
+
+    def test_url_without_port(self) -> None:
+        """Test URL without explicit port."""
+        url = "postgresql://user:pass@dbhost/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost/mydb"
+
+    def test_url_without_database(self) -> None:
+        """Test URL without database name."""
+        url = "postgresql://user:pass@dbhost:5432"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432"
+
+    def test_url_host_only(self) -> None:
+        """Test URL with only host."""
+        url = "postgresql://user:pass@dbhost"
+        result = safe_db_url_display(url)
+        assert result == "dbhost"
+
+    def test_postgres_scheme(self) -> None:
+        """Test URL with 'postgres' scheme (shorter variant)."""
+        url = "postgres://user:pass@dbhost:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432/mydb"
+
+    def test_non_postgres_url_returns_unparseable(self) -> None:
+        """Test that non-PostgreSQL URLs return unparseable marker."""
+        result = safe_db_url_display("https://example.com/path")
+        assert result == "(unparseable URL)"
+
+    def test_mysql_url_returns_unparseable(self) -> None:
+        """Test that MySQL URLs return unparseable marker."""
+        result = safe_db_url_display("mysql://user:pass@host:3306/db")
+        assert result == "(unparseable URL)"
+
+    def test_empty_string_returns_unparseable(self) -> None:
+        """Test that empty string returns unparseable marker."""
+        result = safe_db_url_display("")
+        assert result == "(unparseable URL)"
+
+    def test_garbage_string_returns_unparseable(self) -> None:
+        """Test that non-URL garbage returns unparseable marker."""
+        result = safe_db_url_display("not a url at all")
+        assert result == "(unparseable URL)"
+
+    def test_localhost_url(self) -> None:
+        """Test standard localhost development URL."""
+        url = "postgresql://omnimemory:devpass@localhost:5432/omnimemory"
+        result = safe_db_url_display(url)
+        assert result == "localhost:5432/omnimemory"
+        assert "devpass" not in result
+
+    def test_ip_address_url(self) -> None:
+        """Test URL with IP address host."""
+        url = "postgresql://postgres:s3cret@192.168.86.200:5436/omninode_bridge"
+        result = safe_db_url_display(url)
+        assert result == "192.168.86.200:5436/omninode_bridge"
+        assert "s3cret" not in result
+        assert "postgres" not in result
+
+    def test_special_characters_in_password(self) -> None:
+        """Test URL with special characters in password."""
+        url = "postgresql://user:p%40ss%23word@dbhost:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "dbhost:5432/mydb"
+        assert "p%40ss" not in result
+
+    def test_import_from_utils_package(self) -> None:
+        """Test that safe_db_url_display is importable from utils package."""
+        from omnimemory.utils import safe_db_url_display as imported_fn
+
+        assert callable(imported_fn)
+        result = imported_fn("postgresql://u:p@host:5432/db")
+        assert result == "host:5432/db"

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -102,6 +102,30 @@ class TestSafeDbUrlDisplay:
         assert result == "dbhost:5432/mydb"
         assert "p%40ss" not in result
 
+    def test_ipv6_host_url(self) -> None:
+        """Test URL with IPv6 host preserves brackets for unambiguous output."""
+        url = "postgresql://user:pass@[::1]:5432/mydb"
+        result = safe_db_url_display(url)
+        assert result == "[::1]:5432/mydb"
+        assert "user" not in result
+        assert "pass" not in result
+
+    def test_ipv6_host_without_port(self) -> None:
+        """Test IPv6 URL without port."""
+        url = "postgresql://user:pass@[::1]/mydb"
+        result = safe_db_url_display(url)
+        assert result == "[::1]/mydb"
+
+    def test_non_postgres_url_logs_warning(self) -> None:
+        """Test that non-PostgreSQL URLs emit a structured warning."""
+        from unittest.mock import patch
+
+        with patch("omnimemory.utils.db_url.logger") as mock_logger:
+            result = safe_db_url_display("https://example.com/path")
+            assert result == "(unparseable URL)"
+            mock_logger.warning.assert_called_once()
+            assert "scheme" in str(mock_logger.warning.call_args)
+
     def test_import_from_utils_package(self) -> None:
         """Test that safe_db_url_display is importable from utils package."""
         from omnimemory.utils import safe_db_url_display as imported_fn

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -107,11 +107,11 @@ class TestSafeDbUrlDisplay:
 
     def test_ipv6_host_url(self) -> None:
         """Test URL with IPv6 host preserves brackets for unambiguous output."""
-        url = "postgresql://user:pass@[::1]:5432/mydb"
+        url = "postgresql://testuser:s3cret@[::1]:5432/mydb"
         result = safe_db_url_display(url)
         assert result == "[::1]:5432/mydb"
-        assert "user" not in result
-        assert "pass" not in result
+        assert "testuser" not in result
+        assert "s3cret" not in result
 
     def test_ipv6_host_without_port(self) -> None:
         """Test IPv6 URL without port."""
@@ -128,6 +128,22 @@ class TestSafeDbUrlDisplay:
             assert result == "(unparseable URL)"
             mock_logger.warning.assert_called_once()
             assert "scheme" in str(mock_logger.warning.call_args)
+
+    def test_sqlalchemy_asyncpg_dialect(self) -> None:
+        """Test SQLAlchemy asyncpg dialect URL."""
+        url = "postgresql+asyncpg://appuser:dbpass@db.example.com:5432/myapp"
+        result = safe_db_url_display(url)
+        assert result == "db.example.com:5432/myapp"
+        assert "appuser" not in result
+        assert "dbpass" not in result
+
+    def test_sqlalchemy_psycopg2_dialect(self) -> None:
+        """Test SQLAlchemy psycopg2 dialect URL."""
+        url = "postgresql+psycopg2://appuser:dbpass@localhost:5432/testdb"
+        result = safe_db_url_display(url)
+        assert result == "localhost:5432/testdb"
+        assert "appuser" not in result
+        assert "dbpass" not in result
 
     def test_import_from_utils_package(self) -> None:
         """Test that safe_db_url_display is importable from utils package."""

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -9,9 +9,12 @@ information for safe logging and error messages.
 
 from __future__ import annotations
 
+import pytest
+
 from omnimemory.utils.db_url import safe_db_url_display
 
 
+@pytest.mark.unit
 class TestSafeDbUrlDisplay:
     """Tests for safe_db_url_display()."""
 
@@ -89,11 +92,11 @@ class TestSafeDbUrlDisplay:
 
     def test_ip_address_url(self) -> None:
         """Test URL with IP address host."""
-        url = "postgresql://postgres:s3cret@192.168.86.200:5436/omninode_bridge"
+        url = "postgresql://dbadmin:secretpass@192.168.86.200:5436/omninode_bridge"
         result = safe_db_url_display(url)
         assert result == "192.168.86.200:5436/omninode_bridge"
-        assert "s3cret" not in result
-        assert "postgres" not in result
+        assert "secretpass" not in result
+        assert "dbadmin" not in result
 
     def test_special_characters_in_password(self) -> None:
         """Test URL with special characters in password."""

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -145,6 +145,16 @@ class TestSafeDbUrlDisplay:
         assert "appuser" not in result
         assert "dbpass" not in result
 
+    def test_query_params_stripped(self) -> None:
+        """Test that query parameters (which may contain credentials) are stripped."""
+        url = "postgresql://appuser:dbpass@db.example.com:5432/myapp?sslpassword=secret&sslmode=require"
+        result = safe_db_url_display(url)
+        assert result == "db.example.com:5432/myapp"
+        assert "sslpassword" not in result
+        assert "secret" not in result
+        assert "appuser" not in result
+        assert "dbpass" not in result
+
     def test_import_from_utils_package(self) -> None:
         """Test that safe_db_url_display is importable from utils package."""
         from omnimemory.utils import safe_db_url_display as imported_fn


### PR DESCRIPTION
## Summary

Automated PR created by ticket-pipeline.

**Ticket**: OMN-2220
**Pipeline Run**: a7e3f1c2

Migrates from shared POSTGRES_* environment variables to OMNIMEMORY_DB_URL single connection string. Most of this migration was already completed in OMN-2060. This PR adds the remaining deliverable: a `safe_db_url_display()` utility for safe credential masking in logs, matching omniintelligence's OMN-2059 pattern.

## Changes

1cb846e feat(utils): add safe_db_url_display utility for credential masking (OMN-2220)

### Files

- `src/omnimemory/utils/db_url.py` - New `safe_db_url_display()` utility that strips credentials from PostgreSQL URLs
- `src/omnimemory/utils/__init__.py` - Added import/export of new utility
- `tests/test_db_url.py` - 15 test cases covering credential stripping, edge cases, and error handling

## Test Plan

- [x] 15 new unit tests pass
- [x] Full test suite (2,164 tests) passes
- [x] mypy --strict clean
- [x] ruff check + format clean
- [x] All 24 pre-commit hooks pass
- [ ] CI passes
- [ ] CodeRabbit review addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to safely display database URLs: masks credentials while preserving host, port and database info, handles PostgreSQL variants and IPv6, and returns a clear fallback for unparseable inputs; exposed via the utils package.

* **Tests**
  * Added comprehensive tests covering many URL formats, edge cases, invalid inputs, dialect variants, and package importability.

* **Documentation**
  * Minor docstring note referencing credential-masking behavior for database URL display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->