### PR TITLE
chore(pkg): rename distribution to omninode-memory

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      # SKIP hooks that require the full project installed (poetry + omnimemory).
+      # SKIP hooks that require the full project installed (uv + omnimemory).
       # These hooks have dedicated CI jobs in .github/workflows/test.yml:
       #   - contract-linter  -> contract-validation job
       #   - io-audit         -> io-audit job

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POETRY_VERSION: "2.2.1"
   PYTHON_VERSION: "3.12"
   CACHE_VERSION: "0.1.0"
 
@@ -48,8 +47,6 @@ jobs:
   # SHARED CONFIGURATION FILES (synchronized with .pre-commit-config.yaml):
   # - pyproject.toml: ruff [tool.ruff] (^0.8.0), mypy [tool.mypy] (^1.14.0), pyright (^1.1.390)
   # - pyrightconfig.json: pyright settings (typeCheckingMode: basic, python 3.12)
-  # VERSION SYNC: Poetry uses caret versions (allows updates), pre-commit pins exact versions
-  # (ruff v0.8.6, mypy v1.14.1, pyright v1.1.391) - both are within compatible ranges
   # NOTE: UP007 (PEP 604 union syntax) is ENABLED and organizationally mandated
   #
   # CI-TO-HOOK SYNCHRONIZATION MAP:
@@ -74,8 +71,6 @@ jobs:
   # io-audit        | io-audit                          | python -m omnimemory.audit
   #
   # IMPORTANT: When modifying any CI step, update the corresponding hook in .pre-commit-config.yaml
-  #
-  # POETRY VERSION: Must match POETRY_VERSION env var (currently 2.2.1)
   # =============================================================================
 
   # Phase 1 - Migration Freeze Enforcement
@@ -107,54 +102,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          # Restore-keys use prefix matching for better fallback:
-          # - First tries exact OS + Python + lock hash
-          # - Falls back to OS + Python (different lock hash)
-          # - Falls back to OS only (different Python version)
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       # SYNC: Pre-commit hook 'ruff-format' at pre-commit stage
       # Both pre-commit and CI use --check for consistent validation
       - name: Check ruff formatting
-        run: poetry run ruff format --check src/ tests/
+        run: uv run ruff format --check src/ tests/
 
       # SYNC: Pre-commit hook 'ruff-check' at pre-commit stage
       # Both pre-commit and CI use check-only mode (no --fix)
       - name: Check ruff linting (includes import sorting)
-        run: poetry run ruff check src/ tests/
+        run: uv run ruff check src/ tests/
 
       # SYNC: Pre-commit hook 'mypy-type-check' at pre-push stage
       # Both pre-commit and CI use same flags for consistent output
       - name: Run mypy type checking (strict)
-        run: poetry run mypy --show-error-codes --no-error-summary src/omnimemory
+        run: uv run mypy --show-error-codes --no-error-summary src/omnimemory
 
   # Phase 1 - Pyright Type Checking
   pyright:
@@ -166,44 +133,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          # Restore-keys use prefix matching for better fallback:
-          # - First tries exact OS + Python + lock hash
-          # - Falls back to OS + Python (different lock hash)
-          # - Falls back to OS only (different Python version)
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       # SYNC: Pre-commit hook 'pyright-type-check' at pre-push stage
       # Uses pyrightconfig.json for project-level settings
       - name: Run pyright type checking
-        run: poetry run pyright src/omnimemory
+        run: uv run pyright src/omnimemory
 
   # Phase 1 - ONEX Validation
   onex-validation:
@@ -215,74 +154,46 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          # Restore-keys use prefix matching for better fallback:
-          # - First tries exact OS + Python + lock hash
-          # - Falls back to OS + Python (different lock hash)
-          # - Falls back to OS only (different Python version)
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       # SYNC: Pre-commit hook 'validate-pydantic-patterns' at pre-commit stage
       - name: Validate Pydantic patterns
-        run: poetry run python scripts/validation/validate_pydantic_patterns.py src/
+        run: uv run python scripts/validation/validate_pydantic_patterns.py src/
 
       # SYNC: Pre-commit hook 'validate-single-class-per-file' at pre-commit stage
       - name: Validate single class per file
-        run: poetry run python scripts/validation/validate_single_class_per_file.py src/omnimemory/models/
+        run: uv run python scripts/validation/validate_single_class_per_file.py src/omnimemory/models/
 
       # SYNC: Pre-commit hook 'validate-enum-casing' at pre-commit stage
       - name: Validate enum casing
-        run: poetry run python scripts/validation/validate_enum_casing.py src/omnimemory/enums/
+        run: uv run python scripts/validation/validate_enum_casing.py src/omnimemory/enums/
 
       # SYNC: Pre-commit hook 'validate-no-backward-compatibility' at pre-commit stage
       - name: Validate no backward compatibility
-        run: poetry run python scripts/validation/validate_no_backward_compatibility.py -d src/
+        run: uv run python scripts/validation/validate_no_backward_compatibility.py -d src/
 
       # SYNC: Pre-commit hook 'validate-secrets' at pre-commit stage
       - name: Validate secrets
-        run: poetry run python scripts/validation/validate_secrets.py src/
+        run: uv run python scripts/validation/validate_secrets.py src/
 
       # SYNC: Pre-commit hook 'onex-validate-naming' at pre-commit stage
       # Both local and CI run naming validation at the same stage for consistency
       - name: Validate naming conventions
-        run: poetry run python scripts/validation/validate_naming.py src/
+        run: uv run python scripts/validation/validate_naming.py src/
 
       # SYNC: Pre-commit hook 'validate-http-imports' at pre-commit stage
       # Enforces HTTP import boundary - all HTTP calls must go through adapter layer
       - name: Validate HTTP import boundary
-        run: poetry run python scripts/validation/validate_http_imports.py src/
+        run: uv run python scripts/validation/validate_http_imports.py src/
 
       # SYNC: Pre-commit hook 'validate-kafka-imports' at pre-commit stage
       # Enforces ARCH-002 - runtime owns all Kafka plumbing, nodes use EventBus SPI
       - name: Validate Kafka import boundary (ARCH-002)
-        run: poetry run python scripts/validation/validate_kafka_imports.py src/
+        run: uv run python scripts/validation/validate_kafka_imports.py src/
 
       - name: ONEX validation summary
         if: always()
@@ -316,7 +227,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install PyYAML for transport import guard
         run: pip install pyyaml
@@ -336,35 +246,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       - name: Find and validate contract YAML files
         run: |
@@ -376,7 +262,7 @@ jobs:
           echo "Found contract files:"
           echo "$contracts"
           echo ""
-          poetry run python -m omnimemory.tools.contract_linter --verbose $contracts
+          uv run python -m omnimemory.tools.contract_linter --verbose $contracts
 
   # Phase 1 - I/O Audit
   # SYNC: Pre-commit hook 'io-audit' at pre-commit stage
@@ -390,38 +276,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       - name: Run I/O audit
-        run: poetry run python -m omnimemory.audit
+        run: uv run python -m omnimemory.audit
 
   # Phase 1 - Architecture Handshake Verification
   check-handshake:
@@ -483,43 +345,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ env.CACHE_VERSION }}
-          # Restore-keys use prefix matching for better fallback:
-          # - First tries exact OS + Python + lock hash
-          # - Falls back to OS + Python (different lock hash)
-          # - Falls back to OS only (different Python version)
-          restore-keys: |
-            venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
-            venv-${{ runner.os }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync
 
       - name: Run tests
         run: |
-          poetry run pytest tests/ \
+          uv run pytest tests/ \
             -n auto \
             --timeout=60 \
             --timeout-method=thread \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "omnimemory"
+name = "omninode-memory"
 version = "0.4.0"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Rename the PyPI distribution name from `omnimemory` to `omninode-memory` for namespace consistency across all OmniNode packages.

- **Only file changed**: `pyproject.toml` — `name` field
- **Import paths**: unchanged (`import omnimemory` still works)
- **Reason**: `omnimemory` name is squatted on public PyPI by a third party; `omninode-memory` is available and consistent with the package naming convention

## Test plan

- [ ] CI passes (no code changes, should be straightforward)
- [ ] `pyproject.toml` diff shows only the `name` field changed
- [ ] No import path changes present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project name updated from omnimemory to omninode-memory.
  * Pre-commit workflow comment clarified to reflect updated tooling.

* **Tests / CI**
  * Continuous integration and test runner configuration migrated to use the new "uv" runner; formatting, linting, type checks, and tests now execute through uv equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->