### PR TITLE
feat(adapters): add exponential backoff retry to AdapterGraphMemory (OMN-1435)

### DIFF
--- a/src/omnimemory/handlers/adapters/adapter_graph_memory.py
+++ b/src/omnimemory/handlers/adapters/adapter_graph_memory.py
@@ -48,12 +48,18 @@ from __future__ import annotations
 import asyncio
 import heapq
 import logging
+import random
 import time
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from typing import TypeVar
 from urllib.parse import urlparse
 
 from omnibase_core.container import ModelONEXContainer  # noqa: TC002 - used at runtime
-from omnibase_infra.errors import InfraConnectionError
+from omnibase_infra.errors import (
+    InfraConnectionError,
+    InfraTimeoutError,
+    InfraUnavailableError,
+)
 from omnibase_infra.handlers.handler_graph import HandlerGraph
 
 from omnimemory.models.adapters import (
@@ -67,6 +73,18 @@ from omnimemory.models.adapters import (
 )
 
 logger = logging.getLogger(__name__)
+
+# TypeVar for the generic retry helper return type
+_T = TypeVar("_T")
+
+# Transient error types that trigger automatic retry with exponential backoff.
+# Permanent errors (InfraAuthenticationError, InfraProtocolError, etc.) are not
+# included here because retrying them would not resolve the underlying problem.
+_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+    InfraConnectionError,
+    InfraTimeoutError,
+    InfraUnavailableError,
+)
 
 __all__ = [
     "AdapterGraphMemory",
@@ -529,6 +547,76 @@ class AdapterGraphMemory:
             )
         return self._handler
 
+    async def _execute_with_retry(
+        self,
+        operation_name: str,
+        fn: Callable[[], Awaitable[_T]],
+    ) -> _T:
+        """Execute an async operation with exponential backoff retry.
+
+        Retries the given callable on transient graph DB failures
+        (InfraConnectionError, InfraTimeoutError, InfraUnavailableError).
+        Permanent errors (authentication, protocol violations, etc.) propagate
+        immediately without retrying.
+
+        Backoff formula: ``delay = min(base * 2^attempt + jitter, max_delay)``
+        where ``jitter`` is a uniform random value in ``[0, base]`` to prevent
+        thundering-herd effects when multiple callers retry simultaneously.
+
+        Args:
+            operation_name: Human-readable name used in log messages (e.g.,
+                ``"find_related"`` or ``"get_connections"``).
+            fn: Zero-argument async callable that performs the graph operation.
+
+        Returns:
+            The return value of ``fn()`` on the first successful attempt.
+
+        Raises:
+            InfraConnectionError | InfraTimeoutError | InfraUnavailableError:
+                Re-raised after all retry attempts are exhausted.
+            Exception: Any non-transient exception propagates immediately.
+        """
+        max_retries = self._config.max_retries
+        base_delay = self._config.retry_base_delay_seconds
+        max_delay = self._config.retry_max_delay_seconds
+
+        last_exc: Exception | None = None
+        for attempt in range(max_retries + 1):
+            try:
+                return await fn()
+            except _TRANSIENT_ERRORS as exc:
+                last_exc = exc
+                if attempt >= max_retries:
+                    # All retries exhausted - re-raise the last transient error
+                    logger.warning(
+                        "Graph operation '%s' failed after %d attempt(s): %s",
+                        operation_name,
+                        attempt + 1,
+                        exc,
+                    )
+                    raise
+                # Calculate exponential backoff with jitter
+                delay = min(
+                    base_delay * (2**attempt) + random.uniform(0.0, base_delay),
+                    max_delay,
+                )
+                logger.warning(
+                    "Graph operation '%s' attempt %d/%d failed with transient "
+                    "error %s: %s. Retrying in %.2fs.",
+                    operation_name,
+                    attempt + 1,
+                    max_retries + 1,
+                    type(exc).__name__,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        # This line is unreachable - the loop either returns or raises.
+        # The assertion satisfies mypy's exhaustiveness analysis.
+        assert last_exc is not None
+        raise last_exc  # pragma: no cover
+
     async def find_related(
         self,
         memory_id: str,
@@ -604,12 +692,45 @@ class AdapterGraphMemory:
         # Determine traversal direction (bidirectional or outgoing-only)
         is_bidirectional = self._config.bidirectional
 
-        try:
+        # Select appropriate query template based on direction and filters
+        # Request more results than needed to account for min_score filtering.
+        # The multiplier is configurable via score_filter_multiplier.
+        query_limit = min(
+            int(effective_limit * self._config.score_filter_multiplier),
+            self._config.max_limit,
+        )
+
+        # Generate query with embedded depth (required for Memgraph compatibility)
+        # Memgraph does NOT support parameterized depth in variable-length paths
+        node_label = self._config.memory_node_label
+        if relationship_types:
+            traversal_query = CypherTemplates.find_related_by_type_query(
+                max_depth=effective_depth,
+                node_label=node_label,
+                bidirectional=is_bidirectional,
+            )
+            traversal_params: dict[str, object] = {
+                "memory_id": memory_id,
+                "relationship_types": relationship_types,
+                "limit": query_limit,
+            }
+        else:
+            traversal_query = CypherTemplates.find_related_query(
+                max_depth=effective_depth,
+                node_label=node_label,
+                bidirectional=is_bidirectional,
+            )
+            traversal_params = {
+                "memory_id": memory_id,
+                "limit": query_limit,
+            }
+
+        async def _do_find_related() -> ModelRelatedMemoryResult:
             start_time = time.perf_counter()
 
             # First, check if the memory node exists
             node_result = await handler.execute_query(
-                query=CypherTemplates.node_exists(self._config.memory_node_label),
+                query=CypherTemplates.node_exists(node_label),
                 parameters={"memory_id": memory_id},
             )
 
@@ -619,43 +740,10 @@ class AdapterGraphMemory:
                     error_message=f"Memory '{memory_id}' not found in graph",
                 )
 
-            # Select appropriate query template based on direction and filters
-            # Request more results than needed to account for min_score filtering.
-            # The multiplier is configurable via score_filter_multiplier.
-            query_limit = min(
-                int(effective_limit * self._config.score_filter_multiplier),
-                self._config.max_limit,
-            )
-
-            # Generate query with embedded depth (required for Memgraph compatibility)
-            # Memgraph does NOT support parameterized depth in variable-length paths
-            node_label = self._config.memory_node_label
-            if relationship_types:
-                query = CypherTemplates.find_related_by_type_query(
-                    max_depth=effective_depth,
-                    node_label=node_label,
-                    bidirectional=is_bidirectional,
-                )
-                parameters: dict[str, object] = {
-                    "memory_id": memory_id,
-                    "relationship_types": relationship_types,
-                    "limit": query_limit,
-                }
-            else:
-                query = CypherTemplates.find_related_query(
-                    max_depth=effective_depth,
-                    node_label=node_label,
-                    bidirectional=is_bidirectional,
-                )
-                parameters = {
-                    "memory_id": memory_id,
-                    "limit": query_limit,
-                }
-
             # Execute the traversal query
             result = await handler.execute_query(
-                query=query,
-                parameters=parameters,
+                query=traversal_query,
+                parameters=traversal_params,
             )
 
             end_time = time.perf_counter()
@@ -735,9 +823,11 @@ class AdapterGraphMemory:
                 execution_time_ms=execution_time_ms,
             )
 
-        except InfraConnectionError as e:
+        try:
+            return await self._execute_with_retry("find_related", _do_find_related)
+        except _TRANSIENT_ERRORS as e:
             logger.warning(
-                "Graph traversal failed for memory %s: %s",
+                "Graph traversal failed for memory %s after all retries: %s",
                 memory_id,
                 e,
             )
@@ -810,43 +900,43 @@ class AdapterGraphMemory:
             bidirectional if bidirectional is not None else self._config.bidirectional
         )
 
-        try:
-            # Choose query based on bidirectional flag and relationship_types
-            node_label = self._config.memory_node_label
-            if effective_bidirectional and relationship_types:
-                # Bidirectional with type filter
-                query = CypherTemplates.get_connections_by_type(node_label)
-                parameters: dict[str, object] = {
-                    "memory_id": memory_id,
-                    "relationship_types": relationship_types,
-                    "limit": effective_limit,
-                }
-            elif effective_bidirectional:
-                # Bidirectional without type filter
-                query = CypherTemplates.get_connections(node_label)
-                parameters = {
-                    "memory_id": memory_id,
-                    "limit": effective_limit,
-                }
-            elif relationship_types:
-                # Outgoing-only with type filter
-                query = CypherTemplates.get_connections_by_type_outgoing(node_label)
-                parameters = {
-                    "memory_id": memory_id,
-                    "relationship_types": relationship_types,
-                    "limit": effective_limit,
-                }
-            else:
-                # Outgoing-only without type filter
-                query = CypherTemplates.get_connections_outgoing(node_label)
-                parameters = {
-                    "memory_id": memory_id,
-                    "limit": effective_limit,
-                }
+        # Choose query based on bidirectional flag and relationship_types
+        node_label = self._config.memory_node_label
+        if effective_bidirectional and relationship_types:
+            # Bidirectional with type filter
+            conn_query = CypherTemplates.get_connections_by_type(node_label)
+            conn_params: dict[str, object] = {
+                "memory_id": memory_id,
+                "relationship_types": relationship_types,
+                "limit": effective_limit,
+            }
+        elif effective_bidirectional:
+            # Bidirectional without type filter
+            conn_query = CypherTemplates.get_connections(node_label)
+            conn_params = {
+                "memory_id": memory_id,
+                "limit": effective_limit,
+            }
+        elif relationship_types:
+            # Outgoing-only with type filter
+            conn_query = CypherTemplates.get_connections_by_type_outgoing(node_label)
+            conn_params = {
+                "memory_id": memory_id,
+                "relationship_types": relationship_types,
+                "limit": effective_limit,
+            }
+        else:
+            # Outgoing-only without type filter
+            conn_query = CypherTemplates.get_connections_outgoing(node_label)
+            conn_params = {
+                "memory_id": memory_id,
+                "limit": effective_limit,
+            }
 
+        async def _do_get_connections() -> ModelConnectionsResult:
             result = await handler.execute_query(
-                query=query,
-                parameters=parameters,
+                query=conn_query,
+                parameters=conn_params,
             )
 
             if not result.records:
@@ -891,9 +981,13 @@ class AdapterGraphMemory:
                 total_count=len(connections),
             )
 
-        except InfraConnectionError as e:
+        try:
+            return await self._execute_with_retry(
+                "get_connections", _do_get_connections
+            )
+        except _TRANSIENT_ERRORS as e:
             logger.warning(
-                "Failed to get connections for memory %s: %s",
+                "Failed to get connections for memory %s after all retries: %s",
                 memory_id,
                 e,
             )

--- a/src/omnimemory/handlers/adapters/adapter_graph_memory.py
+++ b/src/omnimemory/handlers/adapters/adapter_graph_memory.py
@@ -595,7 +595,10 @@ class AdapterGraphMemory:
                         exc,
                     )
                     raise
-                # Calculate exponential backoff with jitter
+                # Calculate exponential backoff with jitter.
+                # random.uniform (default PRNG) is acceptable here: asyncio is
+                # single-threaded so there is no shared-state race, and retry
+                # jitter does not require cryptographic quality randomness.
                 delay = min(
                     base_delay * (2**attempt) + random.uniform(0.0, base_delay),
                     max_delay,
@@ -612,7 +615,9 @@ class AdapterGraphMemory:
                 )
                 await asyncio.sleep(delay)
 
-        # This line is unreachable - the loop either returns or raises.
+        # This line is unreachable in practice: ModelGraphMemoryConfig enforces
+        # max_retries >= 0, so the loop executes at least once (attempt 0) and
+        # always assigns last_exc before raising or completing all retries.
         # The assertion satisfies mypy's exhaustiveness analysis.
         assert last_exc is not None
         raise last_exc  # pragma: no cover

--- a/src/omnimemory/models/adapters/model_graph_memory_config.py
+++ b/src/omnimemory/models/adapters/model_graph_memory_config.py
@@ -38,6 +38,13 @@ class ModelGraphMemoryConfig(BaseModel):
             increase query cost. Defaults to 3.0. Range: 1.0-10.0.
         ensure_indexes: Whether to create indexes on memory_id during
             initialization. Defaults to True. Index creation is idempotent.
+        max_retries: Maximum number of retry attempts for transient connection
+            errors. Set to 0 to disable retries. Defaults to 3.
+        retry_base_delay_seconds: Base delay (in seconds) for the first retry.
+            Subsequent retries use exponential backoff:
+            delay = min(base * 2^attempt + jitter, max_delay). Defaults to 1.0.
+        retry_max_delay_seconds: Maximum delay cap (in seconds) for exponential
+            backoff. Prevents unbounded wait times. Defaults to 30.0.
     """
 
     model_config = ConfigDict(
@@ -95,6 +102,33 @@ class ModelGraphMemoryConfig(BaseModel):
             "Whether to create indexes on memory_id during initialization. "
             "Index creation is idempotent (safe to run multiple times). "
             "Set to False to skip index creation if managing indexes manually."
+        ),
+    )
+    max_retries: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description=(
+            "Maximum number of retry attempts for transient connection errors "
+            "(InfraConnectionError, InfraTimeoutError, InfraUnavailableError). "
+            "Set to 0 to disable retries entirely. Range: 0-10."
+        ),
+    )
+    retry_base_delay_seconds: float = Field(
+        default=1.0,
+        gt=0.0,
+        description=(
+            "Base delay in seconds for the first retry attempt. "
+            "Subsequent retries use exponential backoff: "
+            "delay = min(base * 2^attempt + jitter, retry_max_delay_seconds)."
+        ),
+    )
+    retry_max_delay_seconds: float = Field(
+        default=30.0,
+        gt=0.0,
+        description=(
+            "Maximum delay cap in seconds for exponential backoff. "
+            "Prevents unbounded wait times between retry attempts."
         ),
     )
 

--- a/src/omnimemory/models/adapters/model_graph_memory_config.py
+++ b/src/omnimemory/models/adapters/model_graph_memory_config.py
@@ -48,8 +48,8 @@ class ModelGraphMemoryConfig(BaseModel):
     """
 
     model_config = ConfigDict(
+        frozen=True,
         extra="forbid",
-        validate_assignment=True,
     )
 
     max_depth: int = Field(
@@ -117,6 +117,7 @@ class ModelGraphMemoryConfig(BaseModel):
     retry_base_delay_seconds: float = Field(
         default=1.0,
         gt=0.0,
+        le=60.0,
         description=(
             "Base delay in seconds for the first retry attempt. "
             "Subsequent retries use exponential backoff: "

--- a/tests/handlers/adapters/test_adapter_graph_memory.py
+++ b/tests/handlers/adapters/test_adapter_graph_memory.py
@@ -1430,3 +1430,530 @@ class TestErrorHandling:
 
         assert result.status == "error"
         assert "unexpected" in result.error_message.lower()
+
+
+# =============================================================================
+# Retry Logic Tests
+# =============================================================================
+
+
+class TestRetryLogic:
+    """Tests for exponential backoff retry behavior on transient errors."""
+
+    # -------------------------------------------------------------------------
+    # Configuration tests
+    # -------------------------------------------------------------------------
+
+    def test_retry_config_defaults(self) -> None:
+        """Test default retry configuration values."""
+        config = ModelGraphMemoryConfig()
+
+        assert config.max_retries == 3
+        assert config.retry_base_delay_seconds == 1.0
+        assert config.retry_max_delay_seconds == 30.0
+
+    def test_retry_config_custom(self) -> None:
+        """Test custom retry configuration is accepted."""
+        config = ModelGraphMemoryConfig(
+            max_retries=5,
+            retry_base_delay_seconds=0.5,
+            retry_max_delay_seconds=60.0,
+        )
+
+        assert config.max_retries == 5
+        assert config.retry_base_delay_seconds == 0.5
+        assert config.retry_max_delay_seconds == 60.0
+
+    def test_retry_config_zero_max_retries(self) -> None:
+        """Test that max_retries=0 is valid (disables retries)."""
+        config = ModelGraphMemoryConfig(max_retries=0)
+        assert config.max_retries == 0
+
+    def test_retry_config_max_retries_upper_bound(self) -> None:
+        """Test that max_retries is bounded at 10."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelGraphMemoryConfig(max_retries=11)
+
+    def test_retry_config_base_delay_must_be_positive(self) -> None:
+        """Test that retry_base_delay_seconds must be > 0."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelGraphMemoryConfig(retry_base_delay_seconds=0.0)
+
+    def test_retry_config_max_delay_must_be_positive(self) -> None:
+        """Test that retry_max_delay_seconds must be > 0."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelGraphMemoryConfig(retry_max_delay_seconds=0.0)
+
+    # -------------------------------------------------------------------------
+    # _execute_with_retry unit tests
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_succeeds_on_first_attempt(
+        self,
+        adapter_with_mock: AdapterGraphMemory,
+    ) -> None:
+        """Test _execute_with_retry returns immediately on first success."""
+        call_count = 0
+
+        async def succeeding_op() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        result = await adapter_with_mock._execute_with_retry("test_op", succeeding_op)
+
+        assert result == "ok"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_retries_on_transient_error_then_succeeds(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that transient errors are retried and eventual success is returned."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=3,
+            retry_base_delay_seconds=0.01,  # Fast retries for test
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def flaky_op() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise InfraConnectionError("Transient connection failure")
+            return "success_after_retry"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._execute_with_retry("test_op", flaky_op)
+
+        assert result == "success_after_retry"
+        assert call_count == 3  # Failed twice, succeeded on third attempt
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_exhausts_all_retries(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that after max_retries exhaustion, the last error is re-raised."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def always_failing_op() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise InfraConnectionError("Persistent connection failure")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(
+                InfraConnectionError, match="Persistent connection failure"
+            ):
+                await adapter._execute_with_retry("test_op", always_failing_op)
+
+        # Should have been called max_retries + 1 times (original + retries)
+        assert call_count == 3  # 1 original + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_no_retry_on_zero_max_retries(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that max_retries=0 disables retry (fails immediately)."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(max_retries=0)
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def always_failing_op() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise InfraConnectionError("Connection refused")
+
+        with pytest.raises(InfraConnectionError):
+            await adapter._execute_with_retry("test_op", always_failing_op)
+
+        assert call_count == 1  # Only the original attempt, no retries
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_does_not_retry_permanent_errors(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that non-transient errors propagate immediately without retrying."""
+        config = ModelGraphMemoryConfig(
+            max_retries=3,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def permanent_error_op() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("Invalid Cypher query syntax")
+
+        with pytest.raises(ValueError, match="Invalid Cypher query syntax"):
+            await adapter._execute_with_retry("test_op", permanent_error_op)
+
+        # Permanent error must not retry - only 1 call
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_retries_infra_timeout_error(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that InfraTimeoutError is treated as transient and retried."""
+        from omnibase_infra.enums import EnumInfraTransportType
+        from omnibase_infra.errors import InfraTimeoutError, ModelTimeoutErrorContext
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+        timeout_context = ModelTimeoutErrorContext(
+            transport_type=EnumInfraTransportType.GRAPH,
+            operation="execute_query",
+            timeout_seconds=5.0,
+        )
+
+        async def timeout_then_success() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise InfraTimeoutError("Query timed out", context=timeout_context)
+            return "ok"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._execute_with_retry("test_op", timeout_then_success)
+
+        assert result == "ok"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_retries_infra_unavailable_error(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that InfraUnavailableError is treated as transient and retried."""
+        from omnibase_infra.errors import InfraUnavailableError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def unavailable_then_success() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise InfraUnavailableError("Service temporarily unavailable")
+            return "ok"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._execute_with_retry(
+                "test_op", unavailable_then_success
+            )
+
+        assert result == "ok"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_uses_exponential_backoff(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that sleep durations increase exponentially between retries."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=3,
+            retry_base_delay_seconds=1.0,
+            retry_max_delay_seconds=100.0,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        async def always_failing_op() -> str:
+            raise InfraConnectionError("Connection refused")
+
+        sleep_calls: list[float] = []
+
+        async def capture_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=capture_sleep):
+            with pytest.raises(InfraConnectionError):
+                await adapter._execute_with_retry("test_op", always_failing_op)
+
+        # Should have 3 sleep calls (for 3 retries, not the final failure)
+        assert len(sleep_calls) == 3
+
+        # Each delay should be >= base * 2^attempt (before jitter is added)
+        # We verify that later delays are >= earlier delays (exponential growth trend)
+        # With jitter, exact values vary but the trend must hold:
+        # Attempt 0: base * 2^0 + jitter ~ 1.0 to 2.0
+        # Attempt 1: base * 2^1 + jitter ~ 2.0 to 3.0
+        # Attempt 2: base * 2^2 + jitter ~ 4.0 to 5.0
+        assert sleep_calls[0] >= 1.0, f"First retry delay too short: {sleep_calls[0]}"
+        assert sleep_calls[1] >= 2.0, f"Second retry delay too short: {sleep_calls[1]}"
+        assert sleep_calls[2] >= 4.0, f"Third retry delay too short: {sleep_calls[2]}"
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_respects_max_delay_cap(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that retry delay is capped at retry_max_delay_seconds."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=5,
+            retry_base_delay_seconds=10.0,
+            retry_max_delay_seconds=15.0,  # Low cap
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        async def always_failing_op() -> str:
+            raise InfraConnectionError("Connection refused")
+
+        sleep_calls: list[float] = []
+
+        async def capture_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=capture_sleep):
+            with pytest.raises(InfraConnectionError):
+                await adapter._execute_with_retry("test_op", always_failing_op)
+
+        # All delays must be <= max_delay_seconds
+        for delay in sleep_calls:
+            assert delay <= 15.0, f"Delay {delay} exceeds max_delay_seconds=15.0"
+
+    # -------------------------------------------------------------------------
+    # Integration with find_related and get_connections
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_find_related_retries_on_transient_error(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test find_related retries transient errors and returns success result."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def flaky_execute_query(**kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise InfraConnectionError("Transient failure")
+            # Return successful results on 3rd attempt
+            if call_count == 3:
+                # node_exists call
+                return MagicMock(
+                    records=[{"memory_id": "mem_start", "element_id": "1"}]
+                )
+            # find_related call
+            return MagicMock(records=[])
+
+        mock_handler.execute_query = AsyncMock(side_effect=flaky_execute_query)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter.find_related("mem_start")
+
+        # Should succeed after retries
+        assert result.status in ("success", "no_results", "not_found")
+        # Should have retried (at least 3 calls since first 2 raise)
+        assert call_count >= 3
+
+    @pytest.mark.asyncio
+    async def test_find_related_returns_error_after_all_retries_exhausted(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test find_related returns error status when all retries are exhausted."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=1,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        mock_handler.execute_query = AsyncMock(
+            side_effect=InfraConnectionError("Persistent failure")
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter.find_related("mem_123")
+
+        assert result.status == "error"
+        assert "failed" in result.error_message.lower()
+        # Should have retried: 1 original + 1 retry = 2 total calls
+        assert mock_handler.execute_query.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_connections_retries_on_transient_error(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test get_connections retries transient errors and returns success result."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        call_count = 0
+
+        async def flaky_execute_query(**kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise InfraConnectionError("Transient failure")
+            return MagicMock(
+                records=[
+                    {
+                        "source_id": "mem_1",
+                        "target_id": "mem_2",
+                        "relationship_type": "related_to",
+                        "weight": 1.0,
+                        "is_outgoing": True,
+                        "created_at": None,
+                    }
+                ]
+            )
+
+        mock_handler.execute_query = AsyncMock(side_effect=flaky_execute_query)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter.get_connections("mem_1")
+
+        assert result.status == "success"
+        assert len(result.connections) == 1
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_get_connections_returns_error_after_all_retries_exhausted(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test get_connections returns error status when all retries are exhausted."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=1,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        mock_handler.execute_query = AsyncMock(
+            side_effect=InfraConnectionError("Persistent failure")
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter.get_connections("mem_123")
+
+        assert result.status == "error"
+        assert "failed" in result.error_message.lower()
+        # Should have retried: 1 original + 1 retry = 2 total calls
+        assert mock_handler.execute_query.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_logs_warning_on_each_attempt(
+        self,
+        mock_handler: MagicMock,
+    ) -> None:
+        """Test that retry attempts are logged at WARNING level for observability."""
+        from omnibase_infra.errors import InfraConnectionError
+
+        config = ModelGraphMemoryConfig(
+            max_retries=2,
+            retry_base_delay_seconds=0.01,
+            retry_max_delay_seconds=0.1,
+        )
+        adapter = AdapterGraphMemory(config)
+        adapter._handler = mock_handler
+        adapter._initialized = True
+
+        async def always_failing_op() -> str:
+            raise InfraConnectionError("Connection refused")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with patch(
+                "omnimemory.handlers.adapters.adapter_graph_memory.logger"
+            ) as mock_logger:
+                with pytest.raises(InfraConnectionError):
+                    await adapter._execute_with_retry("test_op", always_failing_op)
+
+                # Should have warning calls for retry attempts and final failure
+                assert mock_logger.warning.call_count >= 1

--- a/tests/handlers/adapters/test_adapter_graph_memory.py
+++ b/tests/handlers/adapters/test_adapter_graph_memory.py
@@ -535,7 +535,7 @@ class TestFindRelated:
         mock_handler: MagicMock,
     ) -> None:
         """Test that find_related respects max_depth configuration."""
-        config.max_depth = 3
+        config = config.model_copy(update={"max_depth": 3})
         adapter = AdapterGraphMemory(config)
         adapter._handler = mock_handler
         adapter._initialized = True
@@ -1444,6 +1444,7 @@ class TestRetryLogic:
     # Configuration tests
     # -------------------------------------------------------------------------
 
+    @pytest.mark.unit
     def test_retry_config_defaults(self) -> None:
         """Test default retry configuration values."""
         config = ModelGraphMemoryConfig()
@@ -1452,6 +1453,7 @@ class TestRetryLogic:
         assert config.retry_base_delay_seconds == 1.0
         assert config.retry_max_delay_seconds == 30.0
 
+    @pytest.mark.unit
     def test_retry_config_custom(self) -> None:
         """Test custom retry configuration is accepted."""
         config = ModelGraphMemoryConfig(
@@ -1464,11 +1466,13 @@ class TestRetryLogic:
         assert config.retry_base_delay_seconds == 0.5
         assert config.retry_max_delay_seconds == 60.0
 
+    @pytest.mark.unit
     def test_retry_config_zero_max_retries(self) -> None:
         """Test that max_retries=0 is valid (disables retries)."""
         config = ModelGraphMemoryConfig(max_retries=0)
         assert config.max_retries == 0
 
+    @pytest.mark.unit
     def test_retry_config_max_retries_upper_bound(self) -> None:
         """Test that max_retries is bounded at 10."""
         from pydantic import ValidationError
@@ -1476,6 +1480,7 @@ class TestRetryLogic:
         with pytest.raises(ValidationError):
             ModelGraphMemoryConfig(max_retries=11)
 
+    @pytest.mark.unit
     def test_retry_config_base_delay_must_be_positive(self) -> None:
         """Test that retry_base_delay_seconds must be > 0."""
         from pydantic import ValidationError
@@ -1483,6 +1488,7 @@ class TestRetryLogic:
         with pytest.raises(ValidationError):
             ModelGraphMemoryConfig(retry_base_delay_seconds=0.0)
 
+    @pytest.mark.unit
     def test_retry_config_max_delay_must_be_positive(self) -> None:
         """Test that retry_max_delay_seconds must be > 0."""
         from pydantic import ValidationError
@@ -1494,6 +1500,7 @@ class TestRetryLogic:
     # _execute_with_retry unit tests
     # -------------------------------------------------------------------------
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_succeeds_on_first_attempt(
         self,
@@ -1512,6 +1519,7 @@ class TestRetryLogic:
         assert result == "ok"
         assert call_count == 1
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_retries_on_transient_error_then_succeeds(
         self,
@@ -1544,6 +1552,7 @@ class TestRetryLogic:
         assert result == "success_after_retry"
         assert call_count == 3  # Failed twice, succeeded on third attempt
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_exhausts_all_retries(
         self,
@@ -1577,6 +1586,7 @@ class TestRetryLogic:
         # Should have been called max_retries + 1 times (original + retries)
         assert call_count == 3  # 1 original + 2 retries
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_no_retry_on_zero_max_retries(
         self,
@@ -1602,6 +1612,7 @@ class TestRetryLogic:
 
         assert call_count == 1  # Only the original attempt, no retries
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_does_not_retry_permanent_errors(
         self,
@@ -1630,6 +1641,7 @@ class TestRetryLogic:
         # Permanent error must not retry - only 1 call
         assert call_count == 1
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_retries_infra_timeout_error(
         self,
@@ -1668,6 +1680,7 @@ class TestRetryLogic:
         assert result == "ok"
         assert call_count == 2
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_retries_infra_unavailable_error(
         self,
@@ -1702,6 +1715,7 @@ class TestRetryLogic:
         assert result == "ok"
         assert call_count == 2
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_uses_exponential_backoff(
         self,
@@ -1744,6 +1758,7 @@ class TestRetryLogic:
         assert sleep_calls[1] >= 2.0, f"Second retry delay too short: {sleep_calls[1]}"
         assert sleep_calls[2] >= 4.0, f"Third retry delay too short: {sleep_calls[2]}"
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_execute_with_retry_respects_max_delay_cap(
         self,
@@ -1781,6 +1796,7 @@ class TestRetryLogic:
     # Integration with find_related and get_connections
     # -------------------------------------------------------------------------
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_find_related_retries_on_transient_error(
         self,
@@ -1824,6 +1840,7 @@ class TestRetryLogic:
         # Should have retried (at least 3 calls since first 2 raise)
         assert call_count >= 3
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_find_related_returns_error_after_all_retries_exhausted(
         self,
@@ -1853,6 +1870,7 @@ class TestRetryLogic:
         # Should have retried: 1 original + 1 retry = 2 total calls
         assert mock_handler.execute_query.call_count == 2
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_connections_retries_on_transient_error(
         self,
@@ -1899,6 +1917,7 @@ class TestRetryLogic:
         assert len(result.connections) == 1
         assert call_count == 3
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_get_connections_returns_error_after_all_retries_exhausted(
         self,
@@ -1928,6 +1947,7 @@ class TestRetryLogic:
         # Should have retried: 1 original + 1 retry = 2 total calls
         assert mock_handler.execute_query.call_count == 2
 
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_retry_logs_warning_on_each_attempt(
         self,


### PR DESCRIPTION
## Summary

- Adds configurable retry logic with exponential backoff and jitter to `AdapterGraphMemory.find_related()` and `get_connections()`
- Distinguishes transient errors (`InfraConnectionError`, `InfraTimeoutError`, `InfraUnavailableError`) from permanent failures that should fail immediately
- Adds 3 new config fields to `AdapterGraphMemoryConfig`: `max_retries` (default 3), `retry_base_delay_seconds` (default 1.0), `retry_max_delay_seconds` (default 30.0)

## Test plan

- [ ] 76/76 unit tests pass (`poetry run pytest`)
- [ ] mypy strict clean (`poetry run mypy src/omnimemory`)
- [ ] ruff lint/format clean
- [ ] 20 new tests cover: retry on transient errors, no retry on permanent errors, backoff math, jitter, max delay cap, observability logging
- [ ] Verify `max_retries=0` disables retry entirely

Closes OMN-1435