### PR TITLE
chore: update omnimemory version pins omnibase-core 0.17→0.18, spi 0.8→0.10, infra 0.7→0.8 (OMN-2375)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ asyncio-mqtt = "^0.16.0"
 pyyaml = "^6.0.2"
 
 # ONEX dependencies - versioned releases from PyPI
-omnibase-core = "^0.17.0"
-omnibase-spi = "^0.8.0"
-omnibase-infra = "^0.7.0"
+omnibase-core = ">=0.18.0,<0.19.0"
+omnibase-spi = ">=0.10.0,<0.11.0"
+omnibase-infra = ">=0.8.0,<0.9.0"
 
 # Logging and monitoring
 # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)


### PR DESCRIPTION
## Summary

- Updates `omnibase-core` pin from `^0.17.0` → `>=0.18.0,<0.19.0` (hard install conflict fix)
- Updates `omnibase-spi` pin from `^0.8.0` → `>=0.10.0,<0.11.0` (missing enrichment/delegation contracts)
- Updates `omnibase-infra` pin from `^0.7.0` → `>=0.8.0,<0.9.0` (missing LLM nodes, Infisical, Topic Catalog)

Resolves cross-repo `ResolutionImpossible` conflicts that break shared venvs.

Closes OMN-2375 (GAP-7)

## Test plan

- [x] Baseline tests confirmed passing before change (2170 passed, 157 skipped)
- [x] Tests pass after update with no regressions (2170 passed, 157 skipped)
- [x] `poetry lock` succeeds with resolved versions: core 0.18.1, spi 0.10.0, infra 0.8.1
- [x] Cross-repo import sanity check passes for all three packages + omnimemory
- [x] Local review: 2 consecutive clean passes, 0 blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirements for core dependencies to ensure compatibility with the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->