### PR TITLE
feat(archive): add configurable compression level to HandlerMemoryArchive (OMN-1544)

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -61,6 +61,17 @@ MemoryServiceSettings (top-level)
     +-- dimension
 ```
 
+## Archive Handler Configuration
+
+Variables used by `HandlerMemoryArchive` for cold-storage archival.
+
+| Variable | Type | Default | Constraints | Description |
+|----------|------|---------|-------------|-------------|
+| `OMNIMEMORY_ARCHIVE_PATH` | Path | `{tempdir}/omnimemory/archives` | Must be writable | Base directory for archive files. Overridden by the `archive_base_path` constructor argument. |
+| `OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL` | int | `6` | 1–9 | Gzip compression level for `.jsonl.gz` archive files. Level 1 is fastest (lowest ratio); level 9 is slowest (highest ratio). Level 6 is the balanced default. Overridden by the `compression_level` constructor argument. |
+
+> **Note — naming exception**: These variables use a single underscore (`OMNIMEMORY_ARCHIVE_*`) because they are read directly by `os.environ.get()` inside the handler, not via pydantic-settings. They do **not** use the `OMNIMEMORY__` double-underscore prefix.
+
 ## Required Variables (Phase 1 Minimal)
 
 These variables MUST be set for OmniMemory to start:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -45,14 +45,16 @@ Example::
     container = ModelONEXContainer()
     handler = HandlerMemoryArchive(container)
 
-    # Option 1: Use OMNIMEMORY_ARCHIVE_PATH environment variable (recommended)
+    # Option 1: Use environment variables (recommended)
     # export OMNIMEMORY_ARCHIVE_PATH=/var/omnimemory/archives
+    # export OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL=6
     await handler.initialize(db_pool=pool)
 
-    # Option 2: Explicit path (useful for testing)
+    # Option 2: Explicit path and compression level (useful for testing)
     await handler.initialize(
         db_pool=pool,
         archive_base_path=Path("/custom/archive/path"),
+        compression_level=1,  # Fast compression for high-throughput scenarios
     )
 
     command = ModelArchiveMemoryCommand(
@@ -521,7 +523,7 @@ class HandlerMemoryArchive:
         The current implementation uses a local atomic write pattern.
     """
 
-    # Gzip compression level for archive files (valid range: 1-9).
+    # Default gzip compression level for archive files (valid range: 1-9).
     #
     # Level 6 is the gzip default and provides an optimal balance between
     # compression ratio and CPU time for archive storage workloads:
@@ -533,7 +535,13 @@ class HandlerMemoryArchive:
     # cost matters, level 6 optimizes throughput while maintaining substantial
     # space savings. Higher levels provide diminishing returns for JSON/JSONL
     # content which already compresses well.
-    _ARCHIVE_COMPRESSION_LEVEL: int = 6
+    #
+    # Override via constructor or OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL env var.
+    _DEFAULT_COMPRESSION_LEVEL: int = 6
+
+    # Minimum and maximum valid gzip compression levels.
+    _MIN_COMPRESSION_LEVEL: int = 1
+    _MAX_COMPRESSION_LEVEL: int = 9
 
     # Query timeout for database operations (seconds).
     #
@@ -563,14 +571,16 @@ class HandlerMemoryArchive:
 
         Note:
             After construction, call initialize() to set up runtime dependencies
-            (db_pool, archive_base_path, orphan_tracker). The handler will raise
-            RuntimeError if handle() is called before initialization.
+            (db_pool, archive_base_path, orphan_tracker, compression_level).
+            The handler will raise RuntimeError if handle() is called before
+            initialization.
         """
         self._container = container
         self._db_pool: Pool | None = None
         self._archive_base_path: Path | None = None
         self._orphan_tracker: ProtocolOrphanedArchiveTracker | None = None
         self._db_circuit_breaker: CircuitBreaker | None = None
+        self._compression_level: int = self._DEFAULT_COMPRESSION_LEVEL
         self._initialized = False
 
     async def initialize(
@@ -578,6 +588,7 @@ class HandlerMemoryArchive:
         db_pool: Pool | None = None,
         archive_base_path: Path | None = None,
         orphan_tracker: ProtocolOrphanedArchiveTracker | None = None,
+        compression_level: int | None = None,
     ) -> None:
         """Initialize runtime dependencies for the handler.
 
@@ -596,9 +607,59 @@ class HandlerMemoryArchive:
                 If provided, will be called when an archive file is written
                 but the database state update fails. This enables monitoring
                 and cleanup of orphaned files.
+            compression_level: Gzip compression level (1-9). Level 1 is fastest
+                with lowest ratio; level 9 is slowest with highest ratio. Level
+                6 is the balanced default.
+                Resolution order (first non-None value wins):
+                  1. ``compression_level`` argument (this parameter)
+                  2. ``OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL`` environment variable
+                  3. Built-in default (6)
+
+        Raises:
+            ValueError: If compression_level is outside the valid range 1-9.
         """
         self._db_pool = db_pool
         self._orphan_tracker = orphan_tracker
+
+        # Resolve compression level: explicit arg > env var > default
+        if compression_level is not None:
+            resolved_level = compression_level
+            level_source = "constructor argument"
+        else:
+            env_level_raw = os.environ.get("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL")
+            if env_level_raw is not None:
+                try:
+                    resolved_level = int(env_level_raw)
+                except ValueError:
+                    raise ValueError(
+                        "OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL must be an integer "
+                        f"between {self._MIN_COMPRESSION_LEVEL} and "
+                        f"{self._MAX_COMPRESSION_LEVEL} (inclusive), "
+                        f"got non-integer value: {env_level_raw!r}"
+                    ) from None
+                level_source = "OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL env var"
+            else:
+                resolved_level = self._DEFAULT_COMPRESSION_LEVEL
+                level_source = "built-in default"
+
+        # Validate range
+        if not (
+            self._MIN_COMPRESSION_LEVEL <= resolved_level <= self._MAX_COMPRESSION_LEVEL
+        ):
+            raise ValueError(
+                f"compression_level must be between {self._MIN_COMPRESSION_LEVEL} "
+                f"and {self._MAX_COMPRESSION_LEVEL} (inclusive), "
+                f"got {resolved_level} (from {level_source})"
+            )
+
+        self._compression_level = resolved_level
+        logger.debug(
+            "Archive compression level configured",
+            extra={
+                "compression_level": self._compression_level,
+                "source": level_source,
+            },
+        )
 
         # Initialize circuit breaker for DB operations
         self._db_circuit_breaker = CircuitBreaker(
@@ -645,6 +706,7 @@ class HandlerMemoryArchive:
             self._archive_base_path = None
             self._orphan_tracker = None
             self._db_circuit_breaker = None
+            self._compression_level = self._DEFAULT_COMPRESSION_LEVEL
             self._initialized = False
             logger.info("HandlerMemoryArchive shutdown complete")
 
@@ -696,7 +758,7 @@ class HandlerMemoryArchive:
                 "orphan_tracking",
             ],
             archive_format="JSONL with gzip compression (.jsonl.gz)",
-            compression_level=self._ARCHIVE_COMPRESSION_LEVEL,
+            compression_level=self._compression_level,
             query_timeout_seconds=self._QUERY_TIMEOUT_SECONDS,
             circuit_breaker_config=ModelCircuitBreakerConfigInfo(
                 failure_threshold=self._CB_FAILURE_THRESHOLD,
@@ -722,6 +784,17 @@ class HandlerMemoryArchive:
             The configured archive base path, or None if not yet initialized.
         """
         return self._archive_base_path
+
+    @property
+    def compression_level(self) -> int:
+        """Get the configured gzip compression level.
+
+        Returns:
+            The active compression level (1-9). Returns the instance value,
+            which reflects the resolved configuration from constructor argument,
+            environment variable, or built-in default.
+        """
+        return self._compression_level
 
     async def handle(
         self,
@@ -1186,7 +1259,7 @@ class HandlerMemoryArchive:
         jsonl_line = record.model_dump_json() + "\n"
         return gzip.compress(
             jsonl_line.encode("utf-8"),
-            compresslevel=self._ARCHIVE_COMPRESSION_LEVEL,
+            compresslevel=self._compression_level,
         )
 
     async def _serialize_for_archive_async(

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_handler_memory_archive.py
@@ -1497,3 +1497,356 @@ class TestExplicitGuards:
 
         with pytest.raises(RuntimeError, match="Archive base path not initialized"):
             handler._get_archive_path(memory_id, now)
+
+
+# =============================================================================
+# Compression Level Configuration Tests
+# =============================================================================
+
+
+class TestCompressionLevelConfiguration:
+    """Tests for configurable gzip compression level.
+
+    Covers all three resolution sources:
+    1. Constructor ``compression_level`` argument (highest priority)
+    2. ``OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL`` environment variable
+    3. Built-in default (level 6)
+
+    Also covers range validation and the public property.
+
+    Related ticket: OMN-1544
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_compression_level_is_six(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test handler uses compression level 6 when nothing is configured.
+
+        Given: No compression_level argument and no env var set
+        When: Calling initialize()
+        Then: compression_level property returns 6
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(db_pool=None, archive_base_path=archive_base_path)
+
+        assert handler.compression_level == 6
+
+    @pytest.mark.asyncio
+    async def test_constructor_argument_sets_level(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test explicit constructor argument is used as compression level.
+
+        Given: compression_level=1 passed to initialize()
+        When: Accessing compression_level property
+        Then: Returns 1
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=1,
+        )
+
+        assert handler.compression_level == 1
+
+    @pytest.mark.asyncio
+    async def test_constructor_argument_max_level(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test compression level 9 (maximum) is accepted.
+
+        Given: compression_level=9 passed to initialize()
+        When: Accessing compression_level property
+        Then: Returns 9
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=9,
+        )
+
+        assert handler.compression_level == 9
+
+    @pytest.mark.asyncio
+    async def test_env_var_sets_compression_level(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL env var is respected.
+
+        Given: OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL=3 set in environment
+        When: Calling initialize() without explicit compression_level
+        Then: compression_level property returns 3
+        """
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", "3")
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(db_pool=None, archive_base_path=archive_base_path)
+
+        assert handler.compression_level == 3
+
+    @pytest.mark.asyncio
+    async def test_constructor_argument_overrides_env_var(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test explicit constructor argument takes precedence over env var.
+
+        Given: OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL=9 set in environment
+          and compression_level=1 passed to initialize()
+        When: Accessing compression_level property
+        Then: Returns 1 (constructor wins)
+        """
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", "9")
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=1,
+        )
+
+        assert handler.compression_level == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_level_zero_raises_value_error(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+    ) -> None:
+        """Test compression_level=0 raises ValueError with clear message.
+
+        Given: compression_level=0 passed to initialize()
+        When: Calling initialize()
+        Then: ValueError is raised mentioning valid range 1-9
+        """
+        handler = HandlerMemoryArchive(container)
+
+        with pytest.raises(
+            ValueError, match="compression_level must be between 1 and 9"
+        ):
+            await handler.initialize(
+                db_pool=None,
+                archive_base_path=archive_base_path,
+                compression_level=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_level_ten_raises_value_error(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+    ) -> None:
+        """Test compression_level=10 raises ValueError with clear message.
+
+        Given: compression_level=10 passed to initialize()
+        When: Calling initialize()
+        Then: ValueError is raised mentioning valid range 1-9
+        """
+        handler = HandlerMemoryArchive(container)
+
+        with pytest.raises(
+            ValueError, match="compression_level must be between 1 and 9"
+        ):
+            await handler.initialize(
+                db_pool=None,
+                archive_base_path=archive_base_path,
+                compression_level=10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_level_negative_raises_value_error(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+    ) -> None:
+        """Test negative compression_level raises ValueError.
+
+        Given: compression_level=-1 passed to initialize()
+        When: Calling initialize()
+        Then: ValueError is raised
+        """
+        handler = HandlerMemoryArchive(container)
+
+        with pytest.raises(
+            ValueError, match="compression_level must be between 1 and 9"
+        ):
+            await handler.initialize(
+                db_pool=None,
+                archive_base_path=archive_base_path,
+                compression_level=-1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_env_var_value_raises_value_error(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test out-of-range env var raises ValueError.
+
+        Given: OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL=0 set in environment
+        When: Calling initialize() without explicit compression_level
+        Then: ValueError is raised mentioning valid range 1-9
+        """
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", "0")
+
+        handler = HandlerMemoryArchive(container)
+
+        with pytest.raises(
+            ValueError, match="compression_level must be between 1 and 9"
+        ):
+            await handler.initialize(db_pool=None, archive_base_path=archive_base_path)
+
+    @pytest.mark.asyncio
+    async def test_non_integer_env_var_raises_value_error(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test non-integer env var raises ValueError with clear message.
+
+        Given: OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL="fast" set in environment
+        When: Calling initialize() without explicit compression_level
+        Then: ValueError is raised mentioning the invalid value
+        """
+        monkeypatch.setenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", "fast")
+
+        handler = HandlerMemoryArchive(container)
+
+        with pytest.raises(
+            ValueError,
+            match="OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL must be an integer",
+        ):
+            await handler.initialize(db_pool=None, archive_base_path=archive_base_path)
+
+    @pytest.mark.asyncio
+    async def test_compression_level_reflected_in_describe(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test describe() reports the configured compression level.
+
+        Given: Handler initialized with compression_level=2
+        When: Calling describe()
+        Then: ModelMemoryArchiveMetadata.compression_level is 2
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=2,
+        )
+
+        metadata = await handler.describe()
+
+        assert metadata.compression_level == 2
+
+    @pytest.mark.asyncio
+    async def test_compression_level_affects_serialize_output(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        memory_id: UUID,
+        fixed_now: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that compression level is actually used during serialization.
+
+        Given: Two handlers with different compression levels (1 and 9)
+        When: Serializing the same record
+        Then: Both produce valid, decompressible gzip data with the same content
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        record = ModelArchiveRecord(
+            memory_id=memory_id,
+            content="x" * 10000,  # Repeated content compresses well
+            content_type="text/plain",
+            created_at=fixed_now,
+            expired_at=fixed_now,
+            archived_at=fixed_now,
+            lifecycle_revision=1,
+        )
+
+        handler_fast = HandlerMemoryArchive(container)
+        await handler_fast.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=1,
+        )
+
+        handler_best = HandlerMemoryArchive(container)
+        await handler_best.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=9,
+        )
+
+        compressed_fast = handler_fast._serialize_for_archive_sync(record)
+        compressed_best = handler_best._serialize_for_archive_sync(record)
+
+        # Both outputs must be valid gzip and decompress to the same content
+        decompressed_fast = gzip.decompress(compressed_fast)
+        decompressed_best = gzip.decompress(compressed_best)
+        assert decompressed_fast == decompressed_best
+
+        # Level 9 should produce equal or smaller output than level 1
+        # for highly compressible data (repeated characters)
+        assert len(compressed_best) <= len(compressed_fast)
+
+    @pytest.mark.asyncio
+    async def test_compression_level_resets_on_shutdown(
+        self,
+        container: ModelONEXContainer,
+        archive_base_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test compression level resets to default after shutdown.
+
+        Given: Handler initialized with compression_level=9
+        When: Calling shutdown()
+        Then: _compression_level resets to built-in default (6)
+        """
+        monkeypatch.delenv("OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL", raising=False)
+
+        handler = HandlerMemoryArchive(container)
+        await handler.initialize(
+            db_pool=None,
+            archive_base_path=archive_base_path,
+            compression_level=9,
+        )
+        assert handler.compression_level == 9
+
+        await handler.shutdown()
+
+        # After shutdown, compression_level property resets to default
+        assert handler.compression_level == handler._DEFAULT_COMPRESSION_LEVEL


### PR DESCRIPTION
## Summary

- Add `compression_level` constructor parameter to `HandlerMemoryArchive`
- Support `OMNIMEMORY_ARCHIVE_COMPRESSION_LEVEL` env var (resolution: constructor arg > env var > default 6)
- Validate range 1–9 with clear error messages including source of bad value
- Add read-only `compression_level` property
- `shutdown()` resets level back to default

## Test plan

- [x] 71 unit tests pass (`poetry run pytest -m unit`)
- [x] `mypy --strict` clean
- [x] `ruff check` + `ruff format` clean
- [x] Pre-commit hooks pass
- [x] Tests cover: default, constructor arg, env var, constructor-overrides-env-var, out-of-range, non-integer env var, reflect in `describe()`, actual gzip effect, reset on shutdown

## Related

Closes OMN-1544
Follows up on PR #24 (OMN-1453) code review feedback