### PR TITLE
fix(omnimemory): emit document-indexed.v1 to fix CONTRACT_DRIFT [OMN-2717]

### DIFF
--- a/src/omnimemory/models/crawl/__init__.py
+++ b/src/omnimemory/models/crawl/__init__.py
@@ -12,6 +12,9 @@ from omnimemory.models.crawl.model_document_changed_event import (
 from omnimemory.models.crawl.model_document_discovered_event import (
     ModelDocumentDiscoveredEvent,
 )
+from omnimemory.models.crawl.model_document_indexed_event import (
+    ModelDocumentIndexedEvent,
+)
 from omnimemory.models.crawl.model_document_removed_event import (
     ModelDocumentRemovedEvent,
 )
@@ -22,6 +25,7 @@ __all__ = [
     "ModelCrawlTickCommand",
     "ModelDocumentChangedEvent",
     "ModelDocumentDiscoveredEvent",
+    "ModelDocumentIndexedEvent",
     "ModelDocumentRemovedEvent",
     "TriggerSource",
 ]

--- a/src/omnimemory/models/crawl/model_document_indexed_event.py
+++ b/src/omnimemory/models/crawl/model_document_indexed_event.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OmniNode Team
+"""Document indexed event model for document ingestion pipeline.
+
+Emitted after a document has been fully crawled and indexed (either
+discovered for the first time or updated after content change).
+
+Consumed by omniintelligence ``node_crawl_scheduler_effect`` to reset
+the per-document debounce window, confirming crawl completion.
+
+Related:
+    - OMN-2717: CONTRACT_DRIFT gap fix — add document-indexed.v1 producer
+"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+from omnimemory.models.crawl.types import TriggerSource
+
+
+class ModelDocumentIndexedEvent(BaseModel):
+    """Emitted after a document is fully crawled and written to the index.
+
+    Published to: {env}.onex.evt.omnimemory.document-indexed.v1
+
+    Consumed by ``node_crawl_scheduler_effect`` in omniintelligence to
+    reset the per-``(source_ref, crawler_type)`` debounce window after a
+    successful crawl completion.
+
+    Emitted for both newly-discovered and content-changed documents.
+    Not emitted for mtime-only touches (no content change) or removals.
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentIndexed"] = Field(
+        default="DocumentIndexed",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating crawl tick command",
+    )
+    emitted_at_utc: datetime = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    # Crawler metadata
+    crawler_type: EnumCrawlerType = Field(
+        ...,
+        description="Crawler that indexed this document",
+    )
+    crawl_scope: str = Field(
+        ...,
+        min_length=1,
+        description="Scope string from the originating crawl tick (e.g. 'omninode/omnimemory')",
+    )
+    trigger_source: TriggerSource = Field(
+        ...,
+        description="What triggered the crawl: scheduled, manual, git_hook, or filesystem_watch",
+    )
+
+    # Document identity
+    source_ref: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path, URL, or Linear ID that uniquely identifies this document. "
+            "Used by omniintelligence crawl_scheduler_effect to clear the debounce window."
+        ),
+    )
+    source_type: EnumContextSourceType = Field(
+        ...,
+        description="Authoritative source classification",
+    )
+
+    # Content fingerprint
+    content_fingerprint: str = Field(
+        ...,
+        pattern=r"^[0-9a-f]{64}$",
+        description="SHA-256 hex digest of the indexed document content",
+    )
+
+    # Scope
+    scope_ref: str = Field(
+        ...,
+        min_length=1,
+        description="Resolved scope assignment for this document (e.g. 'omninode/omnimemory')",
+    )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/nodes/filesystem_crawler_effect/contract.yaml
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/contract.yaml
@@ -18,8 +18,9 @@ description: |
     1. mtime fast-path: if stat.st_mtime is unchanged, skip without re-hashing.
     2. If mtime changed: compute SHA-256(content). If hash also unchanged,
        update last_crawled_at_utc only.
-    3. Not in state table: emit document.discovered.v1.
-    4. State table entries not found in walk: emit document.removed.v1.
+    3. Not in state table: emit document.discovered.v1 + document.indexed.v1.
+    4. Content changed: emit document.changed.v1 + document.indexed.v1.
+    5. State table entries not found in walk: emit document.removed.v1.
 
   Consumer group (when wired to crawl-tick topic):
   {env}.omnimemory.filesystem_crawler_effect.consume.v1
@@ -49,6 +50,15 @@ published_events:
     description: "Emitted for files present in crawl state but absent from the current walk. Triggers
       immediate BLACKLISTED transition on ContextItems."
 
+  - topic_suffix: "onex.evt.omnimemory.document-indexed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-indexed.v1"
+    event_type: "DocumentIndexed"
+    trigger: "Document successfully crawled and indexed (discovered or changed)"
+    description: "Emitted after a document is fully crawled and written to the index — once per document-discovered.v1
+      and once per document-changed.v1. Consumed by omniintelligence node_crawl_scheduler_effect to reset
+      the per-(source_ref, crawler_type) debounce window. Not emitted for mtime-only touches (no content
+      change) or removal events."
+
 # === EVENT TYPE CONFIGURATION ===
 event_type:
   version: {major: 1, minor: 0, patch: 0}
@@ -56,6 +66,7 @@ event_type:
     - "document_discovered"
     - "document_changed"
     - "document_removed"
+    - "document_indexed"
   event_categories: ["crawl", "document", "filesystem", "effect"]
   publish_events: true
   subscribe_events: true
@@ -81,6 +92,7 @@ event_bus:
     - "onex.evt.omnimemory.document-discovered.v1"
     - "onex.evt.omnimemory.document-changed.v1"
     - "onex.evt.omnimemory.document-removed.v1"
+    - "onex.evt.omnimemory.document-indexed.v1"
 
   # Metadata for subscribed topics
   subscribe_topic_metadata:
@@ -105,6 +117,12 @@ event_bus:
       schema_ref: "omnimemory.models.crawl.model_document_removed_event.ModelDocumentRemovedEvent"
       description: "Document removed event. Published for state table entries whose source_ref is absent
         from the current filesystem walk."
+
+    "onex.evt.omnimemory.document-indexed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_indexed_event.ModelDocumentIndexedEvent"
+      description: "Document indexed event. Published after a document is fully crawled and indexed. Emitted
+        once per document-discovered and once per document-changed event. Consumed by omniintelligence
+        node_crawl_scheduler_effect to reset the debounce window."
 
 # === HANDLER CONFIGURATION ===
 handler_config:

--- a/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -79,6 +79,9 @@ from omnimemory.models.crawl.model_document_changed_event import (
 from omnimemory.models.crawl.model_document_discovered_event import (
     ModelDocumentDiscoveredEvent,
 )
+from omnimemory.models.crawl.model_document_indexed_event import (
+    ModelDocumentIndexedEvent,
+)
 from omnimemory.models.crawl.model_document_removed_event import (
     ModelDocumentRemovedEvent,
 )
@@ -388,6 +391,7 @@ class HandlerFilesystemCrawler:
         unchanged_count = 0
         skipped_count = 0
         mtime_skipped_count = 0
+        indexed_count = 0
         error_count = 0
         truncated = False
 
@@ -608,6 +612,25 @@ class HandlerFilesystemCrawler:
                     )
                     discovered_count += 1
 
+                    indexed_event = ModelDocumentIndexedEvent(
+                        correlation_id=correlation_id,
+                        emitted_at_utc=now_utc,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        crawl_scope=crawl_scope,
+                        trigger_source=trigger_source,
+                        source_ref=abs_path_str,
+                        source_type=source_type,
+                        content_fingerprint=fingerprint,
+                        scope_ref=scope_ref,
+                    )
+                    await _publish_event(
+                        publish_callback,
+                        f"{env_prefix}.{self._config.publish_topic_indexed}",
+                        indexed_event.model_dump(mode="json"),
+                        correlation_id,
+                    )
+                    indexed_count += 1
+
                     new_state = ModelCrawlStateRecord(
                         source_ref=abs_path_str,
                         crawler_type=EnumCrawlerType.FILESYSTEM,
@@ -664,6 +687,25 @@ class HandlerFilesystemCrawler:
                     )
                     changed_count += 1
 
+                    indexed_event = ModelDocumentIndexedEvent(
+                        correlation_id=correlation_id,
+                        emitted_at_utc=now_utc,
+                        crawler_type=EnumCrawlerType.FILESYSTEM,
+                        crawl_scope=crawl_scope,
+                        trigger_source=trigger_source,
+                        source_ref=abs_path_str,
+                        source_type=source_type,
+                        content_fingerprint=fingerprint,
+                        scope_ref=scope_ref,
+                    )
+                    await _publish_event(
+                        publish_callback,
+                        f"{env_prefix}.{self._config.publish_topic_indexed}",
+                        indexed_event.model_dump(mode="json"),
+                        correlation_id,
+                    )
+                    indexed_count += 1
+
                     updated_state = ModelCrawlStateRecord(
                         source_ref=abs_path_str,
                         crawler_type=EnumCrawlerType.FILESYSTEM,
@@ -713,6 +755,7 @@ class HandlerFilesystemCrawler:
             unchanged_count=unchanged_count,
             skipped_count=skipped_count,
             mtime_skipped_count=mtime_skipped_count,
+            indexed_count=indexed_count,
             removed_count=removed_count,
             error_count=error_count,
             truncated=truncated,
@@ -728,6 +771,7 @@ class HandlerFilesystemCrawler:
                 "changed": changed_count,
                 "unchanged": unchanged_count,
                 "skipped": skipped_count,
+                "indexed": indexed_count,
                 "removed": removed_count,
                 "errors": error_count,
                 "truncated": truncated,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawl_result.py
@@ -58,6 +58,15 @@ class ModelFilesystemCrawlResult(  # omnimemory-model-exempt: handler result
             "These two categories are not distinguished in this field."
         ),
     )
+    indexed_count: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of document-indexed events emitted. Equals discovered_count + "
+            "changed_count (one indexed event per successfully indexed document). "
+            "Consumed by omniintelligence crawl_scheduler_effect to reset debounce windows."
+        ),
+    )
     removed_count: int = Field(
         ...,
         ge=0,

--- a/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -59,6 +59,14 @@ class ModelFilesystemCrawlerConfig(  # omnimemory-model-exempt: handler config
         default="onex.evt.omnimemory.document-removed.v1",
         description="Topic suffix for document-removed events",
     )
+    publish_topic_indexed: str = Field(
+        default="onex.evt.omnimemory.document-indexed.v1",
+        description=(
+            "Topic suffix for document-indexed events. Emitted after a document "
+            "is fully crawled and indexed (discovered or changed). Consumed by "
+            "omniintelligence crawl_scheduler_effect to reset the debounce window."
+        ),
+    )
 
     # Operational limits
     max_file_size_bytes: int = Field(

--- a/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
+++ b/tests/nodes/filesystem_crawler_effect/test_handler_filesystem_crawler.py
@@ -104,12 +104,10 @@ def make_mock_repo() -> MagicMock:
     return repo
 
 
-def make_publish_capture() -> (
-    tuple[
-        Callable[[str, dict[str, object]], Coroutine[object, object, None]],
-        list[PublishRecord],
-    ]
-):
+def make_publish_capture() -> tuple[
+    Callable[[str, dict[str, object]], Coroutine[object, object, None]],
+    list[PublishRecord],
+]:
     published: list[PublishRecord] = []
 
     async def capture(topic: str, payload: dict[str, object]) -> None:
@@ -514,7 +512,13 @@ class TestHandlerFilesystemCrawlerDiscovered:
 
         assert result.files_walked == 5
         assert result.discovered_count == 5
-        assert len(published) == 5
+        assert result.indexed_count == 5
+        # 5 document-discovered + 5 document-indexed = 10 events
+        assert len(published) == 10
+        discovered_topics = [t for t, _ in published if "document-discovered" in t]
+        indexed_topics = [t for t, _ in published if "document-indexed" in t]
+        assert len(discovered_topics) == 5
+        assert len(indexed_topics) == 5
 
 
 class TestHandlerFilesystemCrawlerMtimeFastPath:
@@ -878,10 +882,11 @@ class TestHandlerFilesystemCrawlerPublishErrors:
             publish_callback=failing_publish,
         )
 
-        # All 3 files were walked and attempted to publish
+        # All 3 files were walked and attempted to publish.
+        # Each file emits document-discovered + document-indexed = 2 publish calls.
         assert result.files_walked == 3
         assert result.discovered_count == 3
-        assert call_count == 3
+        assert call_count == 6
 
 
 class TestHandlerFilesystemCrawlerDocTypeAssignment:
@@ -1086,3 +1091,241 @@ class TestHandlerFilesystemCrawlerRecursive:
 
         assert result.files_walked == 1
         assert result.discovered_count == 1
+
+
+# =============================================================================
+# DocumentIndexed event tests (OMN-2717 -- CONTRACT_DRIFT fix)
+# =============================================================================
+
+
+class TestHandlerFilesystemCrawlerIndexedEvent:
+    """document-indexed.v1 is emitted after discovered and changed events.
+
+    Tests cover:
+    - Indexed event emitted after document-discovered for new files
+    - Indexed event emitted after document-changed for updated files
+    - No indexed event emitted for mtime-only touches (content unchanged)
+    - No indexed event emitted for document-removed events
+    - indexed_count in result reflects total indexed documents
+    - Indexed event carries correct source_ref, content_fingerprint, scope_ref
+    - Indexed event topic uses correct suffix (onex.evt.omnimemory.document-indexed.v1)
+    """
+
+    @pytest.mark.unit
+    async def test_new_file_emits_indexed_event(self, tmp_path: Path) -> None:
+        """New file emits both document-discovered and document-indexed."""
+        md_file = tmp_path / "new.md"
+        content = b"# New Document"
+        md_file.write_bytes(content)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.indexed_count == 1
+
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 1
+        topic, payload = indexed_events[0]
+        assert topic == "dev.onex.evt.omnimemory.document-indexed.v1"
+        assert payload["event_type"] == "DocumentIndexed"
+        assert payload["source_ref"] == str(md_file.resolve())
+        assert payload["content_fingerprint"] == _sha256(content)
+
+    @pytest.mark.unit
+    async def test_changed_file_emits_indexed_event(self, tmp_path: Path) -> None:
+        """Updated file emits both document-changed and document-indexed."""
+        md_file = tmp_path / "evolving.md"
+        old_content = b"old content"
+        new_content = b"new content"
+        md_file.write_bytes(new_content)
+
+        old_fp = _sha256(old_content)
+        old_mtime = md_file.stat().st_mtime - 10
+
+        prior = make_state(str(md_file.resolve()), old_fp, mtime=old_mtime)
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.changed_count == 1
+        assert result.indexed_count == 1
+
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 1
+        topic, payload = indexed_events[0]
+        assert topic == "dev.onex.evt.omnimemory.document-indexed.v1"
+        assert payload["event_type"] == "DocumentIndexed"
+        assert payload["content_fingerprint"] == _sha256(new_content)
+
+    @pytest.mark.unit
+    async def test_mtime_only_touch_no_indexed_event(self, tmp_path: Path) -> None:
+        """mtime-only touch (content unchanged) must NOT emit indexed event."""
+        md_file = tmp_path / "touched.md"
+        content = b"same content"
+        md_file.write_bytes(content)
+        fp = _sha256(content)
+        old_mtime = md_file.stat().st_mtime - 5
+        prior = make_state(str(md_file.resolve()), fp, mtime=old_mtime)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        repo.get_state = AsyncMock(return_value=prior)
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.unchanged_count == 1
+        assert result.indexed_count == 0
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 0
+
+    @pytest.mark.unit
+    async def test_removed_file_no_indexed_event(self, tmp_path: Path) -> None:
+        """Removed files must NOT emit indexed event."""
+        ghost_path = str(tmp_path / "deleted.md")
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        ghost_state = make_state(ghost_path, _sha256(b"old"))
+        repo.get_state = AsyncMock(return_value=None)
+        repo.list_states_for_scope = AsyncMock(return_value=[ghost_state])
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.removed_count == 1
+        assert result.indexed_count == 0
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 0
+
+    @pytest.mark.unit
+    async def test_indexed_event_scope_ref_matches_discovered(
+        self, tmp_path: Path
+    ) -> None:
+        """Indexed event carries the same scope_ref as the discovered event."""
+        (tmp_path / "doc.md").write_bytes(b"# Doc")
+        scope_mappings = [(str(tmp_path), "omninode/custom-scope")]
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/custom-scope",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+            scope_mappings=scope_mappings,
+        )
+
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 1
+        _, payload = indexed_events[0]
+        assert payload["scope_ref"] == "omninode/custom-scope"
+
+    @pytest.mark.unit
+    async def test_indexed_event_correlation_id_threaded(self, tmp_path: Path) -> None:
+        """Indexed event carries the same correlation_id as the crawl."""
+        (tmp_path / "a.md").write_bytes(b"content")
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        cid = uuid4()
+        await handler.crawl(
+            correlation_id=cid,
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 1
+        _, payload = indexed_events[0]
+        assert str(payload["correlation_id"]) == str(cid)
+
+    @pytest.mark.unit
+    async def test_indexed_count_equals_discovered_plus_changed(
+        self, tmp_path: Path
+    ) -> None:
+        """indexed_count == discovered_count + changed_count."""
+        # 2 new files (discovered)
+        (tmp_path / "new1.md").write_bytes(b"# New 1")
+        (tmp_path / "new2.md").write_bytes(b"# New 2")
+        # 1 changed file
+        changed_file = tmp_path / "changed.md"
+        changed_file.write_bytes(b"new content")
+        old_fp = _sha256(b"old content")
+        old_mtime = changed_file.stat().st_mtime - 5
+        prior = make_state(str(changed_file.resolve()), old_fp, mtime=old_mtime)
+
+        config = make_config(path_prefixes=[str(tmp_path)])
+        repo = make_mock_repo()
+
+        changed_source_ref = str(changed_file.resolve())
+
+        async def _get_state(
+            source_ref: str,
+            crawler_type: object,
+            scope_ref: str,
+        ) -> object:
+            if source_ref == changed_source_ref:
+                return prior
+            return None
+
+        repo.get_state = AsyncMock(side_effect=_get_state)
+        publish, published = make_publish_capture()
+        handler = HandlerFilesystemCrawler(config=config, crawl_state_repo=repo)
+
+        result = await handler.crawl(
+            correlation_id=uuid4(),
+            crawl_scope="omninode/test",
+            trigger_source="scheduled",
+            env_prefix="dev",
+            publish_callback=publish,
+        )
+
+        assert result.discovered_count == 2
+        assert result.changed_count == 1
+        assert result.indexed_count == 3  # 2 discovered + 1 changed
+
+        indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
+        assert len(indexed_events) == 3


### PR DESCRIPTION
## Summary

Fixes [OMN-2717](https://linear.app/omninode/issue/OMN-2717) — CONTRACT_DRIFT gap where `omniintelligence` `node_crawl_scheduler_effect` subscribes to `onex.evt.omnimemory.document-indexed.v1` but no producer existed in any repo.

**Root cause**: `omnimemory` produced `document-discovered.v1`, `document-changed.v1`, and `document-removed.v1` but not `document-indexed.v1`. This silently broke the crawl debounce reset — the crawl scheduler never resets per-document state after indexing completes.

**Fix**: Emit `document-indexed.v1` from `filesystem_crawler_effect` after each document is successfully indexed (discovered or content-changed). Not emitted for mtime-only touches or removal events.

## Changes

- **New model**: `ModelDocumentIndexedEvent` — frozen, immutable event with `source_ref`, `content_fingerprint`, `scope_ref`, `correlation_id`, `crawler_type`
- **Contract**: `filesystem_crawler_effect/contract.yaml` — adds `onex.evt.omnimemory.document-indexed.v1` to `published_events` and `event_bus.publish_topics`
- **Config**: `ModelFilesystemCrawlerConfig` — adds `publish_topic_indexed` field with correct default
- **Handler**: `HandlerFilesystemCrawler.crawl()` — emits indexed event after each `document-discovered` and `document-changed` event
- **Result**: `ModelFilesystemCrawlResult` — adds `indexed_count` field for observability
- **Tests**: 7 new unit tests in `TestHandlerFilesystemCrawlerIndexedEvent`

## Definition of Done

- [x] Both repos agree on the exact topic name: `onex.evt.omnimemory.document-indexed.v1`
- [x] `filesystem_crawler_effect/contract.yaml` publish_topics updated
- [x] `ModelFilesystemCrawlerConfig` has `publish_topic_indexed` field
- [x] `HandlerFilesystemCrawler` emits indexed event after discovered and changed
- [x] `ModelDocumentIndexedEvent` model created with correct fields for crawl scheduler debounce reset
- [x] 7 new tests covering all emission cases
- [x] 971 unit tests passing

## Test Plan

- [x] `pytest tests/nodes/filesystem_crawler_effect/` — 63 tests pass
- [x] `pytest -m unit` — 971 tests pass
- [x] Pre-commit hooks pass on changed files
- [ ] CI passes

## Note on Pre-existing Issues

18 pre-existing mypy errors (yaml stubs, unused type: ignore comments in unrelated files) were observed and deferred — not caused by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document crawling now emits indexing lifecycle events when documents are discovered or changed
  * Added indexed event tracking to support document lifecycle coordination

* **Tests**
  * Extended test coverage for document indexing event emission and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->