### PR TITLE
chore(ci): publish to public PyPI via PYPI_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,19 +71,11 @@ jobs:
             exit 1
           }
 
-      - name: Publish to private PyPI
+      - name: Publish to PyPI
         run: |
-          if [ -z "$UV_PUBLISH_URL" ] || [ -z "$UV_PUBLISH_TOKEN" ]; then
-            echo "ERROR: PYPI_PRIVATE_UPLOAD_URL and PYPI_PRIVATE_TOKEN secrets are required"
-            exit 1
-          fi
-          uv publish \
-            --publish-url "$UV_PUBLISH_URL" \
-            --token "$UV_PUBLISH_TOKEN" \
-            dist/*.whl dist/*.tar.gz
+          uv publish --token "$UV_PUBLISH_TOKEN" dist/*.whl dist/*.tar.gz
         env:
-          UV_PUBLISH_URL: ${{ secrets.PYPI_PRIVATE_UPLOAD_URL }}
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PRIVATE_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Generate checksums
         run: sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           uv publish --token "$UV_PUBLISH_TOKEN" dist/*.whl dist/*.tar.gz
         env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PRIVATE_TOKEN }}
 
       - name: Generate checksums
         run: sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS.txt


### PR DESCRIPTION
Remove private index URL — repos are public. Drop `PYPI_PRIVATE_UPLOAD_URL`/`PYPI_PRIVATE_TOKEN`, use `PYPI_TOKEN` with default public PyPI endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release workflow by streamlining the publishing process and consolidating authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->