### PR TITLE
feat(adapters): add adapter implementations for memory lifecycle orchestrator (OMN-1603)

### DIFF
--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/__init__.py
@@ -2,25 +2,47 @@
 # Copyright (c) 2025 OmniNode Team
 """Memory Lifecycle Orchestrator Adapters.
 
-Storage adapters for memory lifecycle operations including archive storage
-and projection readers.
+Storage adapters for memory lifecycle operations including runtime tick
+processing and memory deactivation.
 
-Adapters (to be implemented):
-    - AdapterArchiveStorage: Cold storage adapter for archived memories
-    - ProjectionReaderMemoryLifecycle: Read-only projection state access
+Adapters:
+    AdapterRuntimeTickMemory: Tick-based lifecycle detection adapter.
+        Wraps HandlerMemoryTick to provide TTL expiration and archive
+        candidate detection via runtime tick events.
+
+    AdapterPostgresDeactivateMemory: Memory expiration operations adapter.
+        Wraps HandlerMemoryExpire to provide ACTIVE -> EXPIRED state
+        transitions with optimistic locking against PostgreSQL.
 
 Adapter Pattern:
     Adapters wrap external dependencies (storage backends, databases) and
     provide a consistent interface for handlers. All adapters implement
     protocol-based interfaces for dependency injection and testing.
 
-.. versionadded:: 0.1.0
-    Initial implementation for OMN-1453.
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
 
-Ticket: OMN-1453
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1603.
 """
 
-# TODO(OMN-1453): Add adapter imports as implemented:
-#   AdapterArchiveStorage, ProjectionReaderMemoryLifecycle
+from omnimemory.nodes.memory_lifecycle_orchestrator.adapters.adapter_postgres_deactivate_memory import (
+    AdapterPostgresDeactivateMemory,
+    ModelDeactivateAdapterHealth,
+    ModelDeactivateAdapterMetadata,
+)
+from omnimemory.nodes.memory_lifecycle_orchestrator.adapters.adapter_runtime_tick_memory import (
+    AdapterRuntimeTickMemory,
+    ModelRuntimeTickAdapterHealth,
+    ModelRuntimeTickAdapterMetadata,
+)
 
-__all__: list[str] = []
+__all__: list[str] = [
+    "AdapterRuntimeTickMemory",
+    "ModelRuntimeTickAdapterHealth",
+    "ModelRuntimeTickAdapterMetadata",
+    "AdapterPostgresDeactivateMemory",
+    "ModelDeactivateAdapterHealth",
+    "ModelDeactivateAdapterMetadata",
+]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
@@ -56,6 +56,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
     HandlerMemoryExpire,
+    ModelExpireMemoryCommand,
     ModelMemoryExpireHealth,
     ModelMemoryExpireMetadata,
     ModelMemoryExpireResult,
@@ -252,10 +253,6 @@ class AdapterPostgresDeactivateMemory:
                 "AdapterPostgresDeactivateMemory not initialized. "
                 "Call initialize() before deactivate()."
             )
-        from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
-            ModelExpireMemoryCommand,
-        )
-
         command = ModelExpireMemoryCommand(
             memory_id=memory_id,
             expected_revision=expected_revision,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Adapter for memory deactivation (expiration) operations via PostgreSQL.
+
+This adapter provides a clean abstraction over HandlerMemoryExpire,
+encapsulating the ACTIVE -> EXPIRED state transition logic and exposing
+a simplified deactivation API for the memory lifecycle orchestrator.
+
+Adapter Pattern:
+    AdapterPostgresDeactivateMemory wraps HandlerMemoryExpire and provides:
+    - deactivate(): Single expiration with optimistic locking
+    - deactivate_with_retry(): Expiration with automatic conflict retry
+    - Health reporting from the underlying handler
+    - Metadata introspection (describe())
+    - Lifecycle management (initialize / shutdown)
+
+Example::
+
+    from omnibase_core.container import ModelONEXContainer
+    from omnimemory.nodes.memory_lifecycle_orchestrator.adapters import (
+        AdapterPostgresDeactivateMemory,
+    )
+    from uuid import uuid4
+
+    container = ModelONEXContainer()
+    adapter = AdapterPostgresDeactivateMemory(container)
+    await adapter.initialize(db_pool=pool, max_retries=3)
+
+    # Deactivate a memory (ACTIVE -> EXPIRED)
+    result = await adapter.deactivate(
+        memory_id=uuid4(),
+        expected_revision=5,
+        reason="ttl_expired",
+    )
+    if result.success:
+        print(f"Memory deactivated, new revision: {result.new_revision}")
+    elif result.conflict:
+        print("Concurrent modification, retry needed")
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+    - OMN-1392: Original lifecycle orchestrator delivery
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1603.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
+    HandlerMemoryExpire,
+    ModelMemoryExpireHealth,
+    ModelMemoryExpireMetadata,
+    ModelMemoryExpireResult,
+)
+
+if TYPE_CHECKING:
+    from asyncpg import Pool
+    from omnibase_core.container import ModelONEXContainer
+
+    from omnimemory.utils.concurrency import CircuitBreaker
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AdapterPostgresDeactivateMemory",
+    "ModelDeactivateAdapterHealth",
+    "ModelDeactivateAdapterMetadata",
+]
+
+
+class ModelDeactivateAdapterHealth(
+    BaseModel
+):  # omnimemory-model-exempt: adapter health
+    """Health status for AdapterPostgresDeactivateMemory.
+
+    Aggregates health from the underlying HandlerMemoryExpire.
+
+    Attributes:
+        initialized: Whether the adapter has been initialized.
+        handler_health: Health status from the underlying expire handler.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    initialized: bool = Field(
+        ...,
+        description="Whether the adapter has been initialized",
+    )
+    handler_health: ModelMemoryExpireHealth = Field(
+        ...,
+        description="Health status from the underlying HandlerMemoryExpire",
+    )
+
+
+class ModelDeactivateAdapterMetadata(
+    BaseModel
+):  # omnimemory-model-exempt: adapter config
+    """Metadata for AdapterPostgresDeactivateMemory.
+
+    Attributes:
+        name: Adapter class name.
+        description: Brief description of adapter purpose.
+        handler_metadata: Metadata from the underlying expire handler.
+        initialized: Whether the adapter has been initialized.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(
+        ...,
+        description="Adapter class name",
+    )
+    description: str = Field(
+        ...,
+        description="Brief description of adapter purpose",
+    )
+    handler_metadata: ModelMemoryExpireMetadata = Field(
+        ...,
+        description="Metadata from the underlying HandlerMemoryExpire",
+    )
+    initialized: bool = Field(
+        ...,
+        description="Whether the adapter has been initialized",
+    )
+
+
+class AdapterPostgresDeactivateMemory:
+    """Adapter for memory deactivation (expiration) via PostgreSQL.
+
+    Wraps HandlerMemoryExpire to provide a clean interface for the lifecycle
+    orchestrator. This adapter is responsible for:
+
+    1. Initializing the underlying expire handler with a database pool.
+    2. Delegating ACTIVE -> EXPIRED state transitions to the handler.
+    3. Exposing health and metadata for observability.
+
+    The adapter uses the term "deactivate" to emphasize the semantic of
+    removing a memory from the active set, which aligns with the lifecycle
+    orchestrator's responsibility.
+
+    Container-Driven Pattern:
+        Follows the ONEX container-driven initialization pattern:
+        - Constructor takes only ModelONEXContainer
+        - Dependencies injected via async initialize()
+        - health_check() and describe() for introspection
+
+    Attributes:
+        _container: ONEX container for dependency injection.
+        _handler: Underlying HandlerMemoryExpire instance.
+        _initialized: Whether initialize() has been called.
+    """
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        """Initialize AdapterPostgresDeactivateMemory with ONEX container.
+
+        Args:
+            container: ONEX container for dependency injection.
+
+        Note:
+            Call initialize() with a db_pool before using deactivate().
+        """
+        self._container = container
+        self._handler = HandlerMemoryExpire(container)
+        self._initialized: bool = False
+
+    async def initialize(
+        self,
+        db_pool: Pool,
+        max_retries: int = 3,
+        circuit_breaker: CircuitBreaker | None = None,
+    ) -> None:
+        """Initialize the adapter and the underlying expire handler.
+
+        Args:
+            db_pool: PostgreSQL connection pool for database operations.
+            max_retries: Maximum retry attempts for deactivate_with_retry().
+                Defaults to 3 attempts.
+            circuit_breaker: Optional circuit breaker for database operation
+                resilience. A default is created if not provided.
+
+        Raises:
+            ValueError: If max_retries is less than 1.
+        """
+        await self._handler.initialize(
+            db_pool=db_pool,
+            max_retries=max_retries,
+            circuit_breaker=circuit_breaker,
+        )
+        self._initialized = True
+        logger.info(
+            "AdapterPostgresDeactivateMemory initialized",
+            extra={"max_retries": max_retries},
+        )
+
+    async def shutdown(self) -> None:
+        """Shutdown the adapter and the underlying handler.
+
+        Safe to call multiple times (idempotent).
+        """
+        if self._initialized:
+            await self._handler.shutdown()
+            self._initialized = False
+            logger.info("AdapterPostgresDeactivateMemory shutdown complete")
+
+    @property
+    def initialized(self) -> bool:
+        """Return whether the adapter has been initialized."""
+        return self._initialized
+
+    async def deactivate(
+        self,
+        memory_id: UUID,
+        expected_revision: int,
+        reason: str = "ttl_expired",
+        expired_at: datetime | None = None,
+    ) -> ModelMemoryExpireResult:
+        """Deactivate a memory by transitioning it from ACTIVE to EXPIRED.
+
+        Performs a single attempt with optimistic locking. On revision conflict
+        (concurrent modification), the caller is responsible for re-reading
+        and retrying with the updated revision. For automatic retry behavior,
+        use deactivate_with_retry().
+
+        Args:
+            memory_id: UUID of the memory to deactivate.
+            expected_revision: Expected lifecycle revision for optimistic lock.
+                Must match the current revision in the database.
+            reason: Reason for deactivation (for audit trail).
+                Defaults to "ttl_expired".
+            expired_at: Optional explicit expiration timestamp.
+                Defaults to the current UTC time if not provided.
+
+        Returns:
+            ModelMemoryExpireResult indicating:
+            - success=True: Transition completed, new_revision populated.
+            - success=False, conflict=True: Revision mismatch, retry eligible.
+            - success=False, conflict=False: Hard failure (invalid state, not found).
+
+        Raises:
+            RuntimeError: If the adapter has not been initialized.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "AdapterPostgresDeactivateMemory not initialized. "
+                "Call initialize() before deactivate()."
+            )
+        from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
+            ModelExpireMemoryCommand,
+        )
+
+        command = ModelExpireMemoryCommand(
+            memory_id=memory_id,
+            expected_revision=expected_revision,
+            reason=reason,
+            expired_at=expired_at,
+        )
+        return await self._handler.handle(command)
+
+    async def deactivate_with_retry(
+        self,
+        memory_id: UUID,
+        initial_revision: int,
+        reason: str = "ttl_expired",
+        expired_at: datetime | None = None,
+    ) -> ModelMemoryExpireResult:
+        """Deactivate a memory with automatic retry on conflict.
+
+        Wraps deactivate() with automatic conflict resolution by re-reading
+        the current revision and retrying up to max_retries times.
+
+        Args:
+            memory_id: UUID of the memory to deactivate.
+            initial_revision: Starting revision for the first attempt.
+            reason: Reason for deactivation (for audit trail).
+            expired_at: Optional explicit expiration timestamp.
+
+        Returns:
+            ModelMemoryExpireResult with final outcome:
+            - success=True: Deactivation eventually succeeded.
+            - success=False, conflict=True: Max retries exceeded.
+            - success=False, conflict=False: Hard failure.
+
+        Raises:
+            RuntimeError: If the adapter has not been initialized.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "AdapterPostgresDeactivateMemory not initialized. "
+                "Call initialize() before deactivate_with_retry()."
+            )
+        return await self._handler.handle_with_retry(
+            memory_id=memory_id,
+            initial_revision=initial_revision,
+            reason=reason,
+            expired_at=expired_at,
+        )
+
+    async def health_check(self) -> ModelDeactivateAdapterHealth:
+        """Return health status of the adapter and its handler.
+
+        Returns:
+            ModelDeactivateAdapterHealth with initialization status
+            and underlying handler health.
+        """
+        handler_health = await self._handler.health_check()
+        return ModelDeactivateAdapterHealth(
+            initialized=self._initialized,
+            handler_health=handler_health,
+        )
+
+    async def describe(self) -> ModelDeactivateAdapterMetadata:
+        """Return metadata and capabilities of this adapter.
+
+        Returns:
+            ModelDeactivateAdapterMetadata with adapter information
+            and underlying handler metadata.
+        """
+        handler_metadata = await self._handler.describe()
+        return ModelDeactivateAdapterMetadata(
+            name="AdapterPostgresDeactivateMemory",
+            description=(
+                "Adapter for memory deactivation (expiration) via PostgreSQL. "
+                "Wraps HandlerMemoryExpire to provide ACTIVE -> EXPIRED "
+                "state transitions with optimistic locking."
+            ),
+            handler_metadata=handler_metadata,
+            initialized=self._initialized,
+        )

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
@@ -154,7 +154,6 @@ class AdapterPostgresDeactivateMemory:
         - health_check() and describe() for introspection
 
     Attributes:
-        _container: ONEX container for dependency injection.
         _handler: Underlying HandlerMemoryExpire instance.
         _initialized: Whether initialize() has been called.
     """
@@ -168,7 +167,6 @@ class AdapterPostgresDeactivateMemory:
         Note:
             Call initialize() with a db_pool before using deactivate().
         """
-        self._container = container
         self._handler = HandlerMemoryExpire(container)
         self._initialized: bool = False
 
@@ -188,7 +186,8 @@ class AdapterPostgresDeactivateMemory:
                 resilience. A default is created if not provided.
 
         Raises:
-            ValueError: If max_retries is less than 1.
+            ValueError: If max_retries is less than 1. Validation is delegated
+                to HandlerMemoryExpire.initialize(), which enforces this constraint.
         """
         await self._handler.initialize(
             db_pool=db_pool,

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_postgres_deactivate_memory.py
@@ -270,8 +270,8 @@ class AdapterPostgresDeactivateMemory:
     ) -> ModelMemoryExpireResult:
         """Deactivate a memory with automatic retry on conflict.
 
-        Wraps deactivate() with automatic conflict resolution by re-reading
-        the current revision and retrying up to max_retries times.
+        Delegates retry logic to the handler's handle_with_retry() method,
+        which re-reads the current revision and retries up to max_retries times.
 
         Args:
             memory_id: UUID of the memory to deactivate.

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_runtime_tick_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_runtime_tick_memory.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Adapter for tick-based memory lifecycle detection.
+
+This adapter provides a clean abstraction over HandlerMemoryTick,
+encapsulating the tick-based TTL evaluation and archive detection logic.
+It exposes high-level operations for the memory lifecycle orchestrator
+without requiring callers to manage handler internals.
+
+Adapter Pattern:
+    AdapterRuntimeTickMemory wraps HandlerMemoryTick and provides:
+    - A simplified API for processing runtime ticks
+    - Health reporting from the underlying handler
+    - Metadata introspection (describe())
+    - Lifecycle management (initialize / shutdown)
+
+Example::
+
+    from omnibase_core.container import ModelONEXContainer
+    from omnimemory.nodes.memory_lifecycle_orchestrator.adapters import (
+        AdapterRuntimeTickMemory,
+    )
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+    from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
+
+    container = ModelONEXContainer()
+    adapter = AdapterRuntimeTickMemory(container)
+    await adapter.initialize(projection_reader=reader, batch_size=50)
+
+    # Process a runtime tick envelope
+    output = await adapter.process_tick(envelope)
+    print(f"Expired: {output.metrics['expired_count']}")
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+    - OMN-1392: Original lifecycle orchestrator delivery
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1603.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_tick import (
+    HandlerMemoryTick,
+    ModelMemoryTickHealth,
+    ModelMemoryTickMetadata,
+    ProtocolMemoryLifecycleProjectionReader,
+)
+
+if TYPE_CHECKING:
+    from omnibase_core.container import ModelONEXContainer
+    from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+    from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
+
+    from omnimemory.utils.concurrency import CircuitBreaker
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AdapterRuntimeTickMemory",
+    "ModelRuntimeTickAdapterHealth",
+    "ModelRuntimeTickAdapterMetadata",
+]
+
+
+class ModelRuntimeTickAdapterHealth(
+    BaseModel
+):  # omnimemory-model-exempt: adapter health
+    """Health status for AdapterRuntimeTickMemory.
+
+    Aggregates health from the underlying HandlerMemoryTick.
+
+    Attributes:
+        initialized: Whether the adapter has been initialized.
+        handler_health: Health status from the underlying tick handler.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    initialized: bool = Field(
+        ...,
+        description="Whether the adapter has been initialized",
+    )
+    handler_health: ModelMemoryTickHealth = Field(
+        ...,
+        description="Health status from the underlying HandlerMemoryTick",
+    )
+
+
+class ModelRuntimeTickAdapterMetadata(
+    BaseModel
+):  # omnimemory-model-exempt: adapter config
+    """Metadata for AdapterRuntimeTickMemory.
+
+    Attributes:
+        name: Adapter class name.
+        description: Brief description of adapter purpose.
+        handler_metadata: Metadata from the underlying tick handler.
+        initialized: Whether the adapter has been initialized.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(
+        ...,
+        description="Adapter class name",
+    )
+    description: str = Field(
+        ...,
+        description="Brief description of adapter purpose",
+    )
+    handler_metadata: ModelMemoryTickMetadata = Field(
+        ...,
+        description="Metadata from the underlying HandlerMemoryTick",
+    )
+    initialized: bool = Field(
+        ...,
+        description="Whether the adapter has been initialized",
+    )
+
+
+class AdapterRuntimeTickMemory:
+    """Adapter for tick-based memory lifecycle detection.
+
+    Wraps HandlerMemoryTick to provide a clean interface for the lifecycle
+    orchestrator. This adapter is responsible for:
+
+    1. Initializing the underlying tick handler with configured dependencies.
+    2. Delegating tick processing to the handler.
+    3. Exposing health and metadata for observability.
+
+    Container-Driven Pattern:
+        Follows the ONEX container-driven initialization pattern:
+        - Constructor takes only ModelONEXContainer
+        - Dependencies injected via async initialize()
+        - health_check() and describe() for introspection
+
+    Attributes:
+        _container: ONEX container for dependency injection.
+        _handler: Underlying HandlerMemoryTick instance.
+        _initialized: Whether initialize() has been called.
+    """
+
+    def __init__(self, container: ModelONEXContainer) -> None:
+        """Initialize AdapterRuntimeTickMemory with ONEX container.
+
+        Args:
+            container: ONEX container for dependency injection.
+
+        Note:
+            Call initialize() before using process_tick().
+        """
+        self._container = container
+        self._handler = HandlerMemoryTick(container)
+        self._initialized: bool = False
+
+    async def initialize(
+        self,
+        projection_reader: ProtocolMemoryLifecycleProjectionReader | None = None,
+        batch_size: int = 100,
+        circuit_breaker: CircuitBreaker | None = None,
+    ) -> None:
+        """Initialize the adapter and the underlying tick handler.
+
+        Args:
+            projection_reader: Reader for memory lifecycle projection state.
+                If None, handler will return empty results (no-op mode).
+            batch_size: Maximum memories to process per tick.
+            circuit_breaker: Optional circuit breaker for projection reader
+                resilience. A default is created if not provided.
+        """
+        await self._handler.initialize(
+            projection_reader=projection_reader,
+            batch_size=batch_size,
+            circuit_breaker=circuit_breaker,
+        )
+        self._initialized = True
+        logger.info(
+            "AdapterRuntimeTickMemory initialized",
+            extra={
+                "batch_size": batch_size,
+                "has_projection_reader": projection_reader is not None,
+            },
+        )
+
+    async def shutdown(self) -> None:
+        """Shutdown the adapter and the underlying handler.
+
+        Safe to call multiple times (idempotent).
+        """
+        if self._initialized:
+            await self._handler.shutdown()
+            self._initialized = False
+            logger.info("AdapterRuntimeTickMemory shutdown complete")
+
+    @property
+    def initialized(self) -> bool:
+        """Return whether the adapter has been initialized."""
+        return self._initialized
+
+    async def process_tick(
+        self,
+        envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> ModelHandlerOutput[None]:
+        """Process a runtime tick and emit lifecycle transition events.
+
+        Delegates to HandlerMemoryTick.handle() to detect memory expirations
+        and archive candidates within the current tick window.
+
+        Args:
+            envelope: Event envelope containing the runtime tick payload.
+
+        Returns:
+            ModelHandlerOutput containing lifecycle transition events
+            (ModelMemoryExpiredEvent, ModelMemoryArchiveInitiated).
+
+        Raises:
+            RuntimeError: If the adapter has not been initialized.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "AdapterRuntimeTickMemory not initialized. "
+                "Call initialize() before process_tick()."
+            )
+        return await self._handler.handle(envelope)
+
+    async def health_check(self) -> ModelRuntimeTickAdapterHealth:
+        """Return health status of the adapter and its handler.
+
+        Returns:
+            ModelRuntimeTickAdapterHealth with initialization status
+            and underlying handler health.
+        """
+        handler_health = await self._handler.health_check()
+        return ModelRuntimeTickAdapterHealth(
+            initialized=self._initialized,
+            handler_health=handler_health,
+        )
+
+    async def describe(self) -> ModelRuntimeTickAdapterMetadata:
+        """Return metadata and capabilities of this adapter.
+
+        Returns:
+            ModelRuntimeTickAdapterMetadata with adapter information
+            and underlying handler metadata.
+        """
+        handler_metadata = await self._handler.describe()
+        return ModelRuntimeTickAdapterMetadata(
+            name="AdapterRuntimeTickMemory",
+            description=(
+                "Adapter for tick-based memory lifecycle detection. "
+                "Wraps HandlerMemoryTick to provide TTL expiration "
+                "and archive candidate detection via runtime tick events."
+            ),
+            handler_metadata=handler_metadata,
+            initialized=self._initialized,
+        )

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_runtime_tick_memory.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/adapters/adapter_runtime_tick_memory.py
@@ -143,7 +143,6 @@ class AdapterRuntimeTickMemory:
         - health_check() and describe() for introspection
 
     Attributes:
-        _container: ONEX container for dependency injection.
         _handler: Underlying HandlerMemoryTick instance.
         _initialized: Whether initialize() has been called.
     """
@@ -157,7 +156,6 @@ class AdapterRuntimeTickMemory:
         Note:
             Call initialize() before using process_tick().
         """
-        self._container = container
         self._handler = HandlerMemoryTick(container)
         self._initialized: bool = False
 

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/__init__.py
@@ -4,29 +4,46 @@
 
 Validation logic for lifecycle state transitions.
 
-Validators (to be implemented):
-    - ValidatorLifecycleTransition: Validates state transition rules
+Validators:
+    ValidatorLifecycleTransition: Validates lifecycle state machine transitions.
+        Enforces the full 5-state memory lifecycle:
+        ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED
+
+        With additional transitions:
+        STALE   -> ACTIVE   (soft refresh / promotion)
+        ARCHIVED -> ACTIVE  (restore from archive)
+        ACTIVE, STALE, EXPIRED, ARCHIVED -> DELETED (explicit deletion)
 
 Validation Rules:
     State transitions must follow the lifecycle state machine:
-    - ACTIVE -> EXPIRED (TTL expiration)
-    - ACTIVE -> ARCHIVED (explicit archival)
-    - EXPIRED -> ARCHIVED (post-expiration archival)
-    - ARCHIVED -> ACTIVE (restore command)
-    - Any -> DELETED (terminal state)
+    - ACTIVE  -> STALE, EXPIRED, DELETED
+    - STALE   -> ACTIVE, EXPIRED, DELETED
+    - EXPIRED -> ARCHIVED, DELETED
+    - ARCHIVED -> ACTIVE, DELETED
+    - DELETED -> (terminal, no transitions)
 
 Invalid Transitions:
     - DELETED -> any state (terminal, no recovery)
     - ARCHIVED -> EXPIRED (must restore first)
-    - EXPIRED -> ACTIVE (must archive then restore)
+    - EXPIRED -> ACTIVE   (must archive then restore)
+    - Self-transitions (same state to same state)
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+    - OMN-1453: OmniMemory P4b - Lifecycle Orchestrator Database Integration
 
 .. versionadded:: 0.1.0
-    Initial implementation for OMN-1453.
-
-Ticket: OMN-1453
+    Initial implementation for OMN-1603.
 """
 
-# TODO(OMN-1453): Add validator imports as implemented:
-#   ValidatorLifecycleTransition
+from omnimemory.nodes.memory_lifecycle_orchestrator.validators.validator_lifecycle_transition import (
+    VALID_TRANSITIONS,
+    ModelTransitionValidationResult,
+    ValidatorLifecycleTransition,
+)
 
-__all__: list[str] = []
+__all__: list[str] = [
+    "ValidatorLifecycleTransition",
+    "ModelTransitionValidationResult",
+    "VALID_TRANSITIONS",
+]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -7,11 +7,9 @@ This module validates that lifecycle state transitions follow the defined
 
 State Machine:
     ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED
-                          |
-                       PROMOTED (returns to ACTIVE)
 
-    Where PROMOTED is a special transition from ARCHIVED back to ACTIVE,
-    representing a memory restoration operation.
+    ARCHIVED -> ACTIVE is also valid, representing a memory restoration
+    operation (archived memory returned to the active set).
 
 Valid Transitions:
     ACTIVE  -> STALE    (soft TTL exceeded, still accessible)

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -156,6 +156,7 @@ class ValidatorLifecycleTransition:
             to_state=EnumLifecycleState.ACTIVE,
         )
         assert result.valid is False
+        assert result.reason is not None
         assert "terminal" in result.reason
 
     Note:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -43,6 +43,8 @@ Related Tickets:
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnimemory.enums import EnumLifecycleState
@@ -58,36 +60,40 @@ __all__ = [
 # Key: source state, Value: set of valid destination states
 # ---------------------------------------------------------------------------
 
-VALID_TRANSITIONS: dict[EnumLifecycleState, frozenset[EnumLifecycleState]] = {
-    EnumLifecycleState.ACTIVE: frozenset(
-        {
-            EnumLifecycleState.STALE,
-            EnumLifecycleState.EXPIRED,
-            EnumLifecycleState.DELETED,
-        }
-    ),
-    EnumLifecycleState.STALE: frozenset(
-        {
-            EnumLifecycleState.ACTIVE,  # refreshed / promoted
-            EnumLifecycleState.EXPIRED,
-            EnumLifecycleState.DELETED,
-        }
-    ),
-    EnumLifecycleState.EXPIRED: frozenset(
-        {
-            EnumLifecycleState.ARCHIVED,
-            EnumLifecycleState.DELETED,
-        }
-    ),
-    EnumLifecycleState.ARCHIVED: frozenset(
-        {
-            EnumLifecycleState.ACTIVE,  # promoted / restored
-            EnumLifecycleState.DELETED,
-        }
-    ),
-    # DELETED is a terminal state - no outbound transitions.
-    EnumLifecycleState.DELETED: frozenset(),
-}
+VALID_TRANSITIONS: MappingProxyType[
+    EnumLifecycleState, frozenset[EnumLifecycleState]
+] = MappingProxyType(
+    {
+        EnumLifecycleState.ACTIVE: frozenset(
+            {
+                EnumLifecycleState.STALE,
+                EnumLifecycleState.EXPIRED,
+                EnumLifecycleState.DELETED,
+            }
+        ),
+        EnumLifecycleState.STALE: frozenset(
+            {
+                EnumLifecycleState.ACTIVE,  # refreshed / promoted
+                EnumLifecycleState.EXPIRED,
+                EnumLifecycleState.DELETED,
+            }
+        ),
+        EnumLifecycleState.EXPIRED: frozenset(
+            {
+                EnumLifecycleState.ARCHIVED,
+                EnumLifecycleState.DELETED,
+            }
+        ),
+        EnumLifecycleState.ARCHIVED: frozenset(
+            {
+                EnumLifecycleState.ACTIVE,  # promoted / restored
+                EnumLifecycleState.DELETED,
+            }
+        ),
+        # DELETED is a terminal state - no outbound transitions.
+        EnumLifecycleState.DELETED: frozenset(),
+    }
+)
 
 
 class ModelTransitionValidationResult(

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -96,7 +96,7 @@ VALID_TRANSITIONS: MappingProxyType[
 
 class ModelTransitionValidationResult(
     BaseModel
-):  # omnimemory-model-exempt: handler result
+):  # omnimemory-model-exempt: validator result
     """Result of a lifecycle state transition validation.
 
     Attributes:

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""State machine validator for memory lifecycle transitions.
+
+This module validates that lifecycle state transitions follow the defined
+5-state memory lifecycle state machine.
+
+State Machine:
+    ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED
+                          |
+                       PROMOTED (returns to ACTIVE)
+
+    Where PROMOTED is a special transition from ARCHIVED back to ACTIVE,
+    representing a memory restoration operation.
+
+Valid Transitions:
+    ACTIVE  -> STALE    (soft TTL exceeded, still accessible)
+    ACTIVE  -> EXPIRED  (hard TTL exceeded, direct expiration)
+    ACTIVE  -> DELETED  (explicit delete of active memory)
+    STALE   -> EXPIRED  (hard TTL exceeded after staleness)
+    STALE   -> ACTIVE   (refreshed, promoted back to active)
+    STALE   -> DELETED  (explicit delete of stale memory)
+    EXPIRED -> ARCHIVED (moved to cold storage)
+    EXPIRED -> DELETED  (explicit delete of expired memory)
+    ARCHIVED -> ACTIVE  (promoted/restored from archive)
+    ARCHIVED -> DELETED (explicit delete of archived memory)
+    DELETED -> (none)   (terminal state - no transitions allowed)
+
+Invalid Transitions:
+    DELETED -> any      (terminal state, no recovery)
+    ARCHIVED -> EXPIRED (must restore to ACTIVE first)
+    ARCHIVED -> STALE   (must restore to ACTIVE first)
+    EXPIRED -> ACTIVE   (must go through ARCHIVED)
+    EXPIRED -> STALE    (invalid regression)
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+    - OMN-1392: Original lifecycle orchestrator delivery
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-1603.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums import EnumLifecycleState
+
+__all__ = [
+    "ValidatorLifecycleTransition",
+    "ModelTransitionValidationResult",
+    "VALID_TRANSITIONS",
+]
+
+# ---------------------------------------------------------------------------
+# Valid transitions map
+# Key: source state, Value: set of valid destination states
+# ---------------------------------------------------------------------------
+
+VALID_TRANSITIONS: dict[EnumLifecycleState, frozenset[EnumLifecycleState]] = {
+    EnumLifecycleState.ACTIVE: frozenset(
+        {
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.DELETED,
+        }
+    ),
+    EnumLifecycleState.STALE: frozenset(
+        {
+            EnumLifecycleState.ACTIVE,  # refreshed / promoted
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.DELETED,
+        }
+    ),
+    EnumLifecycleState.EXPIRED: frozenset(
+        {
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.DELETED,
+        }
+    ),
+    EnumLifecycleState.ARCHIVED: frozenset(
+        {
+            EnumLifecycleState.ACTIVE,  # promoted / restored
+            EnumLifecycleState.DELETED,
+        }
+    ),
+    # DELETED is a terminal state - no outbound transitions.
+    EnumLifecycleState.DELETED: frozenset(),
+}
+
+
+class ModelTransitionValidationResult(
+    BaseModel
+):  # omnimemory-model-exempt: handler result
+    """Result of a lifecycle state transition validation.
+
+    Attributes:
+        valid: Whether the transition is permitted by the state machine.
+        from_state: The source lifecycle state.
+        to_state: The target lifecycle state.
+        reason: Human-readable explanation if the transition is invalid.
+            None when valid=True.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    valid: bool = Field(
+        ...,
+        description="Whether the transition is permitted by the state machine",
+    )
+    from_state: EnumLifecycleState = Field(
+        ...,
+        description="The source lifecycle state",
+    )
+    to_state: EnumLifecycleState = Field(
+        ...,
+        description="The target lifecycle state",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Human-readable explanation if the transition is invalid",
+    )
+
+
+class ValidatorLifecycleTransition:
+    """State machine validator for memory lifecycle transitions.
+
+    Enforces the full 5-state memory lifecycle:
+
+        ACTIVE -> STALE -> EXPIRED -> ARCHIVED -> DELETED
+
+    With the following additional paths:
+        STALE   -> ACTIVE   (soft refresh / promotion)
+        ARCHIVED -> ACTIVE  (restore from archive)
+        ACTIVE, STALE, EXPIRED, ARCHIVED -> DELETED (explicit deletion)
+
+    DELETED is a terminal state with no outbound transitions.
+
+    Usage::
+
+        validator = ValidatorLifecycleTransition()
+
+        result = validator.validate(
+            from_state=EnumLifecycleState.ACTIVE,
+            to_state=EnumLifecycleState.STALE,
+        )
+        assert result.valid is True
+
+        result = validator.validate(
+            from_state=EnumLifecycleState.DELETED,
+            to_state=EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is False
+        assert "terminal" in result.reason
+
+    Note:
+        This validator enforces the *structural* state machine rules.
+        Business logic (e.g. TTL calculation, promotion eligibility) is
+        handled by the respective handlers and adapters.
+    """
+
+    def validate(
+        self,
+        from_state: EnumLifecycleState,
+        to_state: EnumLifecycleState,
+    ) -> ModelTransitionValidationResult:
+        """Validate a lifecycle state transition.
+
+        Args:
+            from_state: The current lifecycle state of the memory entity.
+            to_state: The desired target lifecycle state.
+
+        Returns:
+            ModelTransitionValidationResult with:
+            - valid=True if the transition is allowed.
+            - valid=False with a human-readable reason if the transition
+              violates the state machine rules.
+        """
+        # Self-transitions are always invalid - a state transition must change state.
+        if from_state == to_state:
+            return ModelTransitionValidationResult(
+                valid=False,
+                from_state=from_state,
+                to_state=to_state,
+                reason=(
+                    f"Self-transition not permitted: state is already "
+                    f"'{from_state.value}'. A transition must move to a "
+                    "different state."
+                ),
+            )
+
+        allowed = VALID_TRANSITIONS[from_state]
+
+        if to_state in allowed:
+            return ModelTransitionValidationResult(
+                valid=True,
+                from_state=from_state,
+                to_state=to_state,
+            )
+
+        # Build a descriptive reason for the invalid transition.
+        if from_state == EnumLifecycleState.DELETED:
+            reason = (
+                f"Cannot transition from '{from_state.value}': DELETED is a "
+                "terminal state. No further transitions are permitted."
+            )
+        elif not allowed:
+            reason = f"No transitions are permitted from '{from_state.value}' state."
+        else:
+            allowed_values = sorted(s.value for s in allowed)
+            reason = (
+                f"Transition '{from_state.value}' -> '{to_state.value}' is not "
+                f"permitted by the lifecycle state machine. "
+                f"Valid transitions from '{from_state.value}': "
+                f"{allowed_values}."
+            )
+
+        return ModelTransitionValidationResult(
+            valid=False,
+            from_state=from_state,
+            to_state=to_state,
+            reason=reason,
+        )
+
+    def is_valid(
+        self,
+        from_state: EnumLifecycleState,
+        to_state: EnumLifecycleState,
+    ) -> bool:
+        """Return True if the transition is valid, False otherwise.
+
+        Convenience wrapper around validate() for boolean checks.
+
+        Args:
+            from_state: The current lifecycle state of the memory entity.
+            to_state: The desired target lifecycle state.
+
+        Returns:
+            True if the transition is allowed by the state machine.
+        """
+        return self.validate(from_state, to_state).valid
+
+    def get_valid_transitions(
+        self,
+        from_state: EnumLifecycleState,
+    ) -> frozenset[EnumLifecycleState]:
+        """Return all valid destination states from a given source state.
+
+        Args:
+            from_state: The current lifecycle state.
+
+        Returns:
+            Frozenset of valid destination states. Empty if from_state
+            is terminal (DELETED).
+        """
+        return VALID_TRANSITIONS[from_state]

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/validators/validator_lifecycle_transition.py
@@ -205,8 +205,6 @@ class ValidatorLifecycleTransition:
                 f"Cannot transition from '{from_state.value}': DELETED is a "
                 "terminal state. No further transitions are permitted."
             )
-        elif not allowed:
-            reason = f"No transitions are permitted from '{from_state.value}' state."
         else:
             allowed_values = sorted(s.value for s in allowed)
             reason = (

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -22,7 +22,8 @@ Usage:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import pytest
@@ -32,6 +33,10 @@ from omnimemory.nodes.memory_lifecycle_orchestrator.adapters import (
     AdapterPostgresDeactivateMemory,
     ModelDeactivateAdapterHealth,
     ModelDeactivateAdapterMetadata,
+)
+from omnimemory.nodes.memory_lifecycle_orchestrator.handlers.handler_memory_expire import (
+    ModelExpireMemoryCommand,
+    ModelMemoryExpireResult,
 )
 
 # ---------------------------------------------------------------------------
@@ -139,6 +144,372 @@ class TestNotInitializedGuard:
 
 
 # ---------------------------------------------------------------------------
+# Command Delegation Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCommandDelegation:
+    """Verify that deactivate() and deactivate_with_retry() delegate correctly.
+
+    These tests bypass the real HandlerMemoryExpire by replacing the adapter's
+    internal _handler with an AsyncMock after initialization, so no database
+    connection is needed. This isolates the adapter's delegation logic from
+    the handler's database logic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_deactivate_constructs_command_with_correct_memory_id(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() builds a ModelExpireMemoryCommand with the given memory_id."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(memory_id=memory_id, expected_revision=1)
+
+        mock_handler.handle.assert_awaited_once()
+        command: ModelExpireMemoryCommand = mock_handler.handle.call_args[0][0]
+        assert command.memory_id == memory_id
+
+    @pytest.mark.asyncio
+    async def test_deactivate_constructs_command_with_correct_expected_revision(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() builds a ModelExpireMemoryCommand with the given expected_revision."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=6,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(memory_id=memory_id, expected_revision=5)
+
+        command: ModelExpireMemoryCommand = mock_handler.handle.call_args[0][0]
+        assert command.expected_revision == 5
+
+    @pytest.mark.asyncio
+    async def test_deactivate_constructs_command_with_default_reason(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() uses 'ttl_expired' as the default reason in the command."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(memory_id=memory_id, expected_revision=1)
+
+        command: ModelExpireMemoryCommand = mock_handler.handle.call_args[0][0]
+        assert command.reason == "ttl_expired"
+
+    @pytest.mark.asyncio
+    async def test_deactivate_constructs_command_with_custom_reason(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() passes a custom reason through to the command."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(
+            memory_id=memory_id,
+            expected_revision=1,
+            reason="manual_admin_expire",
+        )
+
+        command: ModelExpireMemoryCommand = mock_handler.handle.call_args[0][0]
+        assert command.reason == "manual_admin_expire"
+
+    @pytest.mark.asyncio
+    async def test_deactivate_constructs_command_with_explicit_expired_at(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() passes an explicit expired_at timestamp through to the command."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        fixed_ts = datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(
+            memory_id=memory_id,
+            expected_revision=1,
+            expired_at=fixed_ts,
+        )
+
+        command: ModelExpireMemoryCommand = mock_handler.handle.call_args[0][0]
+        assert command.expired_at == fixed_ts
+
+    @pytest.mark.asyncio
+    async def test_deactivate_passes_command_to_handler_handle(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() calls handler.handle() with a ModelExpireMemoryCommand."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate(memory_id=memory_id, expected_revision=1)
+
+        mock_handler.handle.assert_awaited_once()
+        command: object = mock_handler.handle.call_args[0][0]
+        assert isinstance(command, ModelExpireMemoryCommand)
+
+    @pytest.mark.asyncio
+    async def test_deactivate_returns_handler_result(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() returns exactly the result produced by handler.handle()."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=7,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        result = await adapter.deactivate(memory_id=memory_id, expected_revision=6)
+
+        assert result is expected_result
+
+    @pytest.mark.asyncio
+    async def test_deactivate_returns_conflict_result_from_handler(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() passes through a conflict result from handler unchanged."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        conflict_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=True,
+            error_message="Revision conflict: expected 3, found 4",
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle = AsyncMock(return_value=conflict_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        result = await adapter.deactivate(memory_id=memory_id, expected_revision=3)
+
+        assert result is conflict_result
+        assert result.success is False
+        assert result.conflict is True
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_delegates_to_handler_handle_with_retry(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() calls handler.handle_with_retry() with correct args."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=3,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle_with_retry = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate_with_retry(memory_id=memory_id, initial_revision=2)
+
+        mock_handler.handle_with_retry.assert_awaited_once_with(
+            memory_id=memory_id,
+            initial_revision=2,
+            reason="ttl_expired",
+            expired_at=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_returns_handler_result(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() returns exactly the result from handler.handle_with_retry()."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=5,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle_with_retry = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        result = await adapter.deactivate_with_retry(
+            memory_id=memory_id, initial_revision=4
+        )
+
+        assert result is expected_result
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_passes_custom_reason(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() forwards a custom reason to handler.handle_with_retry()."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle_with_retry = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate_with_retry(
+            memory_id=memory_id,
+            initial_revision=1,
+            reason="scheduled_cleanup",
+        )
+
+        mock_handler.handle_with_retry.assert_awaited_once_with(
+            memory_id=memory_id,
+            initial_revision=1,
+            reason="scheduled_cleanup",
+            expired_at=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_passes_explicit_expired_at(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() forwards an explicit expired_at to handler.handle_with_retry()."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        fixed_ts = datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+        expected_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=True,
+            new_revision=2,
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle_with_retry = AsyncMock(return_value=expected_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        await adapter.deactivate_with_retry(
+            memory_id=memory_id,
+            initial_revision=1,
+            expired_at=fixed_ts,
+        )
+
+        mock_handler.handle_with_retry.assert_awaited_once_with(
+            memory_id=memory_id,
+            initial_revision=1,
+            reason="ttl_expired",
+            expired_at=fixed_ts,
+        )
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_returns_conflict_on_max_retries_exceeded(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() passes through a max-retries-exceeded conflict result."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+
+        exhausted_result = ModelMemoryExpireResult(
+            memory_id=memory_id,
+            success=False,
+            conflict=True,
+            error_message="Max retries (3) exceeded due to contention",
+        )
+        mock_handler = MagicMock()
+        mock_handler.handle_with_retry = AsyncMock(return_value=exhausted_result)
+        adapter._handler = mock_handler  # type: ignore[assignment]
+
+        result = await adapter.deactivate_with_retry(
+            memory_id=memory_id, initial_revision=1
+        )
+
+        assert result is exhausted_result
+        assert result.success is False
+        assert result.conflict is True
+
+
+# ---------------------------------------------------------------------------
 # Health Check Tests (without db_pool - tests model structure)
 # ---------------------------------------------------------------------------
 
@@ -233,8 +604,12 @@ class TestAdapterShutdown:
     async def test_shutdown_is_idempotent(
         self, adapter: AdapterPostgresDeactivateMemory
     ) -> None:
-        """Multiple shutdown() calls do not raise."""
+        """shutdown() after initialize() is idempotent: second call does not raise."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+        assert adapter.initialized is True
         await adapter.shutdown()
+        assert adapter.initialized is False
         await adapter.shutdown()
         assert adapter.initialized is False
 

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -22,6 +22,7 @@ Usage:
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
@@ -80,12 +81,19 @@ class TestAdapterInitialization:
             await adapter.initialize()  # type: ignore[call-arg]
 
     @pytest.mark.asyncio
+    async def test_initialized_after_initialize(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """Adapter reports initialized after initialize() is called with a db_pool."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+        assert adapter.initialized is True
+
+    @pytest.mark.asyncio
     async def test_initialize_validates_max_retries(
         self, adapter: AdapterPostgresDeactivateMemory
     ) -> None:
         """initialize() raises ValueError for max_retries < 1."""
-        from unittest.mock import MagicMock
-
         fake_pool = MagicMock()
         with pytest.raises(ValueError, match="max_retries"):
             await adapter.initialize(db_pool=fake_pool, max_retries=0)

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -22,7 +22,6 @@ Usage:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -49,12 +48,6 @@ def container() -> ModelONEXContainer:
 def memory_id() -> UUID:
     """Provide a fixed memory ID for testing."""
     return UUID("12345678-abcd-1234-abcd-567812345678")
-
-
-@pytest.fixture
-def fixed_now() -> datetime:
-    """Provide a fixed timestamp for deterministic testing."""
-    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.fixture

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -536,6 +536,17 @@ class TestAdapterHealthCheck:
         health = await adapter.health_check()
         assert health.handler_health.db_pool_available is False
 
+    @pytest.mark.asyncio
+    async def test_health_after_initialization(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """health_check() reflects initialized state after initialize() is called."""
+        fake_pool = MagicMock()
+        await adapter.initialize(db_pool=fake_pool)
+        health = await adapter.health_check()
+        assert health.initialized is True
+        assert health.handler_health.initialized is True
+
 
 # ---------------------------------------------------------------------------
 # Describe Tests

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -85,6 +85,9 @@ class TestAdapterInitialization:
         self, adapter: AdapterPostgresDeactivateMemory
     ) -> None:
         """Adapter reports initialized after initialize() is called with a db_pool."""
+        # MagicMock() is a valid substitute here because HandlerMemoryExpire.initialize()
+        # only stores the pool reference (self._db_pool = db_pool) without type-checking
+        # it. No pool methods are called during initialization, so any object works.
         fake_pool = MagicMock()
         await adapter.initialize(db_pool=fake_pool)
         assert adapter.initialized is True

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for AdapterPostgresDeactivateMemory.
+
+Tests the memory deactivation adapter that wraps HandlerMemoryExpire.
+
+Test Categories:
+    - Initialization: Adapter setup, initialization state
+    - Not Initialized: RuntimeError on deactivate() before initialize()
+    - Command Delegation: deactivate() passes correct command to handler
+    - Health Check: health_check() aggregates handler health
+    - Describe: describe() returns correct adapter metadata
+    - Shutdown: shutdown() is idempotent and resets state
+    - Model Validation: ModelDeactivateAdapterHealth structure
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_postgres_deactivate_memory.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+from omnibase_core.container import ModelONEXContainer
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.adapters import (
+    AdapterPostgresDeactivateMemory,
+    ModelDeactivateAdapterHealth,
+    ModelDeactivateAdapterMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def container() -> ModelONEXContainer:
+    """Provide an ONEX container for adapter initialization."""
+    return ModelONEXContainer()
+
+
+@pytest.fixture
+def memory_id() -> UUID:
+    """Provide a fixed memory ID for testing."""
+    return UUID("12345678-abcd-1234-abcd-567812345678")
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """Provide a fixed timestamp for deterministic testing."""
+    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def adapter(container: ModelONEXContainer) -> AdapterPostgresDeactivateMemory:
+    """Provide an uninitialized adapter for testing."""
+    return AdapterPostgresDeactivateMemory(container)
+
+
+# ---------------------------------------------------------------------------
+# Initialization Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterInitialization:
+    """Verify adapter initialization behavior."""
+
+    def test_not_initialized_before_initialize(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """Adapter reports not initialized before initialize() is called."""
+        assert adapter.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_initialized_requires_db_pool(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """initialize() requires a db_pool argument (raises without it)."""
+        with pytest.raises(TypeError):
+            await adapter.initialize()  # type: ignore[call-arg]
+
+    @pytest.mark.asyncio
+    async def test_initialize_validates_max_retries(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """initialize() raises ValueError for max_retries < 1."""
+        from unittest.mock import MagicMock
+
+        fake_pool = MagicMock()
+        with pytest.raises(ValueError, match="max_retries"):
+            await adapter.initialize(db_pool=fake_pool, max_retries=0)
+
+
+# ---------------------------------------------------------------------------
+# Not Initialized Guard Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNotInitializedGuard:
+    """Verify that deactivate() raises RuntimeError before initialize()."""
+
+    @pytest.mark.asyncio
+    async def test_deactivate_raises_if_not_initialized(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate() raises RuntimeError if not initialized."""
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await adapter.deactivate(
+                memory_id=memory_id,
+                expected_revision=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_deactivate_with_retry_raises_if_not_initialized(
+        self,
+        adapter: AdapterPostgresDeactivateMemory,
+        memory_id: UUID,
+    ) -> None:
+        """deactivate_with_retry() raises RuntimeError if not initialized."""
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await adapter.deactivate_with_retry(
+                memory_id=memory_id,
+                initial_revision=1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Health Check Tests (without db_pool - tests model structure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterHealthCheck:
+    """Verify health_check() returns correct structure."""
+
+    @pytest.mark.asyncio
+    async def test_health_before_initialization(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """health_check() reflects uninitialized state."""
+        health = await adapter.health_check()
+        assert isinstance(health, ModelDeactivateAdapterHealth)
+        assert health.initialized is False
+        assert health.handler_health.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_health_reports_no_db_pool_before_init(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """health_check() reports db pool not available before init."""
+        health = await adapter.health_check()
+        assert health.handler_health.db_pool_available is False
+
+
+# ---------------------------------------------------------------------------
+# Describe Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterDescribe:
+    """Verify describe() returns correct adapter metadata."""
+
+    @pytest.mark.asyncio
+    async def test_describe_returns_correct_name(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """describe() returns the correct adapter class name."""
+        metadata = await adapter.describe()
+        assert isinstance(metadata, ModelDeactivateAdapterMetadata)
+        assert metadata.name == "AdapterPostgresDeactivateMemory"
+
+    @pytest.mark.asyncio
+    async def test_describe_includes_handler_metadata(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """describe() includes metadata from the underlying handler."""
+        metadata = await adapter.describe()
+        assert metadata.handler_metadata.name == "HandlerMemoryExpire"
+
+    @pytest.mark.asyncio
+    async def test_describe_reflects_initialization_state(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """describe() reflects not-initialized state."""
+        metadata = await adapter.describe()
+        assert metadata.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_describe_contains_deactivation_in_description(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """describe() contains 'deactivation' in the description string."""
+        metadata = await adapter.describe()
+        assert (
+            "deactivation" in metadata.description.lower()
+            or "deactivate" in metadata.description.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shutdown Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterShutdown:
+    """Verify shutdown() is idempotent and resets state."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_before_initialize_is_safe(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """shutdown() on uninitialized adapter is a no-op."""
+        await adapter.shutdown()  # Should not raise
+        assert adapter.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """Multiple shutdown() calls do not raise."""
+        await adapter.shutdown()
+        await adapter.shutdown()
+        assert adapter.initialized is False
+
+
+# ---------------------------------------------------------------------------
+# Model Structure Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelDeactivateAdapterHealth:
+    """Verify ModelDeactivateAdapterHealth structure and immutability."""
+
+    @pytest.mark.asyncio
+    async def test_health_model_is_frozen(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """ModelDeactivateAdapterHealth is immutable."""
+        from pydantic import ValidationError
+
+        health = await adapter.health_check()
+        with pytest.raises((ValidationError, TypeError)):
+            health.initialized = True  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_health_model_has_expected_fields(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """ModelDeactivateAdapterHealth has initialized and handler_health fields."""
+        health = await adapter.health_check()
+        assert hasattr(health, "initialized")
+        assert hasattr(health, "handler_health")
+        # handler_health has its own sub-fields
+        assert hasattr(health.handler_health, "initialized")
+        assert hasattr(health.handler_health, "db_pool_available")
+        assert hasattr(health.handler_health, "max_retries")
+        assert hasattr(health.handler_health, "circuit_breaker_state")
+
+
+@pytest.mark.unit
+class TestModelDeactivateAdapterMetadata:
+    """Verify ModelDeactivateAdapterMetadata structure."""
+
+    @pytest.mark.asyncio
+    async def test_metadata_is_frozen(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """ModelDeactivateAdapterMetadata is immutable."""
+        from pydantic import ValidationError
+
+        metadata = await adapter.describe()
+        with pytest.raises((ValidationError, TypeError)):
+            metadata.name = "Changed"  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_handler_metadata_has_valid_from_states(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """Handler metadata includes valid_from_states for the expire handler."""
+        metadata = await adapter.describe()
+        assert hasattr(metadata.handler_metadata, "valid_from_states")
+        assert "active" in metadata.handler_metadata.valid_from_states
+
+    @pytest.mark.asyncio
+    async def test_handler_metadata_target_state_is_expired(
+        self, adapter: AdapterPostgresDeactivateMemory
+    ) -> None:
+        """Handler metadata target_state is 'expired'."""
+        metadata = await adapter.describe()
+        assert metadata.handler_metadata.target_state == "expired"

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_runtime_tick_memory.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_runtime_tick_memory.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for AdapterRuntimeTickMemory.
+
+Tests the tick-based lifecycle detection adapter that wraps HandlerMemoryTick.
+
+Test Categories:
+    - Initialization: Adapter setup, initialization state
+    - Not Initialized: RuntimeError on process_tick before initialize()
+    - Delegation: process_tick() delegates to the underlying handler
+    - Health Check: health_check() aggregates handler health
+    - Describe: describe() returns correct adapter metadata
+    - Shutdown: shutdown() is idempotent and resets state
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_adapter_runtime_tick_memory.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from omnibase_core.container import ModelONEXContainer
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.runtime.models.model_runtime_tick import ModelRuntimeTick
+
+from omnimemory.nodes.memory_lifecycle_orchestrator.adapters import (
+    AdapterRuntimeTickMemory,
+    ModelRuntimeTickAdapterHealth,
+    ModelRuntimeTickAdapterMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def container() -> ModelONEXContainer:
+    """Provide an ONEX container for adapter initialization."""
+    return ModelONEXContainer()
+
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """Provide a fixed timestamp for deterministic testing."""
+    return datetime(2026, 1, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def tick_id() -> UUID:
+    """Provide a fixed tick ID for testing."""
+    return UUID("12345678-1234-5678-1234-567812345678")
+
+
+@pytest.fixture
+def correlation_id() -> UUID:
+    """Provide a fixed correlation ID for testing."""
+    return UUID("87654321-4321-8765-4321-876543218765")
+
+
+@pytest.fixture
+def scheduler_id() -> str:
+    """Provide a scheduler ID for testing."""
+    return "test-scheduler-001"
+
+
+@pytest.fixture
+def runtime_tick(
+    fixed_now: datetime,
+    tick_id: UUID,
+    correlation_id: UUID,
+    scheduler_id: str,
+) -> ModelRuntimeTick:
+    """Provide a runtime tick for testing."""
+    return ModelRuntimeTick(
+        now=fixed_now,
+        tick_id=tick_id,
+        sequence_number=1,
+        scheduled_at=fixed_now,
+        correlation_id=correlation_id,
+        scheduler_id=scheduler_id,
+        tick_interval_ms=1000,
+    )
+
+
+@pytest.fixture
+def tick_envelope(
+    runtime_tick: ModelRuntimeTick,
+    correlation_id: UUID,
+) -> ModelEventEnvelope[ModelRuntimeTick]:
+    """Provide a tick event envelope for testing."""
+    return ModelEventEnvelope(
+        payload=runtime_tick,
+        correlation_id=correlation_id,
+        envelope_id=uuid4(),
+    )
+
+
+@pytest.fixture
+def adapter(container: ModelONEXContainer) -> AdapterRuntimeTickMemory:
+    """Provide an uninitialized adapter for testing."""
+    return AdapterRuntimeTickMemory(container)
+
+
+# ---------------------------------------------------------------------------
+# Initialization Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterInitialization:
+    """Verify adapter initialization behavior."""
+
+    def test_not_initialized_before_initialize(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """Adapter reports not initialized before initialize() is called."""
+        assert adapter.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_initialized_after_initialize(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """Adapter reports initialized after initialize() is called."""
+        await adapter.initialize()
+        assert adapter.initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_batch_size(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """Adapter initializes successfully with custom batch size."""
+        await adapter.initialize(batch_size=50)
+        assert adapter.initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_without_projection_reader(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """Adapter initializes without a projection reader (no-op mode)."""
+        await adapter.initialize(projection_reader=None)
+        assert adapter.initialized is True
+
+
+# ---------------------------------------------------------------------------
+# Not Initialized Guard Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNotInitializedGuard:
+    """Verify that process_tick() raises RuntimeError before initialize()."""
+
+    @pytest.mark.asyncio
+    async def test_process_tick_raises_if_not_initialized(
+        self,
+        adapter: AdapterRuntimeTickMemory,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """process_tick() raises RuntimeError if not initialized."""
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await adapter.process_tick(tick_envelope)
+
+
+# ---------------------------------------------------------------------------
+# Delegation Tests (no projection reader = empty results)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTickDelegation:
+    """Verify that process_tick() delegates to the underlying handler."""
+
+    @pytest.mark.asyncio
+    async def test_process_tick_returns_empty_events_without_reader(
+        self,
+        adapter: AdapterRuntimeTickMemory,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """process_tick() returns empty events when no projection reader."""
+        await adapter.initialize(projection_reader=None)
+        output = await adapter.process_tick(tick_envelope)
+        # Without a projection reader, no lifecycle events are emitted
+        assert output.events == ()
+
+    @pytest.mark.asyncio
+    async def test_process_tick_records_metrics(
+        self,
+        adapter: AdapterRuntimeTickMemory,
+        tick_envelope: ModelEventEnvelope[ModelRuntimeTick],
+    ) -> None:
+        """process_tick() returns output with metrics keys."""
+        await adapter.initialize(projection_reader=None)
+        output = await adapter.process_tick(tick_envelope)
+        assert "expired_count" in output.metrics
+        assert "archive_initiated_count" in output.metrics
+        assert output.metrics["expired_count"] == 0.0
+        assert output.metrics["archive_initiated_count"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Health Check Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterHealthCheck:
+    """Verify health_check() aggregates handler health correctly."""
+
+    @pytest.mark.asyncio
+    async def test_health_before_initialization(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """health_check() reflects uninitialized state."""
+        health = await adapter.health_check()
+        assert isinstance(health, ModelRuntimeTickAdapterHealth)
+        assert health.initialized is False
+        assert health.handler_health.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_health_after_initialization(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """health_check() reflects initialized state."""
+        await adapter.initialize()
+        health = await adapter.health_check()
+        assert health.initialized is True
+        assert health.handler_health.initialized is True
+
+    @pytest.mark.asyncio
+    async def test_health_reports_no_projection_reader(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """health_check() reports no projection reader when none configured."""
+        await adapter.initialize(projection_reader=None)
+        health = await adapter.health_check()
+        assert health.handler_health.projection_reader_available is False
+
+
+# ---------------------------------------------------------------------------
+# Describe Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterDescribe:
+    """Verify describe() returns correct adapter metadata."""
+
+    @pytest.mark.asyncio
+    async def test_describe_returns_correct_name(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """describe() returns the correct adapter class name."""
+        await adapter.initialize()
+        metadata = await adapter.describe()
+        assert isinstance(metadata, ModelRuntimeTickAdapterMetadata)
+        assert metadata.name == "AdapterRuntimeTickMemory"
+
+    @pytest.mark.asyncio
+    async def test_describe_includes_handler_metadata(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """describe() includes metadata from the underlying handler."""
+        await adapter.initialize()
+        metadata = await adapter.describe()
+        assert metadata.handler_metadata.name == "HandlerMemoryTick"
+
+    @pytest.mark.asyncio
+    async def test_describe_reflects_initialization_state(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """describe() reflects initialization state."""
+        # Before initialization
+        metadata = await adapter.describe()
+        assert metadata.initialized is False
+
+        # After initialization
+        await adapter.initialize()
+        metadata = await adapter.describe()
+        assert metadata.initialized is True
+
+
+# ---------------------------------------------------------------------------
+# Shutdown Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdapterShutdown:
+    """Verify shutdown() is idempotent and resets state."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_resets_initialized(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """shutdown() resets initialized to False."""
+        await adapter.initialize()
+        assert adapter.initialized is True
+        await adapter.shutdown()
+        assert adapter.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """shutdown() can be called multiple times without error."""
+        await adapter.initialize()
+        await adapter.shutdown()
+        await adapter.shutdown()  # Should not raise
+        assert adapter.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_before_initialize_is_safe(
+        self, adapter: AdapterRuntimeTickMemory
+    ) -> None:
+        """shutdown() on uninitialized adapter is a no-op."""
+        await adapter.shutdown()  # Should not raise
+        assert adapter.initialized is False

--- a/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_validator_lifecycle_transition.py
+++ b/tests/unit/nodes/test_memory_lifecycle_orchestrator/test_validator_lifecycle_transition.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for ValidatorLifecycleTransition.
+
+Tests the state machine validator that enforces the 5-state memory
+lifecycle transition rules.
+
+Test Categories:
+    - Valid transitions: All allowed state machine paths
+    - Invalid transitions: All forbidden transitions
+    - Self-transitions: Same-state transitions always invalid
+    - Terminal state (DELETED): No outbound transitions
+    - Convenience methods: is_valid(), get_valid_transitions()
+    - Result model: ModelTransitionValidationResult structure
+
+Related Tickets:
+    - OMN-1603: Add adapter implementations for memory lifecycle orchestrator
+
+Usage:
+    pytest tests/unit/nodes/test_memory_lifecycle_orchestrator/test_validator_lifecycle_transition.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnimemory.enums import EnumLifecycleState
+from omnimemory.nodes.memory_lifecycle_orchestrator.validators import (
+    VALID_TRANSITIONS,
+    ModelTransitionValidationResult,
+    ValidatorLifecycleTransition,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def validator() -> ValidatorLifecycleTransition:
+    """Provide a ValidatorLifecycleTransition instance for testing."""
+    return ValidatorLifecycleTransition()
+
+
+# ---------------------------------------------------------------------------
+# Valid Transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidTransitions:
+    """Verify that all valid lifecycle transitions are accepted."""
+
+    def test_active_to_stale(self, validator: ValidatorLifecycleTransition) -> None:
+        """ACTIVE -> STALE is the first step in the lifecycle."""
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.STALE,
+        )
+        assert result.valid is True
+        assert result.reason is None
+        assert result.from_state == EnumLifecycleState.ACTIVE
+        assert result.to_state == EnumLifecycleState.STALE
+
+    def test_active_to_expired(self, validator: ValidatorLifecycleTransition) -> None:
+        """ACTIVE -> EXPIRED is allowed for direct hard-TTL expiration."""
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.EXPIRED,
+        )
+        assert result.valid is True
+
+    def test_active_to_deleted(self, validator: ValidatorLifecycleTransition) -> None:
+        """ACTIVE -> DELETED is allowed for explicit deletion."""
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.DELETED,
+        )
+        assert result.valid is True
+
+    def test_stale_to_expired(self, validator: ValidatorLifecycleTransition) -> None:
+        """STALE -> EXPIRED is the normal progression after soft-TTL."""
+        result = validator.validate(
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.EXPIRED,
+        )
+        assert result.valid is True
+
+    def test_stale_to_active(self, validator: ValidatorLifecycleTransition) -> None:
+        """STALE -> ACTIVE is allowed when a memory is refreshed."""
+        result = validator.validate(
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is True
+
+    def test_stale_to_deleted(self, validator: ValidatorLifecycleTransition) -> None:
+        """STALE -> DELETED is allowed for explicit deletion."""
+        result = validator.validate(
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.DELETED,
+        )
+        assert result.valid is True
+
+    def test_expired_to_archived(self, validator: ValidatorLifecycleTransition) -> None:
+        """EXPIRED -> ARCHIVED is the cold storage path."""
+        result = validator.validate(
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.ARCHIVED,
+        )
+        assert result.valid is True
+
+    def test_expired_to_deleted(self, validator: ValidatorLifecycleTransition) -> None:
+        """EXPIRED -> DELETED is allowed for explicit deletion."""
+        result = validator.validate(
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.DELETED,
+        )
+        assert result.valid is True
+
+    def test_archived_to_active(self, validator: ValidatorLifecycleTransition) -> None:
+        """ARCHIVED -> ACTIVE is the promote/restore path."""
+        result = validator.validate(
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is True
+
+    def test_archived_to_deleted(self, validator: ValidatorLifecycleTransition) -> None:
+        """ARCHIVED -> DELETED is allowed for explicit deletion."""
+        result = validator.validate(
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.DELETED,
+        )
+        assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid Transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInvalidTransitions:
+    """Verify that all forbidden lifecycle transitions are rejected."""
+
+    def test_deleted_to_active_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """DELETED is terminal - cannot transition to ACTIVE."""
+        result = validator.validate(
+            EnumLifecycleState.DELETED,
+            EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is False
+        assert result.reason is not None
+        assert "terminal" in result.reason.lower()
+
+    def test_deleted_to_stale_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """DELETED is terminal - cannot transition to STALE."""
+        result = validator.validate(
+            EnumLifecycleState.DELETED,
+            EnumLifecycleState.STALE,
+        )
+        assert result.valid is False
+
+    def test_deleted_to_expired_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """DELETED is terminal - cannot transition to EXPIRED."""
+        result = validator.validate(
+            EnumLifecycleState.DELETED,
+            EnumLifecycleState.EXPIRED,
+        )
+        assert result.valid is False
+
+    def test_deleted_to_archived_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """DELETED is terminal - cannot transition to ARCHIVED."""
+        result = validator.validate(
+            EnumLifecycleState.DELETED,
+            EnumLifecycleState.ARCHIVED,
+        )
+        assert result.valid is False
+
+    def test_archived_to_expired_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """ARCHIVED -> EXPIRED is invalid; must restore to ACTIVE first."""
+        result = validator.validate(
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.EXPIRED,
+        )
+        assert result.valid is False
+        assert result.reason is not None
+
+    def test_archived_to_stale_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """ARCHIVED -> STALE is invalid; must restore to ACTIVE first."""
+        result = validator.validate(
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.STALE,
+        )
+        assert result.valid is False
+
+    def test_expired_to_active_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """EXPIRED -> ACTIVE is invalid; must go through ARCHIVED."""
+        result = validator.validate(
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is False
+
+    def test_expired_to_stale_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """EXPIRED -> STALE is an invalid regression."""
+        result = validator.validate(
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.STALE,
+        )
+        assert result.valid is False
+
+    def test_active_to_archived_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """ACTIVE -> ARCHIVED is invalid; must expire first."""
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.ARCHIVED,
+        )
+        assert result.valid is False
+
+    def test_stale_to_archived_is_invalid(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """STALE -> ARCHIVED is invalid; must expire first."""
+        result = validator.validate(
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.ARCHIVED,
+        )
+        assert result.valid is False
+
+
+# ---------------------------------------------------------------------------
+# Self-Transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSelfTransitions:
+    """Self-transitions (same state -> same state) are always invalid."""
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.ARCHIVED,
+            EnumLifecycleState.DELETED,
+        ],
+    )
+    def test_self_transition_is_invalid(
+        self,
+        validator: ValidatorLifecycleTransition,
+        state: EnumLifecycleState,
+    ) -> None:
+        """Self-transition from any state to itself is always invalid."""
+        result = validator.validate(state, state)
+        assert result.valid is False
+        assert result.reason is not None
+        assert "self" in result.reason.lower() or "already" in result.reason.lower()
+        assert result.from_state == state
+        assert result.to_state == state
+
+
+# ---------------------------------------------------------------------------
+# Convenience Method: is_valid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsValidConvenienceMethod:
+    """is_valid() returns a boolean equivalent of validate().valid."""
+
+    def test_is_valid_returns_true_for_valid_transition(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """is_valid() returns True for a valid transition."""
+        assert (
+            validator.is_valid(EnumLifecycleState.ACTIVE, EnumLifecycleState.STALE)
+            is True
+        )
+
+    def test_is_valid_returns_false_for_invalid_transition(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """is_valid() returns False for an invalid transition."""
+        assert (
+            validator.is_valid(EnumLifecycleState.DELETED, EnumLifecycleState.ACTIVE)
+            is False
+        )
+
+    def test_is_valid_returns_false_for_self_transition(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """is_valid() returns False for a self-transition."""
+        assert (
+            validator.is_valid(EnumLifecycleState.ACTIVE, EnumLifecycleState.ACTIVE)
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience Method: get_valid_transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetValidTransitions:
+    """get_valid_transitions() returns the allowed destination states."""
+
+    def test_active_has_three_valid_destinations(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """ACTIVE state has three valid destinations: STALE, EXPIRED, DELETED."""
+        valid = validator.get_valid_transitions(EnumLifecycleState.ACTIVE)
+        assert EnumLifecycleState.STALE in valid
+        assert EnumLifecycleState.EXPIRED in valid
+        assert EnumLifecycleState.DELETED in valid
+        assert EnumLifecycleState.ARCHIVED not in valid
+        assert EnumLifecycleState.ACTIVE not in valid
+
+    def test_stale_has_three_valid_destinations(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """STALE state has three valid destinations: ACTIVE, EXPIRED, DELETED."""
+        valid = validator.get_valid_transitions(EnumLifecycleState.STALE)
+        assert EnumLifecycleState.ACTIVE in valid
+        assert EnumLifecycleState.EXPIRED in valid
+        assert EnumLifecycleState.DELETED in valid
+
+    def test_expired_has_two_valid_destinations(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """EXPIRED state has two valid destinations: ARCHIVED, DELETED."""
+        valid = validator.get_valid_transitions(EnumLifecycleState.EXPIRED)
+        assert EnumLifecycleState.ARCHIVED in valid
+        assert EnumLifecycleState.DELETED in valid
+        assert len(valid) == 2
+
+    def test_archived_has_two_valid_destinations(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """ARCHIVED state has two valid destinations: ACTIVE, DELETED."""
+        valid = validator.get_valid_transitions(EnumLifecycleState.ARCHIVED)
+        assert EnumLifecycleState.ACTIVE in valid
+        assert EnumLifecycleState.DELETED in valid
+        assert len(valid) == 2
+
+    def test_deleted_has_no_valid_destinations(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """DELETED state is terminal - no valid destinations."""
+        valid = validator.get_valid_transitions(EnumLifecycleState.DELETED)
+        assert len(valid) == 0
+
+    def test_returns_frozenset(self, validator: ValidatorLifecycleTransition) -> None:
+        """get_valid_transitions() returns a frozenset (immutable)."""
+        result = validator.get_valid_transitions(EnumLifecycleState.ACTIVE)
+        assert isinstance(result, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Result Model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelTransitionValidationResult:
+    """Verify ModelTransitionValidationResult structure and immutability."""
+
+    def test_valid_result_has_no_reason(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """A valid transition result has reason=None."""
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.STALE,
+        )
+        assert isinstance(result, ModelTransitionValidationResult)
+        assert result.valid is True
+        assert result.reason is None
+
+    def test_invalid_result_has_reason(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """An invalid transition result has a non-empty reason string."""
+        result = validator.validate(
+            EnumLifecycleState.EXPIRED,
+            EnumLifecycleState.ACTIVE,
+        )
+        assert result.valid is False
+        assert result.reason is not None
+        assert len(result.reason) > 0
+
+    def test_result_is_frozen(self, validator: ValidatorLifecycleTransition) -> None:
+        """ModelTransitionValidationResult is immutable (frozen=True)."""
+        from pydantic import ValidationError
+
+        result = validator.validate(
+            EnumLifecycleState.ACTIVE,
+            EnumLifecycleState.STALE,
+        )
+        with pytest.raises((ValidationError, TypeError)):
+            result.valid = False  # type: ignore[misc]
+
+    def test_result_from_and_to_state_fields(
+        self, validator: ValidatorLifecycleTransition
+    ) -> None:
+        """Result correctly records from_state and to_state."""
+        result = validator.validate(
+            EnumLifecycleState.STALE,
+            EnumLifecycleState.EXPIRED,
+        )
+        assert result.from_state == EnumLifecycleState.STALE
+        assert result.to_state == EnumLifecycleState.EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# VALID_TRANSITIONS module constant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidTransitionsConstant:
+    """Verify the module-level VALID_TRANSITIONS constant is complete."""
+
+    def test_all_states_present_as_keys(self) -> None:
+        """VALID_TRANSITIONS has an entry for every lifecycle state."""
+        for state in EnumLifecycleState:
+            assert (
+                state in VALID_TRANSITIONS
+            ), f"State {state!r} missing from VALID_TRANSITIONS"
+
+    def test_deleted_has_empty_transitions(self) -> None:
+        """DELETED maps to an empty frozenset."""
+        assert VALID_TRANSITIONS[EnumLifecycleState.DELETED] == frozenset()
+
+    def test_all_values_are_frozensets(self) -> None:
+        """All values in VALID_TRANSITIONS are frozensets."""
+        for state, destinations in VALID_TRANSITIONS.items():
+            assert isinstance(
+                destinations, frozenset
+            ), f"Expected frozenset for {state!r}, got {type(destinations).__name__}"


### PR DESCRIPTION
## Summary

- Adds `AdapterRuntimeTickMemory` — wraps `HandlerMemoryTick` with clean `process_tick()`, `health_check()`, `describe()` interface; container-driven `initialize()` / `shutdown()` lifecycle
- Adds `AdapterPostgresDeactivateMemory` — wraps `HandlerMemoryExpire` with `deactivate()` and `deactivate_with_retry()` operations; container-driven initialization
- Adds `ValidatorLifecycleTransition` — enforces the full 5-state lifecycle state machine (`ACTIVE → STALE → EXPIRED → ARCHIVED → DELETED`, plus `PROMOTED` return-to-ACTIVE path)
- Updates `adapters/__init__.py` and `validators/__init__.py` exports

## State Machine Enforced

```
ACTIVE  → STALE, EXPIRED, DELETED
STALE   → ACTIVE, EXPIRED, DELETED
EXPIRED → ARCHIVED, DELETED
ARCHIVED → ACTIVE (promote/restore), DELETED
DELETED → (terminal)
```

## Test Plan

- [ ] 41 unit tests for `ValidatorLifecycleTransition` (all transition pairs, terminal state, invalid transition rejection)
- [ ] 16 unit tests for `AdapterRuntimeTickMemory`
- [ ] 18 unit tests for `AdapterPostgresDeactivateMemory`
- [ ] 217/217 total unit tests pass
- [ ] mypy strict: 0 issues
- [ ] ruff: clean

## References

- Closes OMN-1603
- Background: OMN-1392 (original orchestrator handlers), PR #21 (reference implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL-backed memory deactivation to expire memories reliably.
  * Introduced runtime tick processing to detect and act on memory lifecycle events.
  * Implemented a state-machine validator for memory lifecycle transitions with supported recovery paths.

* **Tests**
  * Added comprehensive unit tests covering initialization, lifecycle operations, health/metadata, and validator behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->