### PR TITLE
feat(OMN-2385): add FilesystemCrawlerEffect with mtime+SHA-256 change detection

### DIFF
--- a/src/omnimemory/enums/__init__.py
+++ b/src/omnimemory/enums/__init__.py
@@ -4,6 +4,7 @@ ONEX-compliant enums for omnimemory system.
 All enums are centralized here for better maintainability and ONEX compliance.
 """
 
+from .crawl import EnumContextSourceType, EnumCrawlerType, EnumDetectedDocType
 from .enum_entity_extraction_mode import EnumEntityExtractionMode
 from .enum_error_code import EnumOmniMemoryErrorCode
 from .enum_intelligence_operation_type import EnumIntelligenceOperationType
@@ -21,7 +22,10 @@ from .enum_subscription_status import EnumSubscriptionStatus
 from .enum_trust_level import EnumDecayFunction, EnumTrustLevel
 
 __all__ = [
+    "EnumContextSourceType",
+    "EnumCrawlerType",
     "EnumDecayFunction",
+    "EnumDetectedDocType",
     "EnumEntityExtractionMode",
     "EnumFileProcessingStatus",
     "EnumIntelligenceOperationType",

--- a/src/omnimemory/enums/crawl/__init__.py
+++ b/src/omnimemory/enums/crawl/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Crawl-related enumerations for document ingestion pipeline."""
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+
+__all__ = [
+    "EnumContextSourceType",
+    "EnumCrawlerType",
+    "EnumDetectedDocType",
+]

--- a/src/omnimemory/enums/crawl/enum_context_source_type.py
+++ b/src/omnimemory/enums/crawl/enum_context_source_type.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Context source type enumeration for document ingestion pipeline."""
+
+from enum import Enum
+
+
+class EnumContextSourceType(str, Enum):
+    """Classifies the authoritative source of a ContextItem.
+
+    Used for bootstrap tier assignment and retrieval scoring. Documents
+    from higher-trust sources receive higher initial promotion tiers and
+    stricter promotion thresholds.
+
+    Attributes:
+        STATIC_STANDARDS: Manually curated authoritative documents such
+            as CLAUDE.md files and design documents. These start at
+            VALIDATED tier with bootstrap_confidence=0.85.
+        REPO_DERIVED: Documents derived from git repository content
+            (README.md, architecture docs, etc.). These start at
+            QUARANTINE tier.
+        MEMORY_HOOK: Items derived from agent execution hook events
+            (existing v0 system). Unchanged from v0 promotion rules.
+        LINEAR_TICKET: Issues and documents fetched from Linear.
+    """
+
+    STATIC_STANDARDS = "static_standards"
+    REPO_DERIVED = "repo_derived"
+    MEMORY_HOOK = "memory_hook"
+    LINEAR_TICKET = "linear_ticket"

--- a/src/omnimemory/enums/crawl/enum_crawler_type.py
+++ b/src/omnimemory/enums/crawl/enum_crawler_type.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Crawler type enumeration for document ingestion pipeline."""
+
+from enum import Enum
+
+
+class EnumCrawlerType(str, Enum):
+    """Identifies the crawler that produced a crawl event.
+
+    Each crawler type has distinct source characteristics and change
+    detection strategies as described in the document ingestion pipeline
+    design (DESIGN_OMNIMEMORY_DOCUMENT_INGESTION_PIPELINE.md §5).
+
+    Attributes:
+        FILESYSTEM: Walks configured path prefixes for .md files using
+            mtime + SHA-256 change detection.
+        GIT_REPO: Scans git repositories via git log/diff, versioned by
+            commit SHA.
+        LINEAR: Fetches Linear issues and documents, deduplicated via
+            updatedAt timestamps.
+        WATCHDOG: Receives FSEvents/inotify notifications for unversioned
+            critical files.
+    """
+
+    FILESYSTEM = "filesystem"
+    GIT_REPO = "git_repo"
+    LINEAR = "linear"
+    WATCHDOG = "watchdog"

--- a/src/omnimemory/enums/crawl/enum_detected_doc_type.py
+++ b/src/omnimemory/enums/crawl/enum_detected_doc_type.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Detected document type enumeration for document ingestion pipeline."""
+
+from enum import Enum
+
+
+class EnumDetectedDocType(str, Enum):
+    """Classification of document type for chunking strategy selection.
+
+    Rules are applied in priority order by DetectedDocTypeClassifier.
+    Each type maps to a distinct chunking strategy in DocumentParserCompute.
+
+    Attributes:
+        CLAUDE_MD: Any file named CLAUDE.md (highest priority — section-split).
+        DESIGN_DOC: Files under design/ directories.
+        ARCHITECTURE_DOC: Files matching *ARCHITECTURE*.md or *OVERVIEW*.md.
+        PLAN: Files under plans/ directories.
+        HANDOFF: Files under handoffs/ directories.
+        README: README.md at repo root level.
+        TICKET: Linear issue fetched via MCP.
+        LINEAR_DOCUMENT: Linear document fetched via MCP.
+        DEEP_DIVE: Files matching *DEEP_DIVE*.md.
+        UNKNOWN_MD: Any .md file that matches none of the above rules.
+    """
+
+    CLAUDE_MD = "claude_md"
+    DESIGN_DOC = "design_doc"
+    ARCHITECTURE_DOC = "architecture_doc"
+    PLAN = "plan"
+    HANDOFF = "handoff"
+    README = "readme"
+    TICKET = "ticket"
+    LINEAR_DOCUMENT = "linear_document"
+    DEEP_DIVE = "deep_dive"
+    UNKNOWN_MD = "unknown_md"

--- a/src/omnimemory/models/__init__.py
+++ b/src/omnimemory/models/__init__.py
@@ -24,6 +24,7 @@ from . import (
     config,
     container,
     core,
+    crawl,
     events,
     foundation,
     intelligence,
@@ -32,6 +33,12 @@ from . import (
     subscription,
     utils,
 )
+from .crawl import (
+    ModelCrawlStateRecord,
+    ModelDocumentChangedEvent,
+    ModelDocumentDiscoveredEvent,
+    ModelDocumentRemovedEvent,
+)
 
 # Re-export domains for direct access
 __all__ = [
@@ -39,6 +46,7 @@ __all__ = [
     "config",
     "container",
     "core",
+    "crawl",
     "events",
     "foundation",
     "intelligence",
@@ -46,4 +54,9 @@ __all__ = [
     "service",
     "subscription",
     "utils",
+    # Crawl models
+    "ModelCrawlStateRecord",
+    "ModelDocumentChangedEvent",
+    "ModelDocumentDiscoveredEvent",
+    "ModelDocumentRemovedEvent",
 ]

--- a/src/omnimemory/models/crawl/__init__.py
+++ b/src/omnimemory/models/crawl/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Crawl-related models for the document ingestion pipeline."""
+
+from omnimemory.models.crawl.model_crawl_state_record import ModelCrawlStateRecord
+from omnimemory.models.crawl.model_document_changed_event import (
+    ModelDocumentChangedEvent,
+)
+from omnimemory.models.crawl.model_document_discovered_event import (
+    ModelDocumentDiscoveredEvent,
+)
+from omnimemory.models.crawl.model_document_removed_event import (
+    ModelDocumentRemovedEvent,
+)
+
+__all__ = [
+    "ModelCrawlStateRecord",
+    "ModelDocumentChangedEvent",
+    "ModelDocumentDiscoveredEvent",
+    "ModelDocumentRemovedEvent",
+]

--- a/src/omnimemory/models/crawl/__init__.py
+++ b/src/omnimemory/models/crawl/__init__.py
@@ -12,10 +12,12 @@ from omnimemory.models.crawl.model_document_discovered_event import (
 from omnimemory.models.crawl.model_document_removed_event import (
     ModelDocumentRemovedEvent,
 )
+from omnimemory.models.crawl.types import TriggerSource
 
 __all__ = [
     "ModelCrawlStateRecord",
     "ModelDocumentChangedEvent",
     "ModelDocumentDiscoveredEvent",
     "ModelDocumentRemovedEvent",
+    "TriggerSource",
 ]

--- a/src/omnimemory/models/crawl/model_crawl_state_record.py
+++ b/src/omnimemory/models/crawl/model_crawl_state_record.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Crawl state record model for the omnimemory_crawl_state table."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+
+
+class ModelCrawlStateRecord(BaseModel):
+    """Represents a row in the omnimemory_crawl_state table.
+
+    Stores the last known state of each crawled document, enabling the
+    two-stage mtime → SHA-256 change detection strategy.
+
+    Primary key: (source_ref, crawler_type, scope_ref).
+
+    The scope_ref is included in the PK so that if scope mapping
+    configuration changes (file moves between scopes, or mapping is
+    reconfigured), a clean re-index is required. Without scope_ref in
+    the PK, stale crawl entries would silently block re-indexing under
+    the new scope assignment.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    source_ref: str = Field(
+        ...,
+        description=(
+            "Absolute path for filesystem crawls, URL for web crawls, "
+            "or Linear ID for Linear crawls"
+        ),
+    )
+    crawler_type: EnumCrawlerType = Field(
+        ...,
+        description="Identifies which crawler produced this state record",
+    )
+    scope_ref: str = Field(
+        ...,
+        description=(
+            "Scope assignment for this document (e.g. 'omninode/omnimemory'). "
+            "Included in PK for scope migration safety"
+        ),
+    )
+    content_fingerprint: str = Field(
+        ...,
+        description="SHA-256 hex digest of the document content at last crawl",
+    )
+    source_version: str | None = Field(
+        default=None,
+        description=(
+            "Version identifier: git SHA for repo files, Linear updatedAt for "
+            "Linear items, or None for unversioned filesystem files"
+        ),
+    )
+    last_crawled_at_utc: datetime = Field(
+        ...,
+        description="UTC timestamp of the most recent crawl attempt for this document",
+    )
+    last_changed_at_utc: datetime | None = Field(
+        default=None,
+        description=(
+            "UTC timestamp when content last changed; None if never changed "
+            "since first indexing"
+        ),
+    )
+    last_known_mtime: float | None = Field(
+        default=None,
+        description=(
+            "stat.st_mtime value at last crawl for FilesystemCrawler fast-path. "
+            "Not persisted by other crawler types"
+        ),
+    )

--- a/src/omnimemory/models/crawl/model_crawl_state_record.py
+++ b/src/omnimemory/models/crawl/model_crawl_state_record.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
 
@@ -73,3 +73,17 @@ class ModelCrawlStateRecord(BaseModel):
             "Not persisted by other crawler types"
         ),
     )
+
+    @field_validator("last_crawled_at_utc", mode="after")
+    @classmethod
+    def _require_tz_crawled(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("last_crawled_at_utc must be timezone-aware (UTC)")
+        return v
+
+    @field_validator("last_changed_at_utc", mode="after")
+    @classmethod
+    def _require_tz_changed(cls, v: datetime | None) -> datetime | None:
+        if v is not None and v.tzinfo is None:
+            raise ValueError("last_changed_at_utc must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/models/crawl/model_document_changed_event.py
+++ b/src/omnimemory/models/crawl/model_document_changed_event.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
 from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+from omnimemory.models.crawl.types import TriggerSource
 
 
 class ModelDocumentChangedEvent(BaseModel):
@@ -57,11 +58,9 @@ class ModelDocumentChangedEvent(BaseModel):
         ...,
         description="Scope string from the originating crawl tick",
     )
-    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
-        Field(
-            ...,
-            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
-        )
+    trigger_source: TriggerSource = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
     )
 
     # Document identity

--- a/src/omnimemory/models/crawl/model_document_changed_event.py
+++ b/src/omnimemory/models/crawl/model_document_changed_event.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
@@ -122,3 +122,10 @@ class ModelDocumentChangedEvent(BaseModel):
         default=None,
         description="Version identifier before the change (git SHA, Linear updatedAt, or None)",
     )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/models/crawl/model_document_changed_event.py
+++ b/src/omnimemory/models/crawl/model_document_changed_event.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Document changed event model for document ingestion pipeline."""
+
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+
+
+class ModelDocumentChangedEvent(BaseModel):
+    """Emitted when a previously crawled document has new content.
+
+    Extends the discovered event shape with previous-version fields so
+    downstream processors can perform diff analysis, stat carry-over,
+    and staleness transitions atomically.
+
+    Published to: {env}.onex.evt.omnimemory.document-changed.v1
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentChanged"] = Field(
+        default="DocumentChanged",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating crawl tick command",
+    )
+    emitted_at_utc: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    # Crawler metadata
+    crawler_type: EnumCrawlerType = Field(
+        ...,
+        description="Crawler that detected the change",
+    )
+    crawl_scope: str = Field(
+        ...,
+        description="Scope string from the originating crawl tick",
+    )
+    trigger_source: str = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+    )
+
+    # Document identity
+    source_ref: str = Field(
+        ...,
+        description="Absolute path, URL, or Linear ID",
+    )
+    source_type: EnumContextSourceType = Field(
+        ...,
+        description="Authoritative source classification",
+    )
+    source_version: str | None = Field(
+        default=None,
+        description="New version identifier after the change",
+    )
+
+    # Current content
+    content_fingerprint: str = Field(
+        ...,
+        description="SHA-256 hex digest of the new content",
+    )
+    content_blob_ref: str = Field(
+        ...,
+        description="Pointer to blob storage entry for the new content",
+    )
+    token_estimate: int = Field(
+        ...,
+        ge=0,
+        description="Estimated token count of the new content",
+    )
+
+    # Scope and classification
+    scope_ref: str = Field(
+        ...,
+        description="Resolved scope assignment",
+    )
+    detected_doc_type: EnumDetectedDocType = Field(
+        ...,
+        description="Document type classification",
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Classification tags",
+    )
+    priority_hint: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="Initial priority score 0-100",
+    )
+
+    # Previous version fields (what changed)
+    previous_content_fingerprint: str = Field(
+        ...,
+        description="SHA-256 hex digest of the content before the change",
+    )
+    previous_source_version: str | None = Field(
+        default=None,
+        description="Version identifier before the change (git SHA, Linear updatedAt, or None)",
+    )

--- a/src/omnimemory/models/crawl/model_document_changed_event.py
+++ b/src/omnimemory/models/crawl/model_document_changed_event.py
@@ -57,9 +57,11 @@ class ModelDocumentChangedEvent(BaseModel):
         ...,
         description="Scope string from the originating crawl tick",
     )
-    trigger_source: str = Field(
-        ...,
-        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
+        Field(
+            ...,
+            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+        )
     )
 
     # Document identity

--- a/src/omnimemory/models/crawl/model_document_changed_event.py
+++ b/src/omnimemory/models/crawl/model_document_changed_event.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Document changed event model for document ingestion pipeline."""
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
@@ -42,7 +43,7 @@ class ModelDocumentChangedEvent(BaseModel):
         ...,
         description="Correlation ID threaded from the originating crawl tick command",
     )
-    emitted_at_utc: str = Field(
+    emitted_at_utc: datetime = Field(
         ...,
         description="ISO-8601 UTC timestamp when this event was emitted",
     )

--- a/src/omnimemory/models/crawl/model_document_discovered_event.py
+++ b/src/omnimemory/models/crawl/model_document_discovered_event.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
 from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+from omnimemory.models.crawl.types import TriggerSource
 
 
 class ModelDocumentDiscoveredEvent(BaseModel):
@@ -53,11 +54,9 @@ class ModelDocumentDiscoveredEvent(BaseModel):
         ...,
         description="Scope string from the originating crawl tick (e.g. 'omninode/omnimemory')",
     )
-    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
-        Field(
-            ...,
-            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
-        )
+    trigger_source: TriggerSource = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
     )
 
     # Document identity

--- a/src/omnimemory/models/crawl/model_document_discovered_event.py
+++ b/src/omnimemory/models/crawl/model_document_discovered_event.py
@@ -53,9 +53,11 @@ class ModelDocumentDiscoveredEvent(BaseModel):
         ...,
         description="Scope string from the originating crawl tick (e.g. 'omninode/omnimemory')",
     )
-    trigger_source: str = Field(
-        ...,
-        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
+        Field(
+            ...,
+            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+        )
     )
 
     # Document identity

--- a/src/omnimemory/models/crawl/model_document_discovered_event.py
+++ b/src/omnimemory/models/crawl/model_document_discovered_event.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Document discovered event model for document ingestion pipeline."""
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
@@ -38,7 +39,7 @@ class ModelDocumentDiscoveredEvent(BaseModel):
         ...,
         description="Correlation ID threaded from the originating crawl tick command",
     )
-    emitted_at_utc: str = Field(
+    emitted_at_utc: datetime = Field(
         ...,
         description="ISO-8601 UTC timestamp when this event was emitted",
     )

--- a/src/omnimemory/models/crawl/model_document_discovered_event.py
+++ b/src/omnimemory/models/crawl/model_document_discovered_event.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Document discovered event model for document ingestion pipeline."""
+
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+
+
+class ModelDocumentDiscoveredEvent(BaseModel):
+    """Emitted when a new document is found during crawl with no prior state.
+
+    Published to: {env}.onex.evt.omnimemory.document-discovered.v1
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentDiscovered"] = Field(
+        default="DocumentDiscovered",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating crawl tick command",
+    )
+    emitted_at_utc: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    # Crawler metadata
+    crawler_type: EnumCrawlerType = Field(
+        ...,
+        description="Crawler that discovered this document",
+    )
+    crawl_scope: str = Field(
+        ...,
+        description="Scope string from the originating crawl tick (e.g. 'omninode/omnimemory')",
+    )
+    trigger_source: str = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+    )
+
+    # Document identity
+    source_ref: str = Field(
+        ...,
+        description="Absolute path, URL, or Linear ID that uniquely identifies this document",
+    )
+    source_type: EnumContextSourceType = Field(
+        ...,
+        description="Authoritative source classification for bootstrap tier assignment",
+    )
+    source_version: str | None = Field(
+        default=None,
+        description="Git SHA, Linear updatedAt, or None for unversioned filesystem files",
+    )
+
+    # Content fingerprint (content stored in blob store, not inline)
+    content_fingerprint: str = Field(
+        ...,
+        description="SHA-256 hex digest of the raw document content",
+    )
+    content_blob_ref: str = Field(
+        ...,
+        description=(
+            "Pointer to blob storage entry containing the raw content. "
+            "Format: 'sha256:<hex>' for content-addressed storage"
+        ),
+    )
+    token_estimate: int = Field(
+        ...,
+        ge=0,
+        description="Estimated token count computed as len(content) // 4",
+    )
+
+    # Scope and classification
+    scope_ref: str = Field(
+        ...,
+        description=(
+            "Resolved scope assignment for this document "
+            "(e.g. 'omninode/omnimemory')"
+        ),
+    )
+    detected_doc_type: EnumDetectedDocType = Field(
+        ...,
+        description="Document type classification for chunking strategy selection",
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Classification tags including file path, repo name, doc type, "
+            "and language tags"
+        ),
+    )
+    priority_hint: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description=(
+            "Initial priority score 0-100 based on source pattern. "
+            "The scoring system adjusts this over time"
+        ),
+    )

--- a/src/omnimemory/models/crawl/model_document_discovered_event.py
+++ b/src/omnimemory/models/crawl/model_document_discovered_event.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
@@ -120,3 +120,10 @@ class ModelDocumentDiscoveredEvent(BaseModel):
             "The scoring system adjusts this over time"
         ),
     )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/models/crawl/model_document_removed_event.py
+++ b/src/omnimemory/models/crawl/model_document_removed_event.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
@@ -76,3 +76,10 @@ class ModelDocumentRemovedEvent(BaseModel):
         default=None,
         description="Version identifier at the last successful crawl",
     )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/models/crawl/model_document_removed_event.py
+++ b/src/omnimemory/models/crawl/model_document_removed_event.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 OmniNode Team
 """Document removed event model for document ingestion pipeline."""
 
+from datetime import datetime
 from typing import Literal
 from uuid import UUID, uuid4
 
@@ -40,7 +41,7 @@ class ModelDocumentRemovedEvent(BaseModel):
         ...,
         description="Correlation ID threaded from the originating crawl tick command",
     )
-    emitted_at_utc: str = Field(
+    emitted_at_utc: datetime = Field(
         ...,
         description="ISO-8601 UTC timestamp when this event was emitted",
     )

--- a/src/omnimemory/models/crawl/model_document_removed_event.py
+++ b/src/omnimemory/models/crawl/model_document_removed_event.py
@@ -50,6 +50,12 @@ class ModelDocumentRemovedEvent(BaseModel):
         ...,
         description="Crawler that detected the removal",
     )
+    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
+        Field(
+            ...,
+            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+        )
+    )
     source_ref: str = Field(
         ...,
         description="Absolute path, URL, or Linear ID of the removed document",

--- a/src/omnimemory/models/crawl/model_document_removed_event.py
+++ b/src/omnimemory/models/crawl/model_document_removed_event.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
 from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.models.crawl.types import TriggerSource
 
 
 class ModelDocumentRemovedEvent(BaseModel):
@@ -50,11 +51,9 @@ class ModelDocumentRemovedEvent(BaseModel):
         ...,
         description="Crawler that detected the removal",
     )
-    trigger_source: Literal["scheduled", "manual", "git_hook", "filesystem_watch"] = (
-        Field(
-            ...,
-            description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
-        )
+    trigger_source: TriggerSource = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
     )
     source_ref: str = Field(
         ...,

--- a/src/omnimemory/models/crawl/model_document_removed_event.py
+++ b/src/omnimemory/models/crawl/model_document_removed_event.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Document removed event model for document ingestion pipeline."""
+
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+
+
+class ModelDocumentRemovedEvent(BaseModel):
+    """Emitted when a document in the crawl state table is no longer found.
+
+    Downstream processors (DocStalenessDetectorEffect, Stream C) use this
+    event to immediately blacklist the corresponding ContextItems.
+
+    Published to: {env}.onex.evt.omnimemory.document-removed.v1
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentRemoved"] = Field(
+        default="DocumentRemoved",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating crawl tick command",
+    )
+    emitted_at_utc: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    crawler_type: EnumCrawlerType = Field(
+        ...,
+        description="Crawler that detected the removal",
+    )
+    source_ref: str = Field(
+        ...,
+        description="Absolute path, URL, or Linear ID of the removed document",
+    )
+    source_type: EnumContextSourceType = Field(
+        ...,
+        description="Authoritative source classification of the removed document",
+    )
+    scope_ref: str = Field(
+        ...,
+        description="Scope assignment of the removed document",
+    )
+    last_known_content_fingerprint: str = Field(
+        ...,
+        description="SHA-256 hex digest of the content at the last successful crawl",
+    )
+    last_known_source_version: str | None = Field(
+        default=None,
+        description="Version identifier at the last successful crawl",
+    )

--- a/src/omnimemory/models/crawl/types.py
+++ b/src/omnimemory/models/crawl/types.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Shared type aliases for the crawl domain."""
+
+from typing import Literal
+
+__all__ = ["TriggerSource"]
+
+# Valid trigger sources for crawl events.
+# Used by event models and the FilesystemCrawler handler.
+TriggerSource = Literal["scheduled", "manual", "git_hook", "filesystem_watch"]

--- a/src/omnimemory/models/subscription/model_notification_event.py
+++ b/src/omnimemory/models/subscription/model_notification_event.py
@@ -19,7 +19,9 @@ from .model_notification_event_payload import (
 class ModelNotificationEvent(BaseModel):
     """Notification event for memory changes following ONEX standards."""
 
-    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+    model_config = ConfigDict(
+        frozen=True, extra="forbid", strict=True, from_attributes=True
+    )
 
     event_id: str = Field(
         description="Unique event identifier (non-empty string)",

--- a/src/omnimemory/nodes/__init__.py
+++ b/src/omnimemory/nodes/__init__.py
@@ -29,6 +29,11 @@ from omnimemory.nodes.base import (
     BaseReducerNode,
     ContainerType,
 )
+from omnimemory.nodes.filesystem_crawler_effect import (
+    HandlerFilesystemCrawler,
+    ModelFilesystemCrawlerConfig,
+    ModelFilesystemCrawlResult,
+)
 from omnimemory.nodes.intent_event_consumer_effect import (
     HandlerIntentEventConsumer,
     ModelIntentEventConsumerConfig,
@@ -49,6 +54,9 @@ __all__: list[str] = [
     "HandlerIntentEventConsumer",
     "ModelIntentEventConsumerConfig",
     "ModelIntentEventConsumerHealth",
+    "HandlerFilesystemCrawler",
+    "ModelFilesystemCrawlResult",
+    "ModelFilesystemCrawlerConfig",
     # Compute nodes
     "semantic_analyzer_compute",
     "similarity_compute",

--- a/src/omnimemory/nodes/__init__.py
+++ b/src/omnimemory/nodes/__init__.py
@@ -32,7 +32,7 @@ from omnimemory.nodes.base import (
 from omnimemory.nodes.filesystem_crawler_effect import (
     HandlerFilesystemCrawler,
     ModelFilesystemCrawlerConfig,
-    ModelFilesystemCrawlResult,
+    ModelFilesystemCrawlResult,  # omnimemory-model-exempt: handler result
 )
 from omnimemory.nodes.intent_event_consumer_effect import (
     HandlerIntentEventConsumer,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/__init__.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""FilesystemCrawlerEffect node: walk filesystem for .md files with change detection."""
+
+from omnimemory.nodes.filesystem_crawler_effect.handler_filesystem_crawler import (
+    HandlerFilesystemCrawler,
+)
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawl_result import (
+    ModelFilesystemCrawlResult,
+)
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawler_config import (
+    ModelFilesystemCrawlerConfig,
+)
+
+__all__ = [
+    "HandlerFilesystemCrawler",
+    "ModelFilesystemCrawlResult",
+    "ModelFilesystemCrawlerConfig",
+]

--- a/src/omnimemory/nodes/filesystem_crawler_effect/contract.yaml
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/contract.yaml
@@ -1,0 +1,119 @@
+---
+# ONEX Contract: filesystem_crawler_effect
+# Walks configured filesystem path prefixes for .md files and emits document lifecycle events
+
+name: filesystem_crawler_effect
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+node_type: EFFECT
+input_model: "ModelCrawlTickCommand"
+output_model: "ModelFilesystemCrawlResult"
+description: |
+  FilesystemCrawlerEffect walks configured path prefixes for .md files
+  and emits document lifecycle events using a two-stage mtime → SHA-256
+  change detection strategy.
+
+  Change detection (per design §5):
+    1. mtime fast-path: if stat.st_mtime is unchanged, skip without re-hashing.
+    2. If mtime changed: compute SHA-256(content). If hash also unchanged,
+       update last_crawled_at_utc only.
+    3. Not in state table: emit document.discovered.v1.
+    4. State table entries not found in walk: emit document.removed.v1.
+
+  Consumer group (when wired to crawl-tick topic):
+  {env}.omnimemory.filesystem_crawler_effect.consume.v1
+
+# =============================================================================
+# PUBLISHED EVENTS (Kafka) - Documentation Layer
+# =============================================================================
+published_events:
+  - topic_suffix: "onex.evt.omnimemory.document-discovered.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-discovered.v1"
+    event_type: "DocumentDiscovered"
+    trigger: "New .md file found with no prior crawl state"
+    description: "Emitted when a .md file is found for the first time. Downstream DocumentFetchEffect
+      uses this to fetch content and begin indexing."
+
+  - topic_suffix: "onex.evt.omnimemory.document-changed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-changed.v1"
+    event_type: "DocumentChanged"
+    trigger: "Previously crawled .md file has a different SHA-256 fingerprint"
+    description: "Emitted when a known file's content has changed. Includes both new and previous fingerprints
+      to support atomic staleness transitions."
+
+  - topic_suffix: "onex.evt.omnimemory.document-removed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-removed.v1"
+    event_type: "DocumentRemoved"
+    trigger: "State table entry not found in filesystem walk"
+    description: "Emitted for files present in crawl state but absent from the current walk. Triggers
+      immediate BLACKLISTED transition on ContextItems."
+
+# === EVENT TYPE CONFIGURATION ===
+event_type:
+  version: {major: 1, minor: 0, patch: 0}
+  primary_events:
+    - "document_discovered"
+    - "document_changed"
+    - "document_removed"
+  event_categories: ["crawl", "document", "filesystem", "effect"]
+  publish_events: true
+  subscribe_events: true
+  event_routing: "crawl"
+  invocation_mode: "subscription"
+
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to (receives crawl tick commands)
+  subscribe_topics:
+    - "onex.cmd.omnimemory.crawl-tick.v1"
+
+  # Topics this node publishes to (document lifecycle events)
+  publish_topics:
+    - "onex.evt.omnimemory.document-discovered.v1"
+    - "onex.evt.omnimemory.document-changed.v1"
+    - "onex.evt.omnimemory.document-removed.v1"
+
+  # Metadata for subscribed topics
+  subscribe_topic_metadata:
+    "onex.cmd.omnimemory.crawl-tick.v1":
+      schema_ref: "omnimemory.models.crawl.ModelCrawlTickCommand"
+      description: "Crawl tick command issued by CrawlSchedulerEffect or manual trigger. Contains crawl_type=filesystem,
+        crawl_scope, correlation_id, and trigger_source."
+
+  # Metadata for published topics
+  publish_topic_metadata:
+    "onex.evt.omnimemory.document-discovered.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_discovered_event.ModelDocumentDiscoveredEvent"
+      description: "Document discovered event. Published when a .md file is found for the first time with
+        no prior crawl state."
+
+    "onex.evt.omnimemory.document-changed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_changed_event.ModelDocumentChangedEvent"
+      description: "Document changed event. Published when a known file's SHA-256 fingerprint differs
+        from the stored fingerprint."
+
+    "onex.evt.omnimemory.document-removed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_removed_event.ModelDocumentRemovedEvent"
+      description: "Document removed event. Published for state table entries whose source_ref is absent
+        from the current filesystem walk."
+
+# === HANDLER CONFIGURATION ===
+handler_config:
+  handler_class: "HandlerFilesystemCrawler"
+  handler_module: "omnimemory.nodes.filesystem_crawler_effect.handler_filesystem_crawler"
+
+# === DEPENDENCIES ===
+dependencies:
+  - name: "ProtocolCrawlStateRepository"
+    type: "protocol"
+    required: true
+    description: "Repository for loading and persisting crawl state records"

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -363,7 +363,6 @@ class HandlerFilesystemCrawler:
         """
         resolved_mappings = scope_mappings or []
         now_utc = datetime.now(timezone.utc)
-        now_iso = now_utc.isoformat()
 
         files_walked = 0
         discovered_count = 0
@@ -490,7 +489,7 @@ class HandlerFilesystemCrawler:
                     # New document
                     discovered_event = ModelDocumentDiscoveredEvent(
                         correlation_id=correlation_id,
-                        emitted_at_utc=now_iso,
+                        emitted_at_utc=now_utc,
                         crawler_type=EnumCrawlerType.FILESYSTEM,
                         crawl_scope=crawl_scope,
                         trigger_source=trigger_source,
@@ -544,7 +543,7 @@ class HandlerFilesystemCrawler:
                     # Content changed
                     changed_event = ModelDocumentChangedEvent(
                         correlation_id=correlation_id,
-                        emitted_at_utc=now_iso,
+                        emitted_at_utc=now_utc,
                         crawler_type=EnumCrawlerType.FILESYSTEM,
                         crawl_scope=crawl_scope,
                         trigger_source=trigger_source,
@@ -590,7 +589,7 @@ class HandlerFilesystemCrawler:
             scope_refs_seen=scope_refs_seen,
             crawl_scope=crawl_scope,
             correlation_id=correlation_id,
-            emitted_at_utc=now_iso,
+            emitted_at_utc=now_utc,
             env_prefix=env_prefix,
             publish_callback=publish_callback,
             resolved_mappings=resolved_mappings,
@@ -631,7 +630,7 @@ class HandlerFilesystemCrawler:
         scope_refs_seen: set[str],
         crawl_scope: str,
         correlation_id: UUID,
-        emitted_at_utc: str,
+        emitted_at_utc: datetime,
         env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]
@@ -651,7 +650,7 @@ class HandlerFilesystemCrawler:
                 during the walk, collected as each file is processed.
             crawl_scope: Scope string from the crawl tick.
             correlation_id: Correlation ID for event envelope.
-            emitted_at_utc: ISO-8601 timestamp string.
+            emitted_at_utc: UTC datetime when the crawl run started.
             env_prefix: Environment prefix for topic construction.
             publish_callback: Async publish callback.
             resolved_mappings: Scope mappings for source_type resolution.

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -393,9 +393,13 @@ class HandlerFilesystemCrawler:
                 continue
 
             file_glob = self._config.file_glob
-            for md_path in await asyncio.to_thread(
-                lambda p=prefix_path, g=file_glob: list(p.rglob(g))
-            ):
+
+            def _rglob_prefix(
+                _p: Path = prefix_path, _g: str = file_glob
+            ) -> list[Path]:
+                return list(_p.rglob(_g))
+
+            for md_path in await asyncio.to_thread(_rglob_prefix):
                 if files_walked >= self._config.max_files_per_crawl:
                     truncated = True
                     logger.warning(

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -419,7 +419,6 @@ class HandlerFilesystemCrawler:
 
                 files_walked += 1
                 abs_path_str = str(md_path.resolve())
-                walked_paths.add(abs_path_str)
 
                 try:
                     stat = await asyncio.to_thread(md_path.stat)
@@ -435,6 +434,10 @@ class HandlerFilesystemCrawler:
                     )
                     error_count += 1
                     continue
+
+                # Only mark as walked after a successful stat — a file deleted
+                # between rglob and stat must not be treated as "seen"
+                walked_paths.add(abs_path_str)
 
                 if stat.st_size > self._config.max_file_size_bytes:
                     logger.warning(
@@ -596,17 +599,31 @@ class HandlerFilesystemCrawler:
             if truncated:
                 break
 
-        # Detect removals: state table entries not found in the walk
-        removed_count = await self._detect_and_emit_removals(
-            walked_paths=walked_paths,
-            scope_refs_seen=scope_refs_seen,
-            correlation_id=correlation_id,
-            emitted_at_utc=now_utc,
-            trigger_source=trigger_source,
-            env_prefix=env_prefix,
-            publish_callback=publish_callback,
-            resolved_mappings=resolved_mappings,
-        )
+        # Detect removals: state table entries not found in the walk.
+        # Skip when truncated — walked_paths is a subset of disk, so removal
+        # detection would emit spurious events for unvisited files.
+        if truncated:
+            logger.warning(
+                "crawl truncated at max_files_per_crawl; skipping removal"
+                " detection to avoid spurious removals",
+                extra={
+                    "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                    "max_files_per_crawl": self._config.max_files_per_crawl,
+                    "correlation_id": str(correlation_id),
+                },
+            )
+            removed_count = 0
+        else:
+            removed_count = await self._detect_and_emit_removals(
+                walked_paths=walked_paths,
+                scope_refs_seen=scope_refs_seen,
+                correlation_id=correlation_id,
+                emitted_at_utc=now_utc,
+                trigger_source=trigger_source,
+                env_prefix=env_prefix,
+                publish_callback=publish_callback,
+                resolved_mappings=resolved_mappings,
+            )
 
         result = ModelFilesystemCrawlResult(
             files_walked=files_walked,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -67,7 +67,7 @@ import logging
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
@@ -88,6 +88,7 @@ from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawl_re
 )
 
 if TYPE_CHECKING:
+    from omnimemory.models.crawl.types import TriggerSource
     from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawler_config import (
         ModelFilesystemCrawlerConfig,
     )
@@ -110,9 +111,6 @@ _STATIC_STANDARDS_PREFIXES: tuple[str, ...] = (str(Path("~/.claude").expanduser(
 
 # Intermediate directory names excluded when heuristically extracting repo names from paths
 _SKIP_DIRS: frozenset[str] = frozenset({"src", "docs", "design", "plans", "handoffs"})
-
-# Valid trigger sources for crawl events
-TriggerSource = Literal["scheduled", "manual", "git_hook", "filesystem_watch"]
 
 
 def _compute_sha256(content: bytes) -> str:
@@ -418,7 +416,8 @@ class HandlerFilesystemCrawler:
                     break
 
                 files_walked += 1
-                abs_path_str = str(md_path.resolve())
+                resolved_path: Path = await asyncio.to_thread(md_path.resolve)
+                abs_path_str = str(resolved_path)
 
                 try:
                     stat = await asyncio.to_thread(md_path.stat)
@@ -453,7 +452,7 @@ class HandlerFilesystemCrawler:
                     skipped_count += 1
                     continue
 
-                scope_ref = _scope_ref_for_path(md_path.resolve(), resolved_mappings)
+                scope_ref = _scope_ref_for_path(resolved_path, resolved_mappings)
                 scope_refs_seen.add(scope_ref)
 
                 prior_state = await self._crawl_state_repo.get_state(
@@ -494,12 +493,12 @@ class HandlerFilesystemCrawler:
                 fingerprint = _compute_sha256(content)
                 blob_ref = f"sha256:{fingerprint}"
                 token_estimate = len(content) // 4
-                doc_type = _detect_doc_type(md_path.resolve())
-                source_type = _source_type_for_path(md_path.resolve())
+                doc_type = _detect_doc_type(resolved_path)
+                source_type = _source_type_for_path(resolved_path)
                 priority = _priority_hint_for_path(
-                    md_path.resolve(), self._config.path_prefixes
+                    resolved_path, self._config.path_prefixes
                 )
-                tags = _extract_tags(md_path.resolve(), doc_type)
+                tags = _extract_tags(resolved_path, doc_type)
 
                 if prior_state is None:
                     # New document

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -369,6 +369,7 @@ class HandlerFilesystemCrawler:
         changed_count = 0
         unchanged_count = 0
         skipped_count = 0
+        mtime_skipped_count = 0
         error_count = 0
         truncated = False
 
@@ -381,7 +382,7 @@ class HandlerFilesystemCrawler:
 
         for prefix_str in self._config.path_prefixes:
             prefix_path = Path(prefix_str)
-            if not prefix_path.exists():
+            if not await asyncio.to_thread(prefix_path.exists):
                 logger.warning(
                     "Path prefix does not exist, skipping",
                     extra={
@@ -392,7 +393,10 @@ class HandlerFilesystemCrawler:
                 )
                 continue
 
-            for md_path in prefix_path.rglob(self._config.file_glob):
+            file_glob = self._config.file_glob
+            for md_path in await asyncio.to_thread(
+                lambda p=prefix_path, g=file_glob: list(p.rglob(g))
+            ):
                 if files_walked >= self._config.max_files_per_crawl:
                     truncated = True
                     logger.warning(
@@ -410,7 +414,7 @@ class HandlerFilesystemCrawler:
                 walked_paths.add(abs_path_str)
 
                 try:
-                    stat = md_path.stat()
+                    stat = await asyncio.to_thread(md_path.stat)
                 except OSError as exc:
                     logger.warning(
                         "Could not stat file, skipping",
@@ -467,6 +471,7 @@ class HandlerFilesystemCrawler:
                         last_known_mtime=current_mtime,
                     )
                     await self._crawl_state_repo.upsert_state(updated_state)
+                    mtime_skipped_count += 1
                     continue
 
                 # mtime changed (or no prior state) -- read and hash content
@@ -601,6 +606,7 @@ class HandlerFilesystemCrawler:
             changed_count=changed_count,
             unchanged_count=unchanged_count,
             skipped_count=skipped_count,
+            mtime_skipped_count=mtime_skipped_count,
             removed_count=removed_count,
             error_count=error_count,
             truncated=truncated,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -1,0 +1,764 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""FilesystemCrawler handler: walks path prefixes and emits document lifecycle events.
+
+Architecture:
+    This handler implements the Filesystem crawler described in the OmniMemory
+    Document Ingestion Pipeline design (§5 Crawl State and Change Detection).
+
+    Change Detection Strategy (two-stage):
+        1. mtime fast-path: if stat.st_mtime is unchanged vs stored state, skip
+           the file without re-reading or re-hashing it (most common case).
+        2. If mtime changed: compute SHA-256(content). If the hash is also
+           unchanged, update last_crawled_at_utc only (mtime bumped by an
+           editor without content change). If the hash differs, emit
+           document.changed.v1.
+        3. Not in state table: emit document.discovered.v1.
+        4. Records in state table but not found in walk: emit document.removed.v1.
+
+    Scope Assignment:
+        Path-to-scope mapping uses longest-prefix matching against the
+        scope_mappings list in ModelFilesystemCrawlerConfig. The first matching
+        prefix (in declaration order) wins. Paths with no match use
+        DEFAULT_SCOPE_REF.
+
+    Source Type Assignment:
+        static_standards: ~/.claude/ prefixes and **/CLAUDE.md
+        repo_derived: everything else
+
+    Priority Hints:
+        Computed by _priority_hint_for_path() following the table in design §7.
+
+    Blob Storage:
+        Content is addressed by 'sha256:<fingerprint>'. In this implementation
+        blobs are not persisted — only the fingerprint is computed and the
+        blob_ref is constructed as the content-addressed key. Blob persistence
+        is the responsibility of downstream processors (DocumentFetchEffect).
+
+Example::
+
+    from omnimemory.nodes.filesystem_crawler_effect.handler_filesystem_crawler import (
+        HandlerFilesystemCrawler,
+    )
+
+    async def example(state_repo, publisher, config):
+        handler = HandlerFilesystemCrawler(
+            config=config,
+            crawl_state_repo=state_repo,
+        )
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/omnimemory",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publisher,
+        )
+        print(f"discovered={result.discovered_count}")
+
+.. versionadded:: 0.4.0
+    Initial implementation for OMN-2385.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+from omnimemory.models.crawl.model_crawl_state_record import ModelCrawlStateRecord
+from omnimemory.models.crawl.model_document_changed_event import (
+    ModelDocumentChangedEvent,
+)
+from omnimemory.models.crawl.model_document_discovered_event import (
+    ModelDocumentDiscoveredEvent,
+)
+from omnimemory.models.crawl.model_document_removed_event import (
+    ModelDocumentRemovedEvent,
+)
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawl_result import (
+    ModelFilesystemCrawlResult,
+)
+
+if TYPE_CHECKING:
+    from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawler_config import (
+        ModelFilesystemCrawlerConfig,
+    )
+    from omnimemory.protocols.protocol_crawl_state_repository import (
+        ProtocolCrawlStateRepository,
+    )
+
+__all__ = ["HandlerFilesystemCrawler"]
+
+logger = logging.getLogger(__name__)
+
+HANDLER_ID_FILESYSTEM_CRAWLER: str = "filesystem-crawler"
+
+# Fallback scope used when no prefix matches
+DEFAULT_SCOPE_REF: str = "omninode/shared"
+
+# Mapping of path prefix patterns to EnumContextSourceType
+# Evaluated in order; first match wins.
+_STATIC_STANDARDS_PREFIXES: tuple[str, ...] = (str(Path("~/.claude").expanduser()),)
+
+
+def _compute_sha256(content: bytes) -> str:
+    """Return the lowercase hex SHA-256 digest of content."""
+    return hashlib.sha256(content).hexdigest()
+
+
+def _detect_doc_type(path: Path) -> EnumDetectedDocType:
+    """Classify the document type based on path heuristics.
+
+    Rules are evaluated in priority order per the design spec §8.
+    First match wins; no fallthrough.
+
+    Args:
+        path: Absolute path to the .md file.
+
+    Returns:
+        The detected document type enum value.
+    """
+    name = path.name
+    name_upper = name.upper()
+    parts_lower = [p.lower() for p in path.parts]
+
+    if name == "CLAUDE.md":
+        return EnumDetectedDocType.CLAUDE_MD
+
+    if name_upper.endswith(".MD") and (
+        "ARCHITECTURE" in name_upper or "OVERVIEW" in name_upper
+    ):
+        return EnumDetectedDocType.ARCHITECTURE_DOC
+
+    if name_upper.startswith("DEEP_DIVE") or "DEEP_DIVE" in name_upper:
+        return EnumDetectedDocType.DEEP_DIVE
+
+    if name.upper() == "README.MD":
+        return EnumDetectedDocType.README
+
+    if "design" in parts_lower:
+        return EnumDetectedDocType.DESIGN_DOC
+
+    if "plans" in parts_lower or "plan" in parts_lower:
+        return EnumDetectedDocType.PLAN
+
+    if "handoffs" in parts_lower or "handoff" in parts_lower:
+        return EnumDetectedDocType.HANDOFF
+
+    return EnumDetectedDocType.UNKNOWN_MD
+
+
+def _source_type_for_path(path: Path) -> EnumContextSourceType:
+    """Determine the context source type based on the file path.
+
+    CLAUDE.md files and files under ~/.claude/ are authoritative policy
+    documents (STATIC_STANDARDS). Everything else is REPO_DERIVED.
+
+    Args:
+        path: Absolute path to the .md file.
+
+    Returns:
+        The context source type enum value.
+    """
+    path_str = str(path)
+    for prefix in _STATIC_STANDARDS_PREFIXES:
+        if path_str.startswith(prefix):
+            return EnumContextSourceType.STATIC_STANDARDS
+
+    if path.name == "CLAUDE.md":
+        return EnumContextSourceType.STATIC_STANDARDS
+
+    return EnumContextSourceType.REPO_DERIVED
+
+
+def _priority_hint_for_path(path: Path, path_prefixes: list[str]) -> int:
+    """Compute the initial priority hint (0-100) for a document.
+
+    Follows the priority hint table in design doc §7.
+    The scoring system adjusts these values over time.
+
+    Args:
+        path: Absolute path to the .md file.
+        path_prefixes: Configured crawl path prefixes (as strings) used to
+            determine whether a README is at the repo root level.
+
+    Returns:
+        An integer in [0, 100].
+    """
+    path_str = str(path)
+    name_upper = path.name.upper()
+    parts_lower = [p.lower() for p in path.parts]
+
+    # ~/.claude/CLAUDE.md — global standards
+    for prefix in _STATIC_STANDARDS_PREFIXES:
+        if path_str.startswith(prefix) and path.name == "CLAUDE.md":
+            return 95
+
+    # Any CLAUDE.md in a repo
+    if path.name == "CLAUDE.md":
+        return 85
+
+    # Architecture or overview documents in a design/ directory
+    if "design" in parts_lower and (
+        "ARCHITECTURE" in name_upper or "OVERVIEW" in name_upper
+    ):
+        return 80
+
+    # Design docs generally
+    if "design" in parts_lower:
+        return 70
+
+    # Plans
+    if "plans" in parts_lower or "plan" in parts_lower:
+        return 65
+
+    # Handoffs
+    if "handoffs" in parts_lower or "handoff" in parts_lower:
+        return 60
+
+    # README at repo root: parent directory is one of the configured crawl prefixes
+    if path.name.upper() == "README.MD" and str(path.parent) in path_prefixes:
+        return 55
+
+    return 35
+
+
+def _scope_ref_for_path(
+    path: Path,
+    scope_mappings: list[tuple[str, str]],
+) -> str:
+    """Resolve scope_ref using longest-prefix matching.
+
+    Args:
+        path: Absolute path to the file.
+        scope_mappings: List of (path_prefix, scope_ref) pairs evaluated
+            in declaration order. First match wins.
+
+    Returns:
+        The matched scope_ref, or DEFAULT_SCOPE_REF if no prefix matches.
+    """
+    path_str = str(path)
+    best_prefix_len = -1
+    best_scope = DEFAULT_SCOPE_REF
+
+    for prefix, scope in scope_mappings:
+        if path_str.startswith(prefix) and len(prefix) > best_prefix_len:
+            best_prefix_len = len(prefix)
+            best_scope = scope
+
+    return best_scope
+
+
+def _extract_tags(path: Path, doc_type: EnumDetectedDocType) -> list[str]:
+    """Build a minimal tag list for a discovered document.
+
+    Tags enable FILE_TOUCHED_MATCH attribution signal computation in the
+    tier system. Full tag extraction (code fence languages, service names,
+    etc.) is delegated to ChunkClassifierCompute in Stream B.
+
+    Args:
+        path: Absolute path to the .md file.
+        doc_type: Detected document type.
+
+    Returns:
+        A deduplicated list of tag strings.
+    """
+    tags: list[str] = []
+
+    # File path tag for FILE_TOUCHED_MATCH attribution
+    tags.append(str(path))
+
+    # Document type tag
+    tags.append(f"doctype:{doc_type.value}")
+
+    # Repository name heuristic: last path component before .md file
+    # that is not a common intermediate directory
+    _SKIP_DIRS = frozenset({"src", "docs", "design", "plans", "handoffs"})
+    for part in reversed(path.parts[:-1]):
+        if part not in _SKIP_DIRS and not part.startswith("."):
+            tags.append(f"repo:{part}")
+            break
+
+    return tags
+
+
+class HandlerFilesystemCrawler:
+    """Walks configured path prefixes for .md files and emits crawl events.
+
+    Implements the FilesystemCrawler described in the OmniMemory Document
+    Ingestion Pipeline design (§5). Change detection uses a two-stage
+    mtime -> SHA-256 strategy to avoid unnecessary reads.
+
+    Attributes:
+        _config: Crawler configuration including path prefixes and topics.
+        _crawl_state_repo: Repository for loading and storing crawl state.
+        _scope_mappings: Parsed (path_prefix, scope_ref) pairs from config.
+    """
+
+    def __init__(
+        self,
+        config: ModelFilesystemCrawlerConfig,
+        crawl_state_repo: ProtocolCrawlStateRepository,
+    ) -> None:
+        """Initialize the handler.
+
+        Args:
+            config: Crawler configuration.
+            crawl_state_repo: Repository for crawl state persistence.
+        """
+        self._config = config
+        self._crawl_state_repo = crawl_state_repo
+
+        logger.info(
+            "HandlerFilesystemCrawler initialized",
+            extra={
+                "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                "path_prefixes": config.path_prefixes,
+                "max_file_size_bytes": config.max_file_size_bytes,
+            },
+        )
+
+    async def crawl(
+        self,
+        correlation_id: UUID,
+        crawl_scope: str,
+        trigger_source: str,
+        env_prefix: str,
+        publish_callback: Callable[
+            [str, dict[str, object]], Coroutine[object, object, None]
+        ],
+        scope_mappings: list[tuple[str, str]] | None = None,
+    ) -> ModelFilesystemCrawlResult:
+        """Execute a full filesystem crawl and emit lifecycle events.
+
+        Steps:
+            1. Walk each path prefix for .md files.
+            2. For each file: load prior state, apply mtime fast-path,
+               compute SHA-256 if needed, emit discovered/changed event.
+            3. After walk: compare state table to walked set and emit
+               removed events for missing files.
+            4. Persist updated state for all processed files.
+
+        Args:
+            correlation_id: Threaded from the originating crawl tick command.
+            crawl_scope: Scope string from the crawl tick command.
+            trigger_source: What triggered this crawl run.
+            env_prefix: Deployment environment prefix (e.g. "dev").
+            publish_callback: Async callback for publishing events.
+                Signature: (full_topic, message_dict) -> Coroutine[..., None].
+            scope_mappings: Optional list of (path_prefix, scope_ref) pairs
+                for scope resolution. If None, DEFAULT_SCOPE_REF is used
+                for all files.
+
+        Returns:
+            Summary statistics for this crawl run.
+        """
+        resolved_mappings = scope_mappings or []
+        now_utc = datetime.now(timezone.utc)
+        now_iso = now_utc.isoformat()
+
+        files_walked = 0
+        discovered_count = 0
+        changed_count = 0
+        unchanged_count = 0
+        skipped_count = 0
+        error_count = 0
+        truncated = False
+
+        # Track absolute paths seen during this walk (for removal detection)
+        walked_paths: set[str] = set()
+        # Track all distinct scope_refs assigned during the walk so that
+        # _detect_and_emit_removals can query every scope that may contain
+        # stale records -- including non-default scopes from scope_mappings.
+        scope_refs_seen: set[str] = set()
+
+        for prefix_str in self._config.path_prefixes:
+            prefix_path = Path(prefix_str)
+            if not prefix_path.exists():
+                logger.warning(
+                    "Path prefix does not exist, skipping",
+                    extra={
+                        "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                        "prefix": prefix_str,
+                        "correlation_id": str(correlation_id),
+                    },
+                )
+                continue
+
+            for md_path in prefix_path.rglob("*.md"):
+                if files_walked >= self._config.max_files_per_crawl:
+                    truncated = True
+                    logger.warning(
+                        "max_files_per_crawl reached, crawl truncated",
+                        extra={
+                            "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                            "limit": self._config.max_files_per_crawl,
+                            "correlation_id": str(correlation_id),
+                        },
+                    )
+                    break
+
+                files_walked += 1
+                abs_path_str = str(md_path.resolve())
+                walked_paths.add(abs_path_str)
+
+                try:
+                    stat = md_path.stat()
+                except OSError as exc:
+                    logger.warning(
+                        "Could not stat file, skipping",
+                        extra={
+                            "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                            "path": abs_path_str,
+                            "error": str(exc),
+                            "correlation_id": str(correlation_id),
+                        },
+                    )
+                    error_count += 1
+                    continue
+
+                if stat.st_size > self._config.max_file_size_bytes:
+                    logger.warning(
+                        "File exceeds max_file_size_bytes, skipping",
+                        extra={
+                            "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                            "path": abs_path_str,
+                            "size_bytes": stat.st_size,
+                            "max_bytes": self._config.max_file_size_bytes,
+                            "correlation_id": str(correlation_id),
+                        },
+                    )
+                    skipped_count += 1
+                    continue
+
+                scope_ref = _scope_ref_for_path(md_path.resolve(), resolved_mappings)
+                scope_refs_seen.add(scope_ref)
+
+                prior_state = await self._crawl_state_repo.get_state(
+                    source_ref=abs_path_str,
+                    crawler_type=EnumCrawlerType.FILESYSTEM,
+                    scope_ref=scope_ref,
+                )
+
+                # mtime fast-path: skip if unchanged
+                current_mtime = stat.st_mtime
+                if (
+                    prior_state is not None
+                    and prior_state.last_known_mtime is not None
+                    and prior_state.last_known_mtime == current_mtime
+                ):
+                    # File has not been modified at the OS level; skip.
+                    # Update last_crawled_at_utc to reflect we checked it.
+                    updated_state = ModelCrawlStateRecord(
+                        source_ref=abs_path_str,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        scope_ref=scope_ref,
+                        content_fingerprint=prior_state.content_fingerprint,
+                        source_version=prior_state.source_version,
+                        last_crawled_at_utc=now_utc,
+                        last_changed_at_utc=prior_state.last_changed_at_utc,
+                        last_known_mtime=current_mtime,
+                    )
+                    await self._crawl_state_repo.upsert_state(updated_state)
+                    continue
+
+                # mtime changed (or no prior state) -- read and hash content
+                content = await _read_file_async(md_path)
+                if content is None:
+                    error_count += 1
+                    continue
+
+                fingerprint = _compute_sha256(content)
+                blob_ref = f"sha256:{fingerprint}"
+                token_estimate = len(content) // 4
+                doc_type = _detect_doc_type(md_path.resolve())
+                source_type = _source_type_for_path(md_path.resolve())
+                priority = _priority_hint_for_path(
+                    md_path.resolve(), self._config.path_prefixes
+                )
+                tags = _extract_tags(md_path.resolve(), doc_type)
+
+                if prior_state is None:
+                    # New document
+                    discovered_event = ModelDocumentDiscoveredEvent(
+                        correlation_id=correlation_id,
+                        emitted_at_utc=now_iso,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        crawl_scope=crawl_scope,
+                        trigger_source=trigger_source,
+                        source_ref=abs_path_str,
+                        source_type=source_type,
+                        source_version=None,
+                        content_fingerprint=fingerprint,
+                        content_blob_ref=blob_ref,
+                        token_estimate=token_estimate,
+                        scope_ref=scope_ref,
+                        detected_doc_type=doc_type,
+                        tags=tags,
+                        priority_hint=priority,
+                    )
+                    await _publish_event(
+                        publish_callback,
+                        f"{env_prefix}.{self._config.publish_topic_discovered}",
+                        discovered_event.model_dump(mode="json"),
+                        correlation_id,
+                    )
+                    discovered_count += 1
+
+                    new_state = ModelCrawlStateRecord(
+                        source_ref=abs_path_str,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        scope_ref=scope_ref,
+                        content_fingerprint=fingerprint,
+                        source_version=None,
+                        last_crawled_at_utc=now_utc,
+                        last_changed_at_utc=now_utc,
+                        last_known_mtime=current_mtime,
+                    )
+                    await self._crawl_state_repo.upsert_state(new_state)
+
+                elif prior_state.content_fingerprint == fingerprint:
+                    # mtime bumped but content unchanged -- update crawl time + mtime
+                    unchanged_count += 1
+                    updated_state = ModelCrawlStateRecord(
+                        source_ref=abs_path_str,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        scope_ref=scope_ref,
+                        content_fingerprint=fingerprint,
+                        source_version=prior_state.source_version,
+                        last_crawled_at_utc=now_utc,
+                        last_changed_at_utc=prior_state.last_changed_at_utc,
+                        last_known_mtime=current_mtime,
+                    )
+                    await self._crawl_state_repo.upsert_state(updated_state)
+
+                else:
+                    # Content changed
+                    changed_event = ModelDocumentChangedEvent(
+                        correlation_id=correlation_id,
+                        emitted_at_utc=now_iso,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        crawl_scope=crawl_scope,
+                        trigger_source=trigger_source,
+                        source_ref=abs_path_str,
+                        source_type=source_type,
+                        source_version=None,
+                        content_fingerprint=fingerprint,
+                        content_blob_ref=blob_ref,
+                        token_estimate=token_estimate,
+                        scope_ref=scope_ref,
+                        detected_doc_type=doc_type,
+                        tags=tags,
+                        priority_hint=priority,
+                        previous_content_fingerprint=prior_state.content_fingerprint,
+                        previous_source_version=prior_state.source_version,
+                    )
+                    await _publish_event(
+                        publish_callback,
+                        f"{env_prefix}.{self._config.publish_topic_changed}",
+                        changed_event.model_dump(mode="json"),
+                        correlation_id,
+                    )
+                    changed_count += 1
+
+                    updated_state = ModelCrawlStateRecord(
+                        source_ref=abs_path_str,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        scope_ref=scope_ref,
+                        content_fingerprint=fingerprint,
+                        source_version=None,
+                        last_crawled_at_utc=now_utc,
+                        last_changed_at_utc=now_utc,
+                        last_known_mtime=current_mtime,
+                    )
+                    await self._crawl_state_repo.upsert_state(updated_state)
+
+            if truncated:
+                break
+
+        # Detect removals: state table entries not found in the walk
+        removed_count = await self._detect_and_emit_removals(
+            walked_paths=walked_paths,
+            scope_refs_seen=scope_refs_seen,
+            crawl_scope=crawl_scope,
+            correlation_id=correlation_id,
+            emitted_at_utc=now_iso,
+            env_prefix=env_prefix,
+            publish_callback=publish_callback,
+            resolved_mappings=resolved_mappings,
+        )
+
+        result = ModelFilesystemCrawlResult(
+            files_walked=files_walked,
+            discovered_count=discovered_count,
+            changed_count=changed_count,
+            unchanged_count=unchanged_count,
+            skipped_count=skipped_count,
+            removed_count=removed_count,
+            error_count=error_count,
+            truncated=truncated,
+        )
+
+        logger.info(
+            "Filesystem crawl complete",
+            extra={
+                "handler": HANDLER_ID_FILESYSTEM_CRAWLER,
+                "correlation_id": str(correlation_id),
+                "files_walked": files_walked,
+                "discovered": discovered_count,
+                "changed": changed_count,
+                "unchanged": unchanged_count,
+                "skipped": skipped_count,
+                "removed": removed_count,
+                "errors": error_count,
+                "truncated": truncated,
+            },
+        )
+
+        return result
+
+    async def _detect_and_emit_removals(
+        self,
+        walked_paths: set[str],
+        scope_refs_seen: set[str],
+        crawl_scope: str,
+        correlation_id: UUID,
+        emitted_at_utc: str,
+        env_prefix: str,
+        publish_callback: Callable[
+            [str, dict[str, object]], Coroutine[object, object, None]
+        ],
+        resolved_mappings: list[tuple[str, str]],
+    ) -> int:
+        """Emit document-removed events for state records no longer on disk.
+
+        Loads all state records for each scope encountered during the walk and
+        emits removed events for any record whose source_ref was not visited.
+        Using scope_refs_seen (collected per file during the walk) ensures that
+        files assigned non-default scopes via scope_mappings are also checked.
+
+        Args:
+            walked_paths: Set of absolute path strings visited this run.
+            scope_refs_seen: Set of all scope_ref values assigned to files
+                during the walk, collected as each file is processed.
+            crawl_scope: Scope string from the crawl tick.
+            correlation_id: Correlation ID for event envelope.
+            emitted_at_utc: ISO-8601 timestamp string.
+            env_prefix: Environment prefix for topic construction.
+            publish_callback: Async publish callback.
+            resolved_mappings: Scope mappings for source_type resolution.
+
+        Returns:
+            Number of document-removed events emitted.
+        """
+        removed_count = 0
+
+        # Use the scope_refs seen during the walk: this covers both the
+        # default scope and any non-default scopes assigned via scope_mappings.
+        # Fall back to prefix-level scopes if the walk produced no scope refs
+        # (e.g. all prefixes were missing / no files found).
+        if scope_refs_seen:
+            affected_scopes = scope_refs_seen
+        else:
+            affected_scopes = set()
+            for prefix_str in self._config.path_prefixes:
+                prefix_path = Path(prefix_str)
+                scope = _scope_ref_for_path(prefix_path, resolved_mappings)
+                affected_scopes.add(scope)
+
+        for scope_ref in affected_scopes:
+            known_records = await self._crawl_state_repo.list_states_for_scope(
+                crawler_type=EnumCrawlerType.FILESYSTEM,
+                scope_ref=scope_ref,
+            )
+
+            for record in known_records:
+                if record.source_ref not in walked_paths:
+                    source_type = _source_type_for_path(Path(record.source_ref))
+                    removed_event = ModelDocumentRemovedEvent(
+                        correlation_id=correlation_id,
+                        emitted_at_utc=emitted_at_utc,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        source_ref=record.source_ref,
+                        source_type=source_type,
+                        scope_ref=scope_ref,
+                        last_known_content_fingerprint=record.content_fingerprint,
+                        last_known_source_version=record.source_version,
+                    )
+                    await _publish_event(
+                        publish_callback,
+                        f"{env_prefix}.{self._config.publish_topic_removed}",
+                        removed_event.model_dump(mode="json"),
+                        correlation_id,
+                    )
+                    await self._crawl_state_repo.delete_state(
+                        source_ref=record.source_ref,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        scope_ref=scope_ref,
+                    )
+                    removed_count += 1
+
+        return removed_count
+
+
+async def _read_file_async(path: Path) -> bytes | None:
+    """Read a file's raw bytes asynchronously, returning None on error.
+
+    Uses asyncio.to_thread() to offload the blocking file read to a thread
+    pool, ensuring the event loop is not blocked for the duration of the I/O.
+
+    Args:
+        path: Path to read.
+
+    Returns:
+        Raw file bytes, or None if the read fails.
+    """
+    try:
+        return await asyncio.to_thread(path.read_bytes)
+    except OSError as exc:
+        logger.warning(
+            "Failed to read file content",
+            extra={"path": str(path), "error": str(exc)},
+        )
+        return None
+
+
+async def _publish_event(
+    publish_callback: Callable[
+        [str, dict[str, object]], Coroutine[object, object, None]
+    ],
+    topic: str,
+    payload: dict[str, object],
+    correlation_id: UUID,
+) -> None:
+    """Await the async publish callback, swallowing publish errors non-fatally.
+
+    Crawl progress must not be blocked by a single publish failure.
+    Errors are logged for observability.
+
+    Args:
+        publish_callback: Caller-supplied async publish function.
+        topic: Full topic name (env prefix already applied).
+        payload: Serialized event dict.
+        correlation_id: Used in error log for traceability.
+    """
+    try:
+        await publish_callback(topic, payload)
+    except Exception as exc:
+        logger.error(
+            "Failed to publish crawl event",
+            extra={
+                "topic": topic,
+                "correlation_id": str(correlation_id),
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+        )

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -593,6 +593,7 @@ class HandlerFilesystemCrawler:
             scope_refs_seen=scope_refs_seen,
             correlation_id=correlation_id,
             emitted_at_utc=now_utc,
+            trigger_source=trigger_source,
             env_prefix=env_prefix,
             publish_callback=publish_callback,
             resolved_mappings=resolved_mappings,
@@ -634,6 +635,7 @@ class HandlerFilesystemCrawler:
         scope_refs_seen: set[str],
         correlation_id: UUID,
         emitted_at_utc: datetime,
+        trigger_source: str,
         env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]
@@ -653,6 +655,7 @@ class HandlerFilesystemCrawler:
                 during the walk, collected as each file is processed.
             correlation_id: Correlation ID for event envelope.
             emitted_at_utc: UTC datetime when the crawl run started.
+            trigger_source: What triggered the crawl run.
             env_prefix: Environment prefix for topic construction.
             publish_callback: Async publish callback.
             resolved_mappings: Scope mappings for source_type resolution.
@@ -688,6 +691,7 @@ class HandlerFilesystemCrawler:
                         correlation_id=correlation_id,
                         emitted_at_utc=emitted_at_utc,
                         crawler_type=EnumCrawlerType.FILESYSTEM,
+                        trigger_source=trigger_source,
                         source_ref=record.source_ref,
                         source_type=source_type,
                         scope_ref=scope_ref,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -67,7 +67,7 @@ import logging
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
 from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
@@ -107,6 +107,12 @@ DEFAULT_SCOPE_REF: str = "omninode/shared"
 # Mapping of path prefix patterns to EnumContextSourceType
 # Evaluated in order; first match wins.
 _STATIC_STANDARDS_PREFIXES: tuple[str, ...] = (str(Path("~/.claude").expanduser()),)
+
+# Intermediate directory names excluded when heuristically extracting repo names from paths
+_SKIP_DIRS: frozenset[str] = frozenset({"src", "docs", "design", "plans", "handoffs"})
+
+# Valid trigger sources for crawl events
+TriggerSource = Literal["scheduled", "manual", "git_hook", "filesystem_watch"]
 
 
 def _compute_sha256(content: bytes) -> str:
@@ -281,7 +287,6 @@ def _extract_tags(path: Path, doc_type: EnumDetectedDocType) -> list[str]:
 
     # Repository name heuristic: last path component before .md file
     # that is not a common intermediate directory
-    _SKIP_DIRS = frozenset({"src", "docs", "design", "plans", "handoffs"})
     for part in reversed(path.parts[:-1]):
         if part not in _SKIP_DIRS and not part.startswith("."):
             tags.append(f"repo:{part}")
@@ -329,7 +334,7 @@ class HandlerFilesystemCrawler:
         self,
         correlation_id: UUID,
         crawl_scope: str,
-        trigger_source: str,
+        trigger_source: TriggerSource,
         env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]
@@ -639,7 +644,7 @@ class HandlerFilesystemCrawler:
         scope_refs_seen: set[str],
         correlation_id: UUID,
         emitted_at_utc: datetime,
-        trigger_source: str,
+        trigger_source: TriggerSource,
         env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -240,7 +240,7 @@ def _scope_ref_for_path(
     Args:
         path: Absolute path to the file.
         scope_mappings: List of (path_prefix, scope_ref) pairs evaluated
-            in declaration order. First match wins.
+            for longest-prefix match. Longest-prefix match wins.
 
     Returns:
         The matched scope_ref, or DEFAULT_SCOPE_REF if no prefix matches.
@@ -392,7 +392,7 @@ class HandlerFilesystemCrawler:
                 )
                 continue
 
-            for md_path in prefix_path.rglob("*.md"):
+            for md_path in prefix_path.rglob(self._config.file_glob):
                 if files_walked >= self._config.max_files_per_crawl:
                     truncated = True
                     logger.warning(

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -300,7 +300,6 @@ class HandlerFilesystemCrawler:
     Attributes:
         _config: Crawler configuration including path prefixes and topics.
         _crawl_state_repo: Repository for loading and storing crawl state.
-        _scope_mappings: Parsed (path_prefix, scope_ref) pairs from config.
     """
 
     def __init__(
@@ -592,7 +591,6 @@ class HandlerFilesystemCrawler:
         removed_count = await self._detect_and_emit_removals(
             walked_paths=walked_paths,
             scope_refs_seen=scope_refs_seen,
-            crawl_scope=crawl_scope,
             correlation_id=correlation_id,
             emitted_at_utc=now_utc,
             env_prefix=env_prefix,
@@ -634,7 +632,6 @@ class HandlerFilesystemCrawler:
         self,
         walked_paths: set[str],
         scope_refs_seen: set[str],
-        crawl_scope: str,
         correlation_id: UUID,
         emitted_at_utc: datetime,
         env_prefix: str,
@@ -654,7 +651,6 @@ class HandlerFilesystemCrawler:
             walked_paths: Set of absolute path strings visited this run.
             scope_refs_seen: Set of all scope_ref values assigned to files
                 during the walk, collected as each file is processed.
-            crawl_scope: Scope string from the crawl tick.
             correlation_id: Correlation ID for event envelope.
             emitted_at_utc: UTC datetime when the crawl run started.
             env_prefix: Environment prefix for topic construction.

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/__init__.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Models for FilesystemCrawlerEffect node."""
+
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawl_result import (
+    ModelFilesystemCrawlResult,
+)
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawler_config import (
+    ModelFilesystemCrawlerConfig,
+)
+
+__all__ = [
+    "ModelFilesystemCrawlResult",
+    "ModelFilesystemCrawlerConfig",
+]

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Result model for a single filesystem crawl run."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# omnimemory-model-exempt: handler result
+class ModelFilesystemCrawlResult(BaseModel):
+    """Summary of a completed filesystem crawl run.
+
+    Returned by HandlerFilesystemCrawler.crawl() to the caller
+    (effect node execute_effect method) for logging and observability.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    files_walked: int = Field(
+        ...,
+        ge=0,
+        description="Total number of .md files found during the filesystem walk",
+    )
+    discovered_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of document-discovered events emitted",
+    )
+    changed_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of document-changed events emitted",
+    )
+    unchanged_count: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Number of files whose content fingerprint was unchanged "
+            "(mtime changed but SHA-256 matched)"
+        ),
+    )
+    skipped_count: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Number of files skipped (exceeded max_file_size_bytes or "
+            "other non-fatal exclusion)"
+        ),
+    )
+    removed_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of document-removed events emitted",
+    )
+    error_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of files that caused non-fatal errors during processing",
+    )
+    truncated: bool = Field(
+        default=False,
+        description=(
+            "True if max_files_per_crawl was reached before the walk completed. "
+            "Some files may not have been evaluated"
+        ),
+    )

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
@@ -56,6 +56,10 @@ class ModelFilesystemCrawlResult(BaseModel):
         ge=0,
         description="Number of files that caused non-fatal errors during processing",
     )
+    mtime_skipped_count: int = Field(
+        default=0,
+        description="Files skipped via mtime fast-path (mtime unchanged since last crawl, no content check performed)",
+    )
     truncated: bool = Field(
         default=False,
         description=(

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
@@ -58,6 +58,7 @@ class ModelFilesystemCrawlResult(BaseModel):
     )
     mtime_skipped_count: int = Field(
         default=0,
+        ge=0,
         description="Files skipped via mtime fast-path (mtime unchanged since last crawl, no content check performed)",
     )
     truncated: bool = Field(

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
@@ -5,8 +5,9 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 
-# omnimemory-model-exempt: handler result
-class ModelFilesystemCrawlResult(BaseModel):
+class ModelFilesystemCrawlResult(  # omnimemory-model-exempt: handler result
+    BaseModel
+):
     """Summary of a completed filesystem crawl run.
 
     Returned by HandlerFilesystemCrawler.crawl() to the caller

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -17,7 +17,9 @@ class ModelFilesystemCrawlerConfig(BaseModel):
     truth for topic declarations.
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+    model_config = ConfigDict(
+        frozen=True, extra="forbid", strict=True, from_attributes=True
+    )
 
     # Path prefixes to crawl (longest-prefix scope mapping is applied externally)
     path_prefixes: list[str] = Field(

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Configuration model for FilesystemCrawlerEffect handler."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# omnimemory-model-exempt: handler config
+class ModelFilesystemCrawlerConfig(BaseModel):
+    """Configuration for HandlerFilesystemCrawler.
+
+    Declares the filesystem path prefixes to walk, the .md file glob
+    pattern, topic routing suffixes, and operational limits.
+
+    Note: Topic suffix defaults MUST match the ``event_bus.publish_topics``
+    declared in this node's contract.yaml. The contract is the source of
+    truth for topic declarations.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    # Path prefixes to crawl (longest-prefix scope mapping is applied externally)
+    path_prefixes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Absolute path prefixes to walk recursively for .md files. "
+            "If empty the crawler is a no-op"
+        ),
+    )
+
+    # File pattern
+    file_glob: str = Field(
+        default="**/*.md",
+        description=(
+            "Glob pattern relative to each path prefix. "
+            "Default '**/*.md' matches all Markdown files recursively"
+        ),
+    )
+
+    # Published topic suffixes (env prefix added at runtime)
+    publish_topic_discovered: str = Field(
+        default="onex.evt.omnimemory.document-discovered.v1",
+        description="Topic suffix for document-discovered events",
+    )
+    publish_topic_changed: str = Field(
+        default="onex.evt.omnimemory.document-changed.v1",
+        description="Topic suffix for document-changed events",
+    )
+    publish_topic_removed: str = Field(
+        default="onex.evt.omnimemory.document-removed.v1",
+        description="Topic suffix for document-removed events",
+    )
+
+    # Operational limits
+    max_file_size_bytes: int = Field(
+        default=5_242_880,  # 5 MiB
+        ge=1,
+        description=(
+            "Maximum file size in bytes to index. Files larger than this are "
+            "skipped with a warning log"
+        ),
+    )
+    max_files_per_crawl: int = Field(
+        default=10_000,
+        ge=1,
+        description=(
+            "Hard limit on files processed per crawl run to prevent runaway walks. "
+            "A warning is logged when the limit is reached"
+        ),
+    )

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -32,10 +32,10 @@ class ModelFilesystemCrawlerConfig(BaseModel):
 
     # File pattern
     file_glob: str = Field(
-        default="**/*.md",
+        default="*.md",
         description=(
-            "Glob pattern relative to each path prefix. "
-            "Default '**/*.md' matches all Markdown files recursively"
+            "Glob pattern passed to Path.rglob(). "
+            "Default '*.md' matches all Markdown files recursively"
         ),
     )
 

--- a/src/omnimemory/protocols/__init__.py
+++ b/src/omnimemory/protocols/__init__.py
@@ -57,6 +57,7 @@ from .error_models import (  # Error handling; Error codes
     ProtocolSystemError,
     ProtocolValidationError,
 )
+from .protocol_crawl_state_repository import ProtocolCrawlStateRepository
 from .protocol_embedding import ProtocolEmbeddingClient, ProtocolRateLimiter
 from .protocol_embedding_provider import ProtocolEmbeddingProvider, ProtocolLLMProvider
 from .protocol_handler_intent import ProtocolHandlerIntent
@@ -126,4 +127,6 @@ __all__ = [
     "ProtocolHandlerIntent",
     # Adapter protocols (for contract-driven dependency injection)
     "ProtocolIntentGraphAdapter",
+    # Crawl state repository protocol
+    "ProtocolCrawlStateRepository",
 ]

--- a/src/omnimemory/protocols/protocol_crawl_state_repository.py
+++ b/src/omnimemory/protocols/protocol_crawl_state_repository.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Protocol for the crawl state repository used by all crawlers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+    from omnimemory.models.crawl.model_crawl_state_record import ModelCrawlStateRecord
+
+
+@runtime_checkable
+class ProtocolCrawlStateRepository(Protocol):
+    """Read/write interface for the omnimemory_crawl_state table.
+
+    Each crawler type (FilesystemCrawler, GitRepoCrawler, LinearCrawler)
+    uses this protocol to load prior crawl state, update state after a
+    successful crawl, and delete state for removed documents.
+
+    All methods are independent transactions — the adapter does not support
+    external transaction control.
+    """
+
+    async def get_state(
+        self,
+        source_ref: str,
+        crawler_type: EnumCrawlerType,
+        scope_ref: str,
+    ) -> ModelCrawlStateRecord | None:
+        """Fetch the crawl state record for a specific document.
+
+        Args:
+            source_ref: Absolute path, URL, or Linear ID.
+            crawler_type: Identifies which crawler owns the record.
+            scope_ref: Scope assignment for the document.
+
+        Returns:
+            The crawl state record if one exists; None otherwise.
+        """
+        ...
+
+    async def list_states_for_scope(
+        self,
+        crawler_type: EnumCrawlerType,
+        scope_ref: str,
+    ) -> list[ModelCrawlStateRecord]:
+        """List all crawl state records for a crawler type + scope combination.
+
+        Used by crawlers at the end of a walk to detect removed documents
+        (records in state table that were not found in the filesystem walk).
+
+        Args:
+            crawler_type: Filters records to a specific crawler.
+            scope_ref: Filters records to a specific scope.
+
+        Returns:
+            All records matching the (crawler_type, scope_ref) combination.
+        """
+        ...
+
+    async def upsert_state(self, record: ModelCrawlStateRecord) -> None:
+        """Insert or update a crawl state record.
+
+        Creates the record if none exists for (source_ref, crawler_type,
+        scope_ref), or updates the existing record atomically.
+
+        Args:
+            record: The new or updated state record.
+        """
+        ...
+
+    async def delete_state(
+        self,
+        source_ref: str,
+        crawler_type: EnumCrawlerType,
+        scope_ref: str,
+    ) -> None:
+        """Remove the crawl state record for a document.
+
+        Called when a document is confirmed removed (FilesystemCrawler:
+        file no longer found in walk; LinearCrawler: issue absent from
+        list response).
+
+        Args:
+            source_ref: Absolute path, URL, or Linear ID.
+            crawler_type: Identifies which crawler owns the record.
+            scope_ref: Scope assignment for the document.
+        """
+        ...

--- a/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
+++ b/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
@@ -1,0 +1,997 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerFilesystemCrawler.
+
+Tests cover:
+- mtime fast-path: file not re-read when mtime unchanged
+- SHA-256 change detection: mtime changed, content unchanged → no event
+- Document discovered: new file emits document-discovered.v1
+- Document changed: known file with different content emits document-changed.v1
+- Document removed: state table entries absent from walk emit document-removed.v1
+- File size limit: files exceeding max_file_size_bytes are skipped
+- Scope resolution: longest-prefix mapping applied correctly
+- Source type assignment: CLAUDE.md → STATIC_STANDARDS, other → REPO_DERIVED
+- Priority hints: correct values per design §7
+- Doc type detection: CLAUDE.md, ARCHITECTURE, DEEP_DIVE, DESIGN, PLAN, etc.
+- Publish errors: non-fatal, crawl continues
+- File read errors: non-fatal, error_count incremented
+- max_files_per_crawl: truncation behaviour
+- Empty path_prefixes: no-op, zero events
+- Non-existent prefix: warning logged, no crash
+
+.. versionadded:: 0.4.0
+    Initial tests for OMN-2385.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+from omnimemory.models.crawl.model_crawl_state_record import ModelCrawlStateRecord
+from omnimemory.nodes.filesystem_crawler_effect.handler_filesystem_crawler import (
+    HandlerFilesystemCrawler,
+    _compute_sha256,
+    _detect_doc_type,
+    _priority_hint_for_path,
+    _scope_ref_for_path,
+    _source_type_for_path,
+)
+from omnimemory.nodes.filesystem_crawler_effect.models.model_filesystem_crawler_config import (
+    ModelFilesystemCrawlerConfig,
+)
+
+# Type aliases
+type PublishRecord = tuple[str, dict[str, object]]
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def make_config(
+    path_prefixes: list[str] | None = None,
+    max_file_size_bytes: int = 5_242_880,
+    max_files_per_crawl: int = 10_000,
+) -> ModelFilesystemCrawlerConfig:
+    return ModelFilesystemCrawlerConfig(
+        path_prefixes=path_prefixes or [],
+        max_file_size_bytes=max_file_size_bytes,
+        max_files_per_crawl=max_files_per_crawl,
+    )
+
+
+def make_state(
+    source_ref: str,
+    fingerprint: str,
+    scope_ref: str = "omninode/test",
+    mtime: float | None = None,
+) -> ModelCrawlStateRecord:
+    from datetime import datetime, timezone
+
+    return ModelCrawlStateRecord(
+        source_ref=source_ref,
+        crawler_type=EnumCrawlerType.FILESYSTEM,
+        scope_ref=scope_ref,
+        content_fingerprint=fingerprint,
+        source_version=None,
+        last_crawled_at_utc=datetime.now(timezone.utc),
+        last_known_mtime=mtime,
+    )
+
+
+def make_mock_repo() -> MagicMock:
+    """Return a mock that satisfies ProtocolCrawlStateRepository."""
+    repo = MagicMock()
+    repo.get_state = AsyncMock(return_value=None)
+    repo.list_states_for_scope = AsyncMock(return_value=[])
+    repo.upsert_state = AsyncMock()
+    repo.delete_state = AsyncMock()
+    return repo
+
+
+def make_publish_capture() -> (
+    tuple[Callable[[str, dict[str, object]], None], list[PublishRecord]]
+):
+    published: list[PublishRecord] = []
+
+    def capture(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    return capture, published
+
+
+# =============================================================================
+# Pure function tests (no I/O)
+# =============================================================================
+
+
+class TestComputeSha256:
+    @pytest.mark.unit
+    def test_known_value(self) -> None:
+        content = b"hello"
+        expected = hashlib.sha256(b"hello").hexdigest()
+        assert _compute_sha256(content) == expected
+
+    @pytest.mark.unit
+    def test_empty_bytes(self) -> None:
+        result = _compute_sha256(b"")
+        assert len(result) == 64  # 256 bits → 64 hex chars
+        assert result == hashlib.sha256(b"").hexdigest()
+
+    @pytest.mark.unit
+    def test_different_content_different_hash(self) -> None:
+        assert _compute_sha256(b"a") != _compute_sha256(b"b")
+
+
+class TestDetectDocType:
+    @pytest.mark.unit
+    def test_claude_md(self) -> None:
+        assert (
+            _detect_doc_type(Path("/some/repo/CLAUDE.md"))
+            == EnumDetectedDocType.CLAUDE_MD
+        )
+
+    @pytest.mark.unit
+    def test_architecture_doc(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/docs/ONEX_ARCHITECTURE.md"))
+            == EnumDetectedDocType.ARCHITECTURE_DOC
+        )
+
+    @pytest.mark.unit
+    def test_overview_doc(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/docs/SYSTEM_OVERVIEW.md"))
+            == EnumDetectedDocType.ARCHITECTURE_DOC
+        )
+
+    @pytest.mark.unit
+    def test_deep_dive(self) -> None:
+        assert (
+            _detect_doc_type(Path("/workspace/omni_save/DEEP_DIVE_2026.md"))
+            == EnumDetectedDocType.DEEP_DIVE
+        )
+
+    @pytest.mark.unit
+    def test_readme(self) -> None:
+        assert _detect_doc_type(Path("/repo/README.md")) == EnumDetectedDocType.README
+
+    @pytest.mark.unit
+    def test_design_doc(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/design/my_design.md"))
+            == EnumDetectedDocType.DESIGN_DOC
+        )
+
+    @pytest.mark.unit
+    def test_plan(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/plans/roadmap.md")) == EnumDetectedDocType.PLAN
+        )
+
+    @pytest.mark.unit
+    def test_handoff(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/handoffs/sprint_notes.md"))
+            == EnumDetectedDocType.HANDOFF
+        )
+
+    @pytest.mark.unit
+    def test_unknown_md(self) -> None:
+        assert (
+            _detect_doc_type(Path("/repo/docs/some_random.md"))
+            == EnumDetectedDocType.UNKNOWN_MD
+        )
+
+    @pytest.mark.unit
+    def test_claude_md_takes_priority_over_architecture(self) -> None:
+        # A file literally named CLAUDE.md should be CLAUDE_MD even if in a
+        # directory that would match another rule.
+        assert (
+            _detect_doc_type(Path("/repo/design/CLAUDE.md"))
+            == EnumDetectedDocType.CLAUDE_MD
+        )
+
+
+class TestSourceTypeForPath:
+    @pytest.mark.unit
+    def test_claude_md_is_static_standards(self) -> None:
+        assert (
+            _source_type_for_path(Path("/some/repo/CLAUDE.md"))
+            == EnumContextSourceType.STATIC_STANDARDS
+        )
+
+    @pytest.mark.unit
+    def test_dot_claude_dir_is_static_standards(self) -> None:
+        path = Path.home() / ".claude" / "CLAUDE.md"
+        assert _source_type_for_path(path) == EnumContextSourceType.STATIC_STANDARDS
+
+    @pytest.mark.unit
+    def test_design_doc_is_repo_derived(self) -> None:
+        assert (
+            _source_type_for_path(Path("/repo/design/foo.md"))
+            == EnumContextSourceType.REPO_DERIVED
+        )
+
+    @pytest.mark.unit
+    def test_readme_is_repo_derived(self) -> None:
+        assert (
+            _source_type_for_path(Path("/repo/README.md"))
+            == EnumContextSourceType.REPO_DERIVED
+        )
+
+
+class TestPriorityHintForPath:
+    _PREFIXES: list[str] = ["/repo"]
+
+    @pytest.mark.unit
+    def test_global_claude_md(self) -> None:
+        p = Path.home() / ".claude" / "CLAUDE.md"
+        assert _priority_hint_for_path(p, [str(Path.home() / ".claude")]) == 95
+
+    @pytest.mark.unit
+    def test_repo_claude_md(self) -> None:
+        assert _priority_hint_for_path(Path("/repo/CLAUDE.md"), self._PREFIXES) == 85
+
+    @pytest.mark.unit
+    def test_design_architecture(self) -> None:
+        assert (
+            _priority_hint_for_path(
+                Path("/repo/design/FOO_ARCHITECTURE.md"), self._PREFIXES
+            )
+            == 80
+        )
+
+    @pytest.mark.unit
+    def test_design_doc(self) -> None:
+        assert (
+            _priority_hint_for_path(Path("/repo/design/my_design.md"), self._PREFIXES)
+            == 70
+        )
+
+    @pytest.mark.unit
+    def test_plan(self) -> None:
+        assert (
+            _priority_hint_for_path(Path("/repo/plans/roadmap.md"), self._PREFIXES)
+            == 65
+        )
+
+    @pytest.mark.unit
+    def test_handoff(self) -> None:
+        assert (
+            _priority_hint_for_path(Path("/repo/handoffs/notes.md"), self._PREFIXES)
+            == 60
+        )
+
+    @pytest.mark.unit
+    def test_unknown_md(self) -> None:
+        assert (
+            _priority_hint_for_path(Path("/repo/docs/something.md"), self._PREFIXES)
+            == 35
+        )
+
+
+class TestScopeRefForPath:
+    @pytest.mark.unit
+    def test_exact_prefix_match(self) -> None:
+        mappings = [("/Volumes/PRO-G40/Code/omnimemory", "omninode/omnimemory")]
+        result = _scope_ref_for_path(
+            Path("/Volumes/PRO-G40/Code/omnimemory/CLAUDE.md"), mappings
+        )
+        assert result == "omninode/omnimemory"
+
+    @pytest.mark.unit
+    def test_longest_prefix_wins(self) -> None:
+        mappings = [
+            ("/Volumes/PRO-G40/Code", "omninode/shared"),
+            ("/Volumes/PRO-G40/Code/omni_save/design", "omninode/shared/design"),
+            ("/Volumes/PRO-G40/Code/omni_save", "omninode/shared/plans"),
+        ]
+        result = _scope_ref_for_path(
+            Path("/Volumes/PRO-G40/Code/omni_save/design/my.md"), mappings
+        )
+        assert result == "omninode/shared/design"
+
+    @pytest.mark.unit
+    def test_no_match_returns_default(self) -> None:
+        mappings: list[tuple[str, str]] = []
+        result = _scope_ref_for_path(
+            Path("/completely/different/path/foo.md"), mappings
+        )
+        assert result == "omninode/shared"  # DEFAULT_SCOPE_REF
+
+
+# =============================================================================
+# Handler integration tests (with mocked filesystem and repository)
+# =============================================================================
+
+
+class TestHandlerFilesystemCrawlerNoPathPrefixes:
+    """Handler with empty path_prefixes is a no-op."""
+
+    @pytest.mark.unit
+    async def test_empty_prefixes_returns_zero_counts(self) -> None:
+        config = make_config(path_prefixes=[])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 0
+        assert result.discovered_count == 0
+        assert result.changed_count == 0
+        assert result.removed_count == 0
+        assert not published
+
+
+class TestHandlerFilesystemCrawlerNonExistentPrefix:
+    @pytest.mark.unit
+    async def test_non_existent_prefix_warns_and_returns_zero(
+        self, tmp_path: Path
+    ) -> None:
+        non_existent = str(tmp_path / "does_not_exist")
+        config = make_config(path_prefixes=[non_existent])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 0
+        assert not published
+
+
+class TestHandlerFilesystemCrawlerDiscovered:
+    """New files with no prior state emit document-discovered events."""
+
+    @pytest.mark.unit
+    async def test_new_file_emits_discovered_event(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "test.md"
+        content = b"# Hello World\n\nThis is a test document."
+        md_file.write_bytes(content)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        # No prior state → get_state returns None
+        repo.get_state = AsyncMock(return_value=None)
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 1
+        assert result.discovered_count == 1
+        assert result.changed_count == 0
+        assert result.removed_count == 0
+
+        # Should have emitted exactly one event on the discovered topic
+        discovered_events = [(t, p) for t, p in published if "document-discovered" in t]
+        assert len(discovered_events) == 1
+
+        topic, payload = discovered_events[0]
+        assert topic == "dev.onex.evt.omnimemory.document-discovered.v1"
+        assert payload["event_type"] == "DocumentDiscovered"
+        assert payload["content_fingerprint"] == _sha256(content)
+        assert payload["source_ref"] == str(md_file.resolve())
+
+        # State should be persisted
+        repo.upsert_state.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_discovered_event_has_correct_blob_ref(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "doc.md"
+        content = b"Some content"
+        md_file.write_bytes(content)
+        fp = _sha256(content)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["content_blob_ref"] == f"sha256:{fp}"
+
+    @pytest.mark.unit
+    async def test_discovered_event_correlation_id_threaded(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "a.md").write_bytes(b"content")
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        cid = uuid4()
+        await handler.crawl(
+            correlation_id=cid,
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        # UUID may be serialized as string
+        assert str(payload["correlation_id"]) == str(cid)
+
+    @pytest.mark.unit
+    async def test_discovered_event_token_estimate(self, tmp_path: Path) -> None:
+        content = b"x" * 400
+        (tmp_path / "a.md").write_bytes(content)
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["token_estimate"] == 100  # 400 // 4
+
+    @pytest.mark.unit
+    async def test_multiple_files_all_discovered(self, tmp_path: Path) -> None:
+        for i in range(5):
+            (tmp_path / f"doc_{i}.md").write_bytes(f"# Doc {i}".encode())
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 5
+        assert result.discovered_count == 5
+        assert len(published) == 5
+
+
+class TestHandlerFilesystemCrawlerMtimeFastPath:
+    """When mtime is unchanged, the file must not be re-read."""
+
+    @pytest.mark.unit
+    async def test_unchanged_mtime_skips_hashing(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "stable.md"
+        content = b"stable content"
+        md_file.write_bytes(content)
+        mtime = md_file.stat().st_mtime
+        fp = _sha256(content)
+
+        prior = make_state(str(md_file.resolve()), fp, mtime=mtime)
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        with patch.object(
+            type(md_file), "read_bytes", side_effect=AssertionError("should not read")
+        ):
+            result = await handler.crawl(
+                correlation_id=uuid4(),
+                crawl_scope="omninode/test",
+                trigger_source="scheduled",
+                env_prefix="dev",
+                publish_callback=publish,
+            )
+
+        assert result.discovered_count == 0
+        assert result.changed_count == 0
+        assert not published
+
+    @pytest.mark.unit
+    async def test_unchanged_mtime_updates_last_crawled(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "stable.md"
+        content = b"stable"
+        md_file.write_bytes(content)
+        mtime = md_file.stat().st_mtime
+        fp = _sha256(content)
+
+        prior = make_state(str(md_file.resolve()), fp, mtime=mtime)
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+
+        publish, _ = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        with patch.object(
+            type(md_file), "read_bytes", side_effect=AssertionError("should not read")
+        ):
+            await handler.crawl(
+                correlation_id=uuid4(),
+                crawl_scope="omninode/test",
+                trigger_source="scheduled",
+                env_prefix="dev",
+                publish_callback=publish,
+            )
+
+        # upsert_state should still be called to update last_crawled_at_utc
+        repo.upsert_state.assert_awaited_once()
+
+
+class TestHandlerFilesystemCrawlerChanged:
+    """Files with changed SHA-256 emit document-changed events."""
+
+    @pytest.mark.unit
+    async def test_changed_content_emits_changed_event(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "evolving.md"
+        old_content = b"old content"
+        new_content = b"new content"
+        md_file.write_bytes(new_content)
+
+        old_fp = _sha256(old_content)
+        old_mtime = md_file.stat().st_mtime - 10  # simulate mtime changed
+
+        prior = make_state(str(md_file.resolve()), old_fp, mtime=old_mtime)
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.changed_count == 1
+        assert result.discovered_count == 0
+
+        changed_events = [(t, p) for t, p in published if "document-changed" in t]
+        assert len(changed_events) == 1
+
+        topic, payload = changed_events[0]
+        assert topic == "dev.onex.evt.omnimemory.document-changed.v1"
+        assert payload["event_type"] == "DocumentChanged"
+        assert payload["content_fingerprint"] == _sha256(new_content)
+        assert payload["previous_content_fingerprint"] == old_fp
+
+    @pytest.mark.unit
+    async def test_mtime_changed_content_unchanged_no_event(
+        self, tmp_path: Path
+    ) -> None:
+        md_file = tmp_path / "touched.md"
+        content = b"same content"
+        md_file.write_bytes(content)
+        fp = _sha256(content)
+
+        # Simulate mtime differs from stored (editor touched without saving)
+        old_mtime = md_file.stat().st_mtime - 5
+        prior = make_state(str(md_file.resolve()), fp, mtime=old_mtime)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.changed_count == 0
+        assert result.discovered_count == 0
+        assert result.unchanged_count == 1
+        assert not published
+
+
+class TestHandlerFilesystemCrawlerRemoved:
+    """Files in state table but not found in walk emit document-removed events."""
+
+    @pytest.mark.unit
+    async def test_missing_file_emits_removed_event(self, tmp_path: Path) -> None:
+        # State table knows about a file that no longer exists on disk
+        ghost_path = str(tmp_path / "deleted.md")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=None)
+
+        # list_states_for_scope returns a stale record
+        ghost_state = make_state(ghost_path, _sha256(b"old content"))
+        repo.list_states_for_scope = AsyncMock(return_value=[ghost_state])
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.removed_count == 1
+
+        removed_events = [(t, p) for t, p in published if "document-removed" in t]
+        assert len(removed_events) == 1
+
+        topic, payload = removed_events[0]
+        assert topic == "dev.onex.evt.omnimemory.document-removed.v1"
+        assert payload["event_type"] == "DocumentRemoved"
+        assert payload["source_ref"] == ghost_path
+
+        # State should be deleted
+        repo.delete_state.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_existing_file_not_emitted_as_removed(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "real.md"
+        content = b"# Real doc"
+        md_file.write_bytes(content)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        # The file IS in the state table but still on disk → no removal
+        state = make_state(str(md_file.resolve()), _sha256(content))
+        repo.get_state = AsyncMock(return_value=state)
+        repo.list_states_for_scope = AsyncMock(return_value=[state])
+
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.removed_count == 0
+        removed_events = [(t, p) for t, p in published if "document-removed" in t]
+        assert len(removed_events) == 0
+
+
+class TestHandlerFilesystemCrawlerFileLimits:
+    @pytest.mark.unit
+    async def test_oversized_file_is_skipped(self, tmp_path: Path) -> None:
+        big_file = tmp_path / "big.md"
+        big_file.write_bytes(b"x" * 100)
+
+        # Set max to 50 bytes
+        config = make_config(path_prefixes=[str(tmp_path)], max_file_size_bytes=50)
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 1
+        assert result.skipped_count == 1
+        assert result.discovered_count == 0
+        assert not published
+
+    @pytest.mark.unit
+    async def test_max_files_per_crawl_truncates(self, tmp_path: Path) -> None:
+        for i in range(10):
+            (tmp_path / f"f{i}.md").write_bytes(f"# Doc {i}".encode())
+
+        config = make_config(path_prefixes=[str(tmp_path)], max_files_per_crawl=3)
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.truncated is True
+        assert result.files_walked == 3
+        # Should have discovered 3 (not 10)
+        assert result.discovered_count == 3
+
+
+class TestHandlerFilesystemCrawlerPublishErrors:
+    """Publish errors must not abort the crawl."""
+
+    @pytest.mark.unit
+    async def test_publish_error_continues_crawl(self, tmp_path: Path) -> None:
+        for i in range(3):
+            (tmp_path / f"f{i}.md").write_bytes(f"# {i}".encode())
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+
+        call_count = 0
+
+        def failing_publish(topic: str, payload: dict[str, object]) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("Kafka unavailable")
+
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        # Should not raise
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=failing_publish,
+        )
+
+        # All 3 files were walked and attempted to publish
+        assert result.files_walked == 3
+        assert result.discovered_count == 3
+        assert call_count == 3
+
+
+class TestHandlerFilesystemCrawlerDocTypeAssignment:
+    """Correct doc types are embedded in emitted events."""
+
+    @pytest.mark.unit
+    async def test_claude_md_doc_type_in_event(self, tmp_path: Path) -> None:
+        claude_file = tmp_path / "CLAUDE.md"
+        claude_file.write_bytes(b"# Standards")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["detected_doc_type"] == EnumDetectedDocType.CLAUDE_MD.value
+
+    @pytest.mark.unit
+    async def test_readme_doc_type_in_event(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_bytes(b"# Readme")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["detected_doc_type"] == EnumDetectedDocType.README.value
+
+
+class TestHandlerFilesystemCrawlerSourceType:
+    """CLAUDE.md files are classified as STATIC_STANDARDS."""
+
+    @pytest.mark.unit
+    async def test_claude_md_source_type_static_standards(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_bytes(b"# Policy")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["source_type"] == EnumContextSourceType.STATIC_STANDARDS.value
+
+    @pytest.mark.unit
+    async def test_regular_md_source_type_repo_derived(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.md").write_bytes(b"# Notes")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["source_type"] == EnumContextSourceType.REPO_DERIVED.value
+
+
+class TestHandlerFilesystemCrawlerPriorityHints:
+    @pytest.mark.unit
+    async def test_claude_md_priority_85(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_bytes(b"# Standards")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["priority_hint"] == 85
+
+    @pytest.mark.unit
+    async def test_unknown_md_priority_35(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.md").write_bytes(b"# Notes")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        _, payload = published[0]
+        assert payload["priority_hint"] == 35
+
+
+class TestHandlerFilesystemCrawlerScopeMappings:
+    @pytest.mark.unit
+    async def test_scope_mapping_applied_to_event(self, tmp_path: Path) -> None:
+        (tmp_path / "doc.md").write_bytes(b"# Doc")
+
+        scope_mappings = [(str(tmp_path), "omninode/custom-scope")]
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/custom-scope",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+            scope_mappings=scope_mappings,
+        )
+
+        _, payload = published[0]
+        assert payload["scope_ref"] == "omninode/custom-scope"
+
+
+class TestHandlerFilesystemCrawlerRecursive:
+    """Files in nested subdirectories are discovered."""
+
+    @pytest.mark.unit
+    async def test_recursive_walk_finds_nested_files(self, tmp_path: Path) -> None:
+        nested = tmp_path / "docs" / "subdir"
+        nested.mkdir(parents=True)
+        (nested / "deep.md").write_bytes(b"# Deep")
+        (tmp_path / "root.md").write_bytes(b"# Root")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 2
+        assert result.discovered_count == 2
+
+    @pytest.mark.unit
+    async def test_non_md_files_are_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "code.py").write_bytes(b"print('hello')")
+        (tmp_path / "data.json").write_bytes(b"{}")
+        (tmp_path / "doc.md").write_bytes(b"# Doc")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.files_walked == 1
+        assert result.discovered_count == 1

--- a/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
+++ b/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
@@ -26,7 +26,7 @@ Tests cover:
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -104,11 +104,14 @@ def make_mock_repo() -> MagicMock:
 
 
 def make_publish_capture() -> (
-    tuple[Callable[[str, dict[str, object]], None], list[PublishRecord]]
+    tuple[
+        Callable[[str, dict[str, object]], Coroutine[object, object, None]],
+        list[PublishRecord],
+    ]
 ):
     published: list[PublishRecord] = []
 
-    def capture(topic: str, payload: dict[str, object]) -> None:
+    async def capture(topic: str, payload: dict[str, object]) -> None:
         published.append((topic, payload))
 
     return capture, published
@@ -771,7 +774,7 @@ class TestHandlerFilesystemCrawlerPublishErrors:
 
         call_count = 0
 
-        def failing_publish(topic: str, payload: dict[str, object]) -> None:
+        async def failing_publish(topic: str, payload: dict[str, object]) -> None:
             nonlocal call_count
             call_count += 1
             raise RuntimeError("Kafka unavailable")


### PR DESCRIPTION
## Summary

Implements `FilesystemCrawlerEffect` (Stream A, Document Ingestion Pipeline) per design doc `omni_save/design/DESIGN_OMNIMEMORY_DOCUMENT_INGESTION_PIPELINE.md §5`.

- Adds `EnumCrawlerType`, `EnumContextSourceType`, `EnumDetectedDocType` enums
- Adds `ModelCrawlStateRecord` (DB row for `omnimemory_crawl_state` table)
- Adds `ModelDocumentDiscoveredEvent`, `ModelDocumentChangedEvent`, `ModelDocumentRemovedEvent` (frozen, Kafka events)
- Adds `ProtocolCrawlStateRepository` (`get_state`, `list_states_for_scope`, `upsert_state`, `delete_state`)
- Adds `FilesystemCrawlerEffect` node with handler implementing two-stage mtime → SHA-256 change detection
- 52 unit tests covering all 3 detection cases (discovered, changed, removed), mtime fast-path, scope resolution, priority hints

## Change Detection Algorithm

1. Walk target paths, collect `(path, stat.st_mtime)` for `*.md` files
2. mtime fast-path: if unchanged, skip without re-hashing
3. If mtime changed: compute SHA-256. If hash unchanged → update `last_crawled_at_utc` only. If hash differs → emit `document.changed.v1`
4. Not in state table → emit `document.discovered.v1`
5. Paths in state table NOT found in walk → emit `document.removed.v1`

## Test plan

- [x] 52/52 unit tests pass (all 3 detection cases, mtime fast-path, scope resolution)
- [x] Full suite: 2260 passed, 0 failed
- [x] `poetry run mypy src/omnimemory --strict` — 0 errors
- [x] `poetry run ruff check src/ tests/` — 0 errors
- [x] `pre-commit run --all-files` — all hooks pass

Closes OMN-2385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filesystem-based document crawler with change detection and mtime fast-path
  * Emits document lifecycle events: discovered, changed, removed
  * Configurable crawl paths, glob patterns, file size and per-run limits, and event topic routing
  * New structured event and crawl-state models and a crawl-state repository protocol for persistence

* **Tests**
  * Comprehensive unit/integration tests covering crawler behavior, edge cases, and event emission
<!-- end of auto-generated comment: release notes by coderabbit.ai -->