### PR TITLE
build(omnimemory): migrate to PEP 621 + hatchling [OMN-2670]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,91 @@
+[project]
+name = "omnimemory"
+version = "0.3.0"
+description = "Advanced memory management and retrieval system for AI applications"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    # Core MCP integration for Archon connectivity
+    "mcp>=1.8.0,<2",
+    # HTTP client for MCP calls and API communication
+    "httpx>=0.28.0,<1",
+    # Data validation and serialization
+    "pydantic>=2.10.0,<3",
+    # FastAPI web framework for production API
+    "fastapi>=0.120.1,<1",
+    "uvicorn[standard]>=0.32.0,<1",
+    # Memory and storage components
+    # Database support for memory storage - using Supabase client
+    "supabase>=2.9.0,<3",
+    "asyncpg>=0.29.0,<1",
+    "psycopg2-binary>=2.9.10,<3",
+    # SQLAlchemy for memory database
+    "sqlalchemy>=2.0.0,<3",
+    "alembic>=1.13.0,<2",
+    # Redis support for caching and ephemeral memory
+    "redis>=6.4.0,<7",
+    # Vector database support
+    # Pinecone for vector memory storage
+    "pinecone-client>=4.1.0,<5",
+    # qdrant-client is a transitive dep; ceiling at <1.17.0 because 1.17.0 applies
+    # PEP 604 union syntax to protobuf EnumTypeWrapper objects, causing TypeError at
+    # import time under Python 3.12. Remove ceiling once fixed upstream.
+    "qdrant-client>=1.7.0,<1.17.0",
+    # Environment variable management
+    "python-dotenv>=1.0.1,<2",
+    # Async support
+    "asyncio-mqtt>=0.16.0,<1",
+    # JSON and YAML processing
+    "pyyaml>=6.0.2,<7",
+    # ONEX dependencies - versioned releases from PyPI
+    "omnibase-core>=0.18.0,<0.19.0",
+    "omnibase-spi>=0.10.0,<0.11.0",
+    "omnibase-infra>=0.8.0,<0.9.0",
+    # Logging and monitoring
+    # Version >=23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
+    "structlog>=23.3.0,<24",
+    # Runtime configuration and utilities
+    "pydantic-settings>=2.10.1,<3",
+    "psutil>=7.0.0,<8",
+    "aiohttp>=3.12.15,<4",
+    "cachetools>=6.2.4,<7",
+]
+
+[project.optional-dependencies]
+dev = [
+    # Testing framework
+    "pytest>=8.3.4,<9",
+    "pytest-asyncio>=0.25.0,<1",
+    "pytest-cov>=6.0.0,<7",
+    "pytest-timeout>=2.3.1,<3",
+    "pytest-split>=0.10.0,<1",
+    "pytest-xdist>=3.5.0,<4",
+    # Code formatting and linting
+    "ruff>=0.8.0,<1",
+    # Type checking
+    "mypy>=1.14.0,<2",
+    "pyright>=1.1.390,<2",
+    "types-cachetools>=6.2.0,<7",
+    # Pre-commit hooks
+    "pre-commit>=4.0.1,<5",
+    # Security
+    "detect-secrets>=1.5.0,<2",
+    # Development utilities
+    "memory-profiler>=0.61.0,<1",
+    "docker>=7.1.0,<8",
+    "types-pyyaml>=6.0.12,<7",
+]
+
+[project.entry-points."onex.domain_plugins"]
+memory = "omnimemory.runtime.plugin:PluginMemory"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/omnimemory"]
+
 [tool.poetry]
 name = "omnimemory"
 version = "0.3.0"
@@ -99,13 +187,6 @@ detect-secrets = "^1.5.0"
 memory-profiler = "^0.61.0"
 docker = "^7.1.0"
 types-pyyaml = "^6.0.12.20250915"
-
-[tool.poetry.plugins."onex.domain_plugins"]
-memory = "omnimemory.runtime.plugin:PluginMemory"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
## Summary

- Add PEP 621 `[project]` section with `name`, `version`, `requires-python`, and full `dependencies` list
- Add `[project.optional-dependencies.dev]` mirroring the existing poetry dev group so `uv sync --extra dev` works
- Migrate `[build-system]` from `poetry-core` to `hatchling` with `[tool.hatch.build.targets.wheel]` pointing to `src/omnimemory`
- Preserve `onex.domain_plugins` entry point under `[project.entry-points]`
- Keep `[tool.poetry]` sections in place for backward compatibility with poetry-based dev workflows

## Verification

- `hatch build` produces `dist/omnimemory-0.3.0.tar.gz` and `dist/omnimemory-0.3.0-py3-none-any.whl` with no warnings
- All 964 unit tests pass (`uv run pytest -m unit`)

## Notes

Per OMN-2670: do **not** merge until T6 (reusable release workflow, OMN-2668) is wired up. This PR is ready for review in the meantime.

## Test plan

- [ ] `hatch build` succeeds and produces `.tar.gz` + `.whl` in `dist/`
- [ ] `uv sync --extra dev && uv run pytest -m unit` passes
- [ ] `[project]` table has `name`, `version`, `requires-python`, `dependencies`
- [ ] `[build-system]` uses `hatchling`
- [ ] `onex.domain_plugins` entry point preserved