### PR TITLE
feat(OMN-2733): add KreuzbergParseEffect node for document extraction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,22 @@ services:
           memory: ${VALKEY_MEMORY_RESERVATION:-128M}
     restart: unless-stopped
 
+  # Kreuzberg Document Parser (Text Extraction Service)
+  kreuzberg-parser:
+    image: ghcr.io/kreuzberg-dev/kreuzberg:core
+    container_name: omnimemory-kreuzberg-parser
+    ports:
+      - "${KREUZBERG_PORT:-8090}:8000"
+    networks:
+      - omnimemory-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
 networks:
   omnimemory-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
 
   # Kreuzberg Document Parser (Text Extraction Service)
   kreuzberg-parser:
-    image: ghcr.io/kreuzberg-dev/kreuzberg:core
+    image: ghcr.io/kreuzberg-dev/kreuzberg:core  # TODO: pin to a specific digest for production (e.g. ghcr.io/kreuzberg-dev/kreuzberg@sha256:...)
     container_name: omnimemory-kreuzberg-parser
     ports:
       - "${KREUZBERG_PORT:-8090}:8000"

--- a/scripts/validation/validate_http_imports.py
+++ b/scripts/validation/validate_http_imports.py
@@ -107,6 +107,8 @@ ALLOWED_PATHS = [
     # Legacy clients directory - allowed during migration
     # TODO: Remove this allowance after migration to adapters is complete
     "nodes/memory_retrieval_effect/clients/",
+    # Kreuzberg effect client - HTTP transport boundary for document extraction (OMN-2733)
+    "nodes/kreuzberg_parse_effect/clients/",
     # Tests can mock HTTP clients
     "tests/",
 ]

--- a/src/omnimemory/models/crawl/model_document_indexed_kreuzberg_event.py
+++ b/src/omnimemory/models/crawl/model_document_indexed_kreuzberg_event.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Document indexed kreuzberg event model for kreuzberg parsing pipeline.
+
+Emitted after a document has been successfully parsed by the kreuzberg
+service and the extracted text has been stored.
+
+Related:
+    - OMN-2733: Adopt kreuzberg as document parsing handler for omnimemory
+"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ModelDocumentIndexedKreuzbergEvent(BaseModel):
+    """Emitted after a document is successfully parsed by kreuzberg.
+
+    Published to: {env}.onex.evt.omnimemory.document-indexed.v1
+
+    Extended form of the indexed event that carries kreuzberg-specific
+    parsing metadata in addition to the standard event envelope.
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    # Standard envelope
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentIndexedKreuzberg"] = Field(
+        default="DocumentIndexedKreuzberg",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating event",
+    )
+    emitted_at_utc: datetime = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    # Kreuzberg-specific document identity
+    document_id: UUID = Field(
+        ...,
+        description=(
+            "Stable document identifier computed as first 16 bytes of "
+            "sha256(source_url + content_hash + parser_version)"
+        ),
+    )
+    source_url: str = Field(
+        ...,
+        min_length=1,
+        description="Source reference (path or URL) from the triggering event",
+    )
+    content_hash: str = Field(
+        ...,
+        pattern=r"^[0-9a-f]{64}$",
+        description="SHA-256 hex digest of the document content (from triggering event)",
+    )
+
+    # Kreuzberg parsing output
+    extracted_text_ref: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Inline extracted text if len < inline_text_max_chars, "
+            "otherwise a file:// pointer to the stored text file"
+        ),
+    )
+    mime_type: str = Field(
+        ...,
+        min_length=1,
+        description="MIME type of the parsed document",
+    )
+    parser_version: str = Field(
+        ...,
+        min_length=1,
+        description="Semver string of the kreuzberg parser version used",
+    )
+    parse_status: Literal["ok"] = Field(
+        default="ok",
+        description="Parse outcome — always 'ok' for this event type",
+    )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/models/crawl/model_document_parse_failed_event.py
+++ b/src/omnimemory/models/crawl/model_document_parse_failed_event.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Document parse failed event model for kreuzberg parsing pipeline.
+
+Emitted when kreuzberg fails to parse a document due to size limits,
+request timeouts, or server-side parse errors.
+
+Related:
+    - OMN-2733: Adopt kreuzberg as document parsing handler for omnimemory
+"""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ModelDocumentParseFailedEvent(BaseModel):
+    """Emitted when kreuzberg fails to parse a document.
+
+    Published to: {env}.onex.evt.omnimemory.document-parse-failed.v1
+
+    Covers three failure modes:
+        - too_large: document exceeds configured max_doc_bytes
+        - timeout: kreuzberg HTTP request exceeded timeout_ms
+        - parse_error: kreuzberg returned an HTTP error response
+
+    All fields are frozen; this event is immutable after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    event_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this event instance",
+    )
+    event_type: Literal["DocumentParseFailed"] = Field(
+        default="DocumentParseFailed",
+        description="Discriminator for event routing and deserialization",
+    )
+    schema_version: Literal["v1"] = Field(
+        default="v1",
+        description="Schema version for forward-compatibility",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID threaded from the originating event",
+    )
+    emitted_at_utc: datetime = Field(
+        ...,
+        description="ISO-8601 UTC timestamp when this event was emitted",
+    )
+
+    source_url: str = Field(
+        ...,
+        min_length=1,
+        description="Source reference (path or URL) from the triggering event",
+    )
+    content_hash: str = Field(
+        ...,
+        pattern=r"^[0-9a-f]{64}$",
+        description="SHA-256 hex digest of the document content (from triggering event)",
+    )
+    error_code: Literal["too_large", "timeout", "parse_error"] = Field(
+        ...,
+        description="Machine-readable failure reason",
+    )
+    error_detail: str = Field(
+        ...,
+        description="Human-readable detail about the failure",
+    )
+    parser_version: str = Field(
+        ...,
+        min_length=1,
+        description="Semver string of the kreuzberg parser version configured",
+    )
+
+    @field_validator("emitted_at_utc", mode="after")
+    @classmethod
+    def _require_timezone_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware (UTC)")
+        return v

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/__init__.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""KreuzbergParseEffect node package.
+
+Subscribes to document-discovered and document-changed events,
+calls the kreuzberg HTTP service to extract plain text, and emits
+document-indexed (kreuzberg variant) or document-parse-failed events.
+
+Related: OMN-2733
+"""

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/__init__.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Kreuzberg parse effect clients — HTTP transport boundary."""

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -94,7 +94,12 @@ async def call_kreuzberg_extract(
             detail=exc.response.text[:200],
         ) from exc
 
-    response_data: list[dict[str, object]] = response.json()
+    response_data = response.json()
+    if not isinstance(response_data, list):
+        raise KreuzbergExtractionError(
+            status_code=200,
+            detail=f"kreuzberg returned unexpected response type: {type(response_data).__name__}",
+        )
     if not response_data:
         raise KreuzbergExtractionError(
             status_code=200,

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""HTTP client for the kreuzberg document extraction REST service.
+
+This module is the designated transport boundary for kreuzberg HTTP calls.
+All httpx usage is confined here per ARCH-002.
+
+.. versionadded:: 0.5.0
+    Initial implementation for OMN-2733.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+
+__all__ = [
+    "KreuzbergExtractionError",
+    "KreuzbergTimeoutError",
+    "call_kreuzberg_extract",
+]
+
+
+class KreuzbergTimeoutError(Exception):
+    """Raised when the kreuzberg /extract request exceeds the configured timeout."""
+
+
+class KreuzbergExtractionError(Exception):
+    """Raised when kreuzberg returns a non-2xx HTTP response."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(f"HTTP {status_code}: {detail}")
+        self.status_code = status_code
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class KreuzbergExtractResult:
+    """Result from a successful kreuzberg /extract call."""
+
+    extracted_text: str
+    status: Literal["ok"] = "ok"
+
+
+async def call_kreuzberg_extract(
+    *,
+    kreuzberg_url: str,
+    file_bytes: bytes,
+    filename: str,
+    mime_type: str,
+    timeout_seconds: float,
+) -> KreuzbergExtractResult:
+    """Call kreuzberg POST /extract and return the extracted text.
+
+    Args:
+        kreuzberg_url: Base URL of the kreuzberg service
+            (e.g. ``"http://localhost:8090"``).
+        file_bytes: Raw binary content of the document to parse.
+        filename: Original filename hint for kreuzberg (e.g. ``"report.pdf"``).
+        mime_type: MIME type hint for kreuzberg.
+        timeout_seconds: Request timeout in seconds.
+
+    Returns:
+        KreuzbergExtractResult with the extracted plain text.
+
+    Raises:
+        KreuzbergTimeoutError: If the request exceeds ``timeout_seconds``.
+        KreuzbergExtractionError: If kreuzberg returns a non-2xx response.
+    """
+    extract_url = f"{kreuzberg_url.rstrip('/')}/extract"
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout_seconds)) as client:
+            response = await client.post(
+                extract_url,
+                files=[("files", (filename, file_bytes, mime_type))],
+            )
+            response.raise_for_status()
+    except httpx.TimeoutException as exc:
+        raise KreuzbergTimeoutError(
+            f"kreuzberg extract timed out after {timeout_seconds:.1f}s"
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise KreuzbergExtractionError(
+            status_code=exc.response.status_code,
+            detail=exc.response.text[:200],
+        ) from exc
+
+    response_data: list[dict[str, object]] = response.json()
+    extracted_text = str(response_data[0]["content"])
+
+    return KreuzbergExtractResult(extracted_text=extracted_text)
+
+
+def read_cached_text(text_path: Path) -> tuple[str, str] | None:
+    """Read cached text file and return (fingerprint, text) if available.
+
+    The file format is::
+
+        fingerprint:<sha256_hex>\\n
+        <extracted_text>
+
+    Returns None if the file does not exist or cannot be parsed.
+    """
+    _FINGERPRINT_PREFIX = "fingerprint:"
+
+    if not text_path.exists():
+        return None
+    try:
+        content = text_path.read_text(encoding="utf-8")
+        first_newline = content.index("\n")
+        first_line = content[:first_newline]
+        if not first_line.startswith(_FINGERPRINT_PREFIX):
+            return None
+        stored_fingerprint = first_line[len(_FINGERPRINT_PREFIX) :]
+        text = content[first_newline + 1 :]
+        return stored_fingerprint, text
+    except (OSError, ValueError):
+        return None
+
+
+def write_cached_text(text_path: Path, fingerprint: str, text: str) -> None:
+    """Write extracted text to the text store file.
+
+    Args:
+        text_path: Destination path for the cached text file.
+        fingerprint: SHA-256 hex fingerprint of the source document content.
+        text: Extracted text content to store.
+    """
+    _FINGERPRINT_PREFIX = "fingerprint:"
+    text_path.parent.mkdir(parents=True, exist_ok=True)
+    text_path.write_text(
+        f"{_FINGERPRINT_PREFIX}{fingerprint}\n{text}",
+        encoding="utf-8",
+    )

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -93,6 +93,11 @@ async def call_kreuzberg_extract(
             status_code=exc.response.status_code,
             detail=exc.response.text[:200],
         ) from exc
+    except httpx.TransportError as exc:
+        raise KreuzbergExtractionError(
+            status_code=503,
+            detail=f"kreuzberg transport error: {exc}",
+        ) from exc
 
     try:
         response_data = response.json()

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -75,7 +75,9 @@ async def call_kreuzberg_extract(
 
     Raises:
         KreuzbergTimeoutError: If the request exceeds ``timeout_seconds``.
-        KreuzbergExtractionError: If kreuzberg returns a non-2xx response.
+        KreuzbergExtractionError: If kreuzberg returns a non-2xx response,
+            a transport-level failure occurs, or a request-side error such as
+            ``httpx.TooManyRedirects`` or ``httpx.InvalidURL`` is raised.
     """
     extract_url = f"{kreuzberg_url.rstrip('/')}/extract"
 
@@ -99,6 +101,11 @@ async def call_kreuzberg_extract(
         raise KreuzbergExtractionError(
             status_code=503,
             detail=f"kreuzberg transport error: {exc}",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise KreuzbergExtractionError(
+            status_code=503,
+            detail=f"kreuzberg request error: {exc}",
         ) from exc
 
     try:

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -23,6 +23,11 @@ __all__ = [
     "call_kreuzberg_extract",
 ]
 
+# Prefix written as the first line of every cached text file.
+# Both read_cached_text and write_cached_text rely on this exact string; keeping
+# it at module level ensures they can never silently diverge.
+_FINGERPRINT_PREFIX = "fingerprint:"
+
 
 class KreuzbergTimeoutError(Exception):
     """Raised when the kreuzberg /extract request exceeds the configured timeout."""
@@ -116,8 +121,6 @@ def read_cached_text(text_path: Path) -> tuple[str, str] | None:
 
     Returns None if the file does not exist or cannot be parsed.
     """
-    _FINGERPRINT_PREFIX = "fingerprint:"
-
     if not text_path.exists():
         return None
     try:
@@ -141,7 +144,6 @@ def write_cached_text(text_path: Path, fingerprint: str, text: str) -> None:
         fingerprint: SHA-256 hex fingerprint of the source document content.
         text: Extracted text content to store.
     """
-    _FINGERPRINT_PREFIX = "fingerprint:"
     text_path.parent.mkdir(parents=True, exist_ok=True)
     text_path.write_text(
         f"{_FINGERPRINT_PREFIX}{fingerprint}\n{text}",

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -21,6 +21,8 @@ __all__ = [
     "KreuzbergExtractionError",
     "KreuzbergTimeoutError",
     "call_kreuzberg_extract",
+    "read_cached_text",
+    "write_cached_text",
 ]
 
 # Prefix written as the first line of every cached text file.
@@ -117,14 +119,19 @@ async def call_kreuzberg_extract(
             detail="kreuzberg returned empty response array",
         )
     try:
-        extracted_text = str(response_data[0]["content"])
+        content = response_data[0]["content"]
     except (KeyError, TypeError):
         raise KreuzbergExtractionError(
             status_code=200,
             detail="kreuzberg response item has unexpected format",
         )
+    if content is None:
+        raise KreuzbergExtractionError(
+            status_code=200,
+            detail="kreuzberg returned null content",
+        )
 
-    return KreuzbergExtractResult(extracted_text=extracted_text)
+    return KreuzbergExtractResult(extracted_text=str(content))
 
 
 def read_cached_text(text_path: Path) -> tuple[str, str] | None:

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -94,7 +94,13 @@ async def call_kreuzberg_extract(
             detail=exc.response.text[:200],
         ) from exc
 
-    response_data = response.json()
+    try:
+        response_data = response.json()
+    except (ValueError, httpx.DecodingError) as exc:
+        raise KreuzbergExtractionError(
+            status_code=response.status_code,
+            detail=f"kreuzberg returned non-JSON response: {exc}",
+        ) from exc
     if not isinstance(response_data, list):
         raise KreuzbergExtractionError(
             status_code=200,
@@ -107,10 +113,10 @@ async def call_kreuzberg_extract(
         )
     try:
         extracted_text = str(response_data[0]["content"])
-    except KeyError:
+    except (KeyError, TypeError):
         raise KreuzbergExtractionError(
             status_code=200,
-            detail="kreuzberg response item missing 'content' key",
+            detail="kreuzberg response item has unexpected format",
         )
 
     return KreuzbergExtractResult(extracted_text=extracted_text)

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py
@@ -90,7 +90,18 @@ async def call_kreuzberg_extract(
         ) from exc
 
     response_data: list[dict[str, object]] = response.json()
-    extracted_text = str(response_data[0]["content"])
+    if not response_data:
+        raise KreuzbergExtractionError(
+            status_code=200,
+            detail="kreuzberg returned empty response array",
+        )
+    try:
+        extracted_text = str(response_data[0]["content"])
+    except KeyError:
+        raise KreuzbergExtractionError(
+            status_code=200,
+            detail="kreuzberg response item missing 'content' key",
+        )
 
     return KreuzbergExtractResult(extracted_text=extracted_text)
 

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
@@ -37,13 +37,15 @@ published_events:
     full_topic_pattern: "{env}.onex.evt.omnimemory.document-indexed.v1"
     event_type: "DocumentIndexedKreuzberg"
     trigger: "Document successfully parsed by kreuzberg"
-    description: "Emitted after kreuzberg extracts text from a document. Carries extracted_text_ref (inline or file://) plus mime_type and parser_version."
+    description: "Emitted after kreuzberg extracts text from a document. Carries extracted_text_ref (inline
+      or file://) plus mime_type and parser_version."
 
   - topic_suffix: "onex.evt.omnimemory.document-parse-failed.v1"
     full_topic_pattern: "{env}.onex.evt.omnimemory.document-parse-failed.v1"
     event_type: "DocumentParseFailed"
     trigger: "Document too large, kreuzberg timeout, or kreuzberg HTTP error"
-    description: "Emitted when kreuzberg cannot parse a document. error_code distinguishes too_large, timeout, and parse_error."
+    description: "Emitted when kreuzberg cannot parse a document. error_code distinguishes too_large,
+      timeout, and parse_error."
 
 # =============================================================================
 # SUBSCRIBED EVENTS (Kafka) - Documentation Layer

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
@@ -115,3 +115,29 @@ event_bus:
 handler_config:
   handler_class: "HandlerKreuzbergParse"
   handler_module: "omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse"
+
+# === CONFIGURATION FIELDS (ModelKreuzbergParseConfig) ===
+config_fields:
+  KREUZBERG_URL:
+    default: "http://localhost:8090"
+    description: "Base URL of the kreuzberg Docker service"
+  KREUZBERG_TEXT_STORE_PATH:
+    required: true
+    description: "Filesystem path where extracted text files are stored"
+  KREUZBERG_DOCUMENT_ROOT:
+    default: "/"
+    description: >
+      Root directory that source_ref paths must be confined to. Defaults to filesystem root (permissive
+      — still prevents .. traversal). Set to a tighter path in production (e.g. /data/documents).
+  KREUZBERG_PARSER_VERSION:
+    required: true
+    description: "Semver string identifying the kreuzberg parser version (e.g. '1.0.0')"
+  KREUZBERG_MAX_DOC_BYTES:
+    default: 50000000
+    description: "Maximum document size in bytes before emitting too_large parse failure"
+  KREUZBERG_TIMEOUT_MS:
+    default: 30000
+    description: "HTTP request timeout in milliseconds for kreuzberg extract calls"
+  KREUZBERG_INLINE_TEXT_MAX_CHARS:
+    default: 4096
+    description: "Maximum character length for inline text storage; longer texts use file://"

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/contract.yaml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Contract: kreuzberg_parse_effect
+# Subscribes to document-discovered / document-changed events and calls kreuzberg
+# to extract text, then emits document-indexed or document-parse-failed events.
+
+name: kreuzberg_parse_effect
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+uuid: "a4e72f19-3c8b-4d56-b0a1-7f9e2d45c830"
+node_type: EFFECT
+input_model: "ModelDocumentDiscoveredEvent | ModelDocumentChangedEvent"
+output_model: "ModelKreuzbergParseResult"
+description: |
+  KreuzbergParseEffect consumes document-discovered and document-changed events,
+  calls the kreuzberg HTTP service to extract plain text from the raw document,
+  and emits document-indexed (kreuzberg variant) or document-parse-failed events.
+
+  Hard limits:
+    - Documents > 50 MB: emit parse-failed with error_code=too_large, no kreuzberg call.
+    - Requests exceeding 30 s: emit parse-failed with error_code=timeout.
+
+  Idempotency:
+    Before calling kreuzberg, check if <text_store_path>/<sha256_of_source_url>.txt
+    already exists and contains a matching content_fingerprint. If so, re-emit the
+    indexed event without re-parsing (same document_id).
+
+  Consumer group (when wired to document-discovered / document-changed topics):
+  {env}.omnimemory.kreuzberg_parse_effect.consume.v1
+
+# =============================================================================
+# PUBLISHED EVENTS (Kafka) - Documentation Layer
+# =============================================================================
+published_events:
+  - topic_suffix: "onex.evt.omnimemory.document-indexed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-indexed.v1"
+    event_type: "DocumentIndexedKreuzberg"
+    trigger: "Document successfully parsed by kreuzberg"
+    description: "Emitted after kreuzberg extracts text from a document. Carries extracted_text_ref (inline or file://) plus mime_type and parser_version."
+
+  - topic_suffix: "onex.evt.omnimemory.document-parse-failed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-parse-failed.v1"
+    event_type: "DocumentParseFailed"
+    trigger: "Document too large, kreuzberg timeout, or kreuzberg HTTP error"
+    description: "Emitted when kreuzberg cannot parse a document. error_code distinguishes too_large, timeout, and parse_error."
+
+# =============================================================================
+# SUBSCRIBED EVENTS (Kafka) - Documentation Layer
+# =============================================================================
+subscribed_events:
+  - topic_suffix: "onex.evt.omnimemory.document-discovered.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-discovered.v1"
+    event_type: "DocumentDiscovered"
+    description: "Triggers a kreuzberg parse for newly discovered documents."
+
+  - topic_suffix: "onex.evt.omnimemory.document-changed.v1"
+    full_topic_pattern: "{env}.onex.evt.omnimemory.document-changed.v1"
+    event_type: "DocumentChanged"
+    description: "Triggers a kreuzberg re-parse for documents with updated content."
+
+# === EVENT TYPE CONFIGURATION ===
+event_type:
+  version: {major: 1, minor: 0, patch: 0}
+  primary_events:
+    - "document_indexed"
+    - "document_parse_failed"
+  event_categories: ["parse", "document", "kreuzberg", "effect"]
+  publish_events: true
+  subscribe_events: true
+  event_routing: "parse"
+  invocation_mode: "subscription"
+
+# =============================================================================
+# EVENT BUS SUBCONTRACT - Runtime Routing Layer
+# =============================================================================
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  # Topics this node subscribes to
+  subscribe_topics:
+    - "onex.evt.omnimemory.document-discovered.v1"
+    - "onex.evt.omnimemory.document-changed.v1"
+
+  # Topics this node publishes to
+  publish_topics:
+    - "onex.evt.omnimemory.document-indexed.v1"
+    - "onex.evt.omnimemory.document-parse-failed.v1"
+
+  subscribe_topic_metadata:
+    "onex.evt.omnimemory.document-discovered.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_discovered_event.ModelDocumentDiscoveredEvent"
+      description: "Document discovered event from FilesystemCrawlerEffect or other crawlers."
+
+    "onex.evt.omnimemory.document-changed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_changed_event.ModelDocumentChangedEvent"
+      description: "Document changed event from FilesystemCrawlerEffect or other crawlers."
+
+  publish_topic_metadata:
+    "onex.evt.omnimemory.document-indexed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_indexed_kreuzberg_event.ModelDocumentIndexedKreuzbergEvent"
+      description: "Document indexed (kreuzberg) event. Contains extracted text reference and parser metadata."
+
+    "onex.evt.omnimemory.document-parse-failed.v1":
+      schema_ref: "omnimemory.models.crawl.model_document_parse_failed_event.ModelDocumentParseFailedEvent"
+      description: "Document parse failed event. Emitted when kreuzberg cannot extract text."
+
+# === HANDLER CONFIGURATION ===
+handler_config:
+  handler_class: "HandlerKreuzbergParse"
+  handler_module: "omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse"

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -412,8 +412,29 @@ class HandlerKreuzbergParse:
                     "error": str(exc),
                 },
             )
-            # Extraction succeeded; only caching failed — inline the text directly.
-            extracted_text_ref = extracted_text
+            # Extraction succeeded; only caching failed.
+            # Inline only if the text is small enough to fit safely in a Kafka event.
+            if len(extracted_text) < config.inline_text_max_chars:
+                extracted_text_ref = extracted_text
+            else:
+                failed_event = ModelDocumentParseFailedEvent(
+                    correlation_id=event.correlation_id,
+                    emitted_at_utc=now,
+                    source_url=source_url,
+                    content_hash=content_hash,
+                    error_code="parse_error",
+                    error_detail="cache write failed and text too large to inline",
+                    parser_version=config.parser_version,
+                )
+                await publish_callback(
+                    failed_topic, failed_event.model_dump(mode="json")
+                )
+                return ModelKreuzbergParseResult(
+                    indexed_count=0,
+                    failed_count=1,
+                    skipped_too_large_count=0,
+                    timeout_count=0,
+                )
 
         # ------------------------------------------------------------------
         # Step 8: Emit document-indexed event

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -394,14 +394,26 @@ class HandlerKreuzbergParse:
         # Step 7: Store text and compute extracted_text_ref
         # ------------------------------------------------------------------
         # Write cache for idempotency on next call (always, regardless of branch).
-        await asyncio.to_thread(
-            write_cached_text, text_path, content_hash, extracted_text
-        )
+        try:
+            await asyncio.to_thread(
+                write_cached_text, text_path, content_hash, extracted_text
+            )
 
-        if len(extracted_text) < config.inline_text_max_chars:
+            if len(extracted_text) < config.inline_text_max_chars:
+                extracted_text_ref = extracted_text
+            else:
+                extracted_text_ref = f"file://{text_path.resolve()}"
+        except OSError as exc:
+            _log.warning(
+                "Failed to write kreuzberg text cache; using inline fallback",
+                extra={
+                    "source_url": source_url,
+                    "text_path": str(text_path),
+                    "error": str(exc),
+                },
+            )
+            # Extraction succeeded; only caching failed — inline the text directly.
             extracted_text_ref = extracted_text
-        else:
-            extracted_text_ref = f"file://{text_path.resolve()}"
 
         # ------------------------------------------------------------------
         # Step 8: Emit document-indexed event

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -197,6 +197,11 @@ class HandlerKreuzbergParse:
         # Step 1: Validate source path is within document root
         # ------------------------------------------------------------------
         document_root = Path(config.document_root)
+        if str(document_root) == "/":
+            _log.warning(
+                "document_root is set to filesystem root ('/'). "
+                "Set KREUZBERG_DOCUMENT_ROOT to a tighter path in production."
+            )
         try:
             validated_path = _validate_source_path(source_url, document_root)
         except ValueError as exc:

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -269,7 +269,29 @@ class HandlerKreuzbergParse:
         # ------------------------------------------------------------------
         # Step 3: Read file bytes (deferred until after idempotency check)
         # ------------------------------------------------------------------
-        file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
+        try:
+            file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
+        except OSError as exc:
+            _log.warning(
+                "Failed to read source file",
+                extra={"source_url": source_url, "error": str(exc)},
+            )
+            failed_event = ModelDocumentParseFailedEvent(
+                correlation_id=event.correlation_id,
+                emitted_at_utc=now,
+                source_url=source_url,
+                content_hash=content_hash,
+                error_code="parse_error",
+                error_detail=f"Failed to read source file: {exc}",
+                parser_version=config.parser_version,
+            )
+            await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
+            return ModelKreuzbergParseResult(
+                indexed_count=0,
+                failed_count=1,
+                skipped_too_large_count=0,
+                timeout_count=0,
+            )
 
         # ------------------------------------------------------------------
         # Step 4: Hard limit — too large

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -78,6 +78,9 @@ from omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg import (
     read_cached_text,
     write_cached_text,
 )
+from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_result import (
+    ModelKreuzbergParseResult,
+)
 
 if TYPE_CHECKING:
     from omnimemory.models.crawl.model_document_changed_event import (
@@ -91,6 +94,31 @@ if TYPE_CHECKING:
     )
 
 _log = logging.getLogger(__name__)
+
+
+def _validate_source_path(source_url: str, document_root: Path) -> Path:
+    """Validate that source_url resolves to a path within document_root.
+
+    Raises:
+        ValueError: If source_url is absolute and outside document_root, or
+            contains ``..`` components that would escape document_root.
+    """
+    candidate = Path(source_url)
+    # Resolve relative to document_root so that relative paths are anchored.
+    if not candidate.is_absolute():
+        resolved = (document_root / candidate).resolve()
+    else:
+        resolved = candidate.resolve()
+
+    # Ensure the resolved path is within the document root.
+    try:
+        resolved.relative_to(document_root.resolve())
+    except ValueError:
+        raise ValueError(
+            f"source_url {source_url!r} resolves to {resolved} which is outside "
+            f"the permitted document root {document_root.resolve()}"
+        )
+    return resolved
 
 
 def _compute_document_id(
@@ -134,7 +162,7 @@ class HandlerKreuzbergParse:
         event: ModelDocumentDiscoveredEvent | ModelDocumentChangedEvent,
         env_prefix: str,
         publish_callback: Callable[[str, dict[str, object]], Coroutine[Any, Any, None]],
-    ) -> None:
+    ) -> ModelKreuzbergParseResult:
         """Process a single document discovered or changed event.
 
         Args:
@@ -144,6 +172,10 @@ class HandlerKreuzbergParse:
                 topic names (e.g. "dev", "prod").
             publish_callback: Async callable that accepts (topic, payload_dict)
                 and publishes the message to the event bus.
+
+        Returns:
+            ModelKreuzbergParseResult summarising the outcome of this
+            invocation (counts for indexed, failed, too_large, timeout).
         """
         source_url = event.source_ref
         content_hash = event.content_fingerprint
@@ -154,9 +186,11 @@ class HandlerKreuzbergParse:
         now = datetime.now(tz=timezone.utc)
 
         # ------------------------------------------------------------------
-        # Step 1: Read file bytes (may raise — propagate to caller)
+        # Step 1: Validate source path is within document root, then read bytes
         # ------------------------------------------------------------------
-        file_bytes: bytes = await asyncio.to_thread(Path(source_url).read_bytes)
+        document_root = Path(config.text_store_path)
+        validated_path = _validate_source_path(source_url, document_root)
+        file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
 
         # ------------------------------------------------------------------
         # Step 2: Hard limit — too large
@@ -183,7 +217,12 @@ class HandlerKreuzbergParse:
                 parser_version=config.parser_version,
             )
             await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
-            return
+            return ModelKreuzbergParseResult(
+                indexed_count=0,
+                failed_count=0,
+                skipped_too_large_count=1,
+                timeout_count=0,
+            )
 
         # ------------------------------------------------------------------
         # Step 3: Idempotency check — skip re-parse if text already stored
@@ -221,12 +260,17 @@ class HandlerKreuzbergParse:
                 await publish_callback(
                     indexed_topic, indexed_event.model_dump(mode="json")
                 )
-                return
+                return ModelKreuzbergParseResult(
+                    indexed_count=1,
+                    failed_count=0,
+                    skipped_too_large_count=0,
+                    timeout_count=0,
+                )
 
         # ------------------------------------------------------------------
         # Step 4: Call kreuzberg POST /extract
         # ------------------------------------------------------------------
-        filename = Path(source_url).name
+        filename = validated_path.name
         mime_type = _detect_mime_type(source_url)
         timeout_seconds = config.timeout_ms / 1000.0
 
@@ -255,7 +299,12 @@ class HandlerKreuzbergParse:
                 parser_version=config.parser_version,
             )
             await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
-            return
+            return ModelKreuzbergParseResult(
+                indexed_count=0,
+                failed_count=1,
+                skipped_too_large_count=0,
+                timeout_count=1,
+            )
         except KreuzbergExtractionError as exc:
             _log.warning(
                 "kreuzberg HTTP error",
@@ -271,7 +320,12 @@ class HandlerKreuzbergParse:
                 parser_version=config.parser_version,
             )
             await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
-            return
+            return ModelKreuzbergParseResult(
+                indexed_count=0,
+                failed_count=1,
+                skipped_too_large_count=0,
+                timeout_count=0,
+            )
 
         # ------------------------------------------------------------------
         # Step 5: Extract text from response
@@ -281,18 +335,15 @@ class HandlerKreuzbergParse:
         # ------------------------------------------------------------------
         # Step 6: Store text and compute extracted_text_ref
         # ------------------------------------------------------------------
-        if len(extracted_text) < config.inline_text_max_chars:
-            extracted_text_ref = extracted_text
-        else:
-            await asyncio.to_thread(
-                write_cached_text, text_path, content_hash, extracted_text
-            )
-            extracted_text_ref = f"file://{text_path.resolve()}"
-
-        # Write cache even for inline text (for idempotency on next call)
+        # Write cache for idempotency on next call (always, regardless of branch).
         await asyncio.to_thread(
             write_cached_text, text_path, content_hash, extracted_text
         )
+
+        if len(extracted_text) < config.inline_text_max_chars:
+            extracted_text_ref = extracted_text
+        else:
+            extracted_text_ref = f"file://{text_path.resolve()}"
 
         # ------------------------------------------------------------------
         # Step 7: Emit document-indexed event
@@ -318,4 +369,10 @@ class HandlerKreuzbergParse:
                 "document_id": str(document_id),
                 "extracted_text_len": len(extracted_text),
             },
+        )
+        return ModelKreuzbergParseResult(
+            indexed_count=1,
+            failed_count=0,
+            skipped_too_large_count=0,
+            timeout_count=0,
         )

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -181,51 +181,50 @@ class HandlerKreuzbergParse:
         content_hash = event.content_fingerprint
         config = self._config
 
-        indexed_topic = f"{env_prefix}.{config.publish_topic_indexed}"
-        failed_topic = f"{env_prefix}.{config.publish_topic_parse_failed}"
+        indexed_topic = (
+            f"{env_prefix}.{config.publish_topic_indexed}"
+            if env_prefix
+            else config.publish_topic_indexed
+        )
+        failed_topic = (
+            f"{env_prefix}.{config.publish_topic_parse_failed}"
+            if env_prefix
+            else config.publish_topic_parse_failed
+        )
         now = datetime.now(tz=timezone.utc)
 
         # ------------------------------------------------------------------
-        # Step 1: Validate source path is within document root, then read bytes
+        # Step 1: Validate source path is within document root
         # ------------------------------------------------------------------
-        document_root = Path(config.text_store_path)
-        validated_path = _validate_source_path(source_url, document_root)
-        file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
-
-        # ------------------------------------------------------------------
-        # Step 2: Hard limit — too large
-        # ------------------------------------------------------------------
-        if len(file_bytes) > config.max_doc_bytes:
+        document_root = Path(config.document_root)
+        try:
+            validated_path = _validate_source_path(source_url, document_root)
+        except ValueError as exc:
             _log.warning(
-                "Document too large for kreuzberg",
-                extra={
-                    "source_url": source_url,
-                    "size_bytes": len(file_bytes),
-                    "max_doc_bytes": config.max_doc_bytes,
-                },
+                "Invalid source_ref path rejected",
+                extra={"source_url": source_url, "error": str(exc)},
             )
             failed_event = ModelDocumentParseFailedEvent(
                 correlation_id=event.correlation_id,
                 emitted_at_utc=now,
                 source_url=source_url,
                 content_hash=content_hash,
-                error_code="too_large",
-                error_detail=(
-                    f"Document size {len(file_bytes)} bytes exceeds "
-                    f"max_doc_bytes={config.max_doc_bytes}"
-                ),
+                error_code="parse_error",
+                error_detail=f"Invalid source_ref path: {exc}",
                 parser_version=config.parser_version,
             )
             await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
             return ModelKreuzbergParseResult(
                 indexed_count=0,
-                failed_count=0,
-                skipped_too_large_count=1,
+                failed_count=1,
+                skipped_too_large_count=0,
                 timeout_count=0,
             )
 
         # ------------------------------------------------------------------
-        # Step 3: Idempotency check — skip re-parse if text already stored
+        # Step 2: Idempotency check — skip re-parse if text already stored.
+        # This check uses only source_url (for the cache slug) and
+        # event.content_fingerprint, so no file read is required yet.
         # ------------------------------------------------------------------
         slug = _source_url_slug(source_url)
         text_store = Path(config.text_store_path)
@@ -268,7 +267,44 @@ class HandlerKreuzbergParse:
                 )
 
         # ------------------------------------------------------------------
-        # Step 4: Call kreuzberg POST /extract
+        # Step 3: Read file bytes (deferred until after idempotency check)
+        # ------------------------------------------------------------------
+        file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
+
+        # ------------------------------------------------------------------
+        # Step 4: Hard limit — too large
+        # ------------------------------------------------------------------
+        if len(file_bytes) > config.max_doc_bytes:
+            _log.warning(
+                "Document too large for kreuzberg",
+                extra={
+                    "source_url": source_url,
+                    "size_bytes": len(file_bytes),
+                    "max_doc_bytes": config.max_doc_bytes,
+                },
+            )
+            failed_event = ModelDocumentParseFailedEvent(
+                correlation_id=event.correlation_id,
+                emitted_at_utc=now,
+                source_url=source_url,
+                content_hash=content_hash,
+                error_code="too_large",
+                error_detail=(
+                    f"Document size {len(file_bytes)} bytes exceeds "
+                    f"max_doc_bytes={config.max_doc_bytes}"
+                ),
+                parser_version=config.parser_version,
+            )
+            await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
+            return ModelKreuzbergParseResult(
+                indexed_count=0,
+                failed_count=0,
+                skipped_too_large_count=1,
+                timeout_count=0,
+            )
+
+        # ------------------------------------------------------------------
+        # Step 5: Call kreuzberg POST /extract
         # ------------------------------------------------------------------
         filename = validated_path.name
         mime_type = _detect_mime_type(source_url)
@@ -328,12 +364,12 @@ class HandlerKreuzbergParse:
             )
 
         # ------------------------------------------------------------------
-        # Step 5: Extract text from response
+        # Step 6: Extract text from response
         # ------------------------------------------------------------------
         extracted_text = result.extracted_text
 
         # ------------------------------------------------------------------
-        # Step 6: Store text and compute extracted_text_ref
+        # Step 7: Store text and compute extracted_text_ref
         # ------------------------------------------------------------------
         # Write cache for idempotency on next call (always, regardless of branch).
         await asyncio.to_thread(
@@ -346,7 +382,7 @@ class HandlerKreuzbergParse:
             extracted_text_ref = f"file://{text_path.resolve()}"
 
         # ------------------------------------------------------------------
-        # Step 7: Emit document-indexed event
+        # Step 8: Emit document-indexed event
         # ------------------------------------------------------------------
         document_id = _compute_document_id(
             source_url, content_hash, config.parser_version

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""KreuzbergParse handler: calls kreuzberg HTTP service to extract text from documents.
+
+Architecture:
+    This handler implements the kreuzberg parse step described in OMN-2733.
+    It consumes document-discovered and document-changed events, calls the
+    kreuzberg REST API to extract plain text, and emits either
+    document-indexed (kreuzberg variant) or document-parse-failed events.
+
+    Hard Limits:
+        - Documents > max_doc_bytes (default 50 MB): emit parse-failed with
+          error_code=too_large without calling kreuzberg.
+        - Requests exceeding timeout_ms (default 30 s): emit parse-failed
+          with error_code=timeout.
+        - HTTP errors from kreuzberg: emit parse-failed with error_code=parse_error.
+
+    Idempotency:
+        Before calling kreuzberg, check if a text file already exists at
+        <text_store_path>/<sha256_of_source_url>.txt. If so, compare the
+        stored content_fingerprint (first line of the file, prefix "fingerprint:").
+        If the fingerprint matches event.content_fingerprint, re-emit the
+        indexed event without re-parsing and return immediately.
+
+    Text Storage:
+        Texts shorter than inline_text_max_chars are stored inline in
+        extracted_text_ref. Longer texts are written to disk and referenced
+        as "file://<absolute_path>".
+
+    Document ID:
+        Computed as UUID from the first 16 bytes of
+        sha256(source_url + content_hash + parser_version).
+
+Example::
+
+    from omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse import (
+        HandlerKreuzbergParse,
+    )
+    from omnimemory.nodes.kreuzberg_parse_effect.models import ModelKreuzbergParseConfig
+
+    config = ModelKreuzbergParseConfig(
+        kreuzberg_url="http://localhost:8090",
+        text_store_path="/tmp/kreuzberg_texts",
+        parser_version="1.0.0",
+    )
+    handler = HandlerKreuzbergParse(config=config)
+    await handler.process_event(event=event, env_prefix="dev", publish_callback=cb)
+
+.. versionadded:: 0.5.0
+    Initial implementation for OMN-2733.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import mimetypes
+import uuid
+from collections.abc import Callable, Coroutine
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from omnimemory.models.crawl.model_document_indexed_kreuzberg_event import (
+    ModelDocumentIndexedKreuzbergEvent,
+)
+from omnimemory.models.crawl.model_document_parse_failed_event import (
+    ModelDocumentParseFailedEvent,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg import (
+    KreuzbergExtractionError,
+    KreuzbergTimeoutError,
+    call_kreuzberg_extract,
+    read_cached_text,
+    write_cached_text,
+)
+
+if TYPE_CHECKING:
+    from omnimemory.models.crawl.model_document_changed_event import (
+        ModelDocumentChangedEvent,
+    )
+    from omnimemory.models.crawl.model_document_discovered_event import (
+        ModelDocumentDiscoveredEvent,
+    )
+    from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_config import (
+        ModelKreuzbergParseConfig,
+    )
+
+_log = logging.getLogger(__name__)
+
+
+def _compute_document_id(
+    source_url: str,
+    content_hash: str,
+    parser_version: str,
+) -> UUID:
+    """Compute a stable document UUID from source_url, content_hash, and parser_version.
+
+    Uses the first 16 bytes of sha256(source_url + content_hash + parser_version)
+    formatted as a UUID v4-like identifier.
+    """
+    raw = (source_url + content_hash + parser_version).encode("utf-8")
+    digest = hashlib.sha256(raw).digest()
+    return uuid.UUID(bytes=digest[:16])
+
+
+def _source_url_slug(source_url: str) -> str:
+    """Compute sha256 hex of source_url for use as a filename component."""
+    return hashlib.sha256(source_url.encode("utf-8")).hexdigest()
+
+
+def _detect_mime_type(source_url: str) -> str:
+    """Best-effort MIME type detection from source URL/path."""
+    mime, _ = mimetypes.guess_type(source_url)
+    return mime or "application/octet-stream"
+
+
+class HandlerKreuzbergParse:
+    """Handler that calls kreuzberg to extract text from documents.
+
+    This handler is stateless except for the injected configuration.
+    All I/O is async; filesystem operations run via asyncio.to_thread.
+    """
+
+    def __init__(self, config: ModelKreuzbergParseConfig) -> None:
+        self._config = config
+
+    async def process_event(
+        self,
+        event: ModelDocumentDiscoveredEvent | ModelDocumentChangedEvent,
+        env_prefix: str,
+        publish_callback: Callable[[str, dict[str, object]], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Process a single document discovered or changed event.
+
+        Args:
+            event: The triggering document event carrying source_ref and
+                content_fingerprint.
+            env_prefix: Environment prefix used to build fully-qualified
+                topic names (e.g. "dev", "prod").
+            publish_callback: Async callable that accepts (topic, payload_dict)
+                and publishes the message to the event bus.
+        """
+        source_url = event.source_ref
+        content_hash = event.content_fingerprint
+        config = self._config
+
+        indexed_topic = f"{env_prefix}.{config.publish_topic_indexed}"
+        failed_topic = f"{env_prefix}.{config.publish_topic_parse_failed}"
+        now = datetime.now(tz=timezone.utc)
+
+        # ------------------------------------------------------------------
+        # Step 1: Read file bytes (may raise — propagate to caller)
+        # ------------------------------------------------------------------
+        file_bytes: bytes = await asyncio.to_thread(Path(source_url).read_bytes)
+
+        # ------------------------------------------------------------------
+        # Step 2: Hard limit — too large
+        # ------------------------------------------------------------------
+        if len(file_bytes) > config.max_doc_bytes:
+            _log.warning(
+                "Document too large for kreuzberg",
+                extra={
+                    "source_url": source_url,
+                    "size_bytes": len(file_bytes),
+                    "max_doc_bytes": config.max_doc_bytes,
+                },
+            )
+            failed_event = ModelDocumentParseFailedEvent(
+                correlation_id=event.correlation_id,
+                emitted_at_utc=now,
+                source_url=source_url,
+                content_hash=content_hash,
+                error_code="too_large",
+                error_detail=(
+                    f"Document size {len(file_bytes)} bytes exceeds "
+                    f"max_doc_bytes={config.max_doc_bytes}"
+                ),
+                parser_version=config.parser_version,
+            )
+            await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
+            return
+
+        # ------------------------------------------------------------------
+        # Step 3: Idempotency check — skip re-parse if text already stored
+        # ------------------------------------------------------------------
+        slug = _source_url_slug(source_url)
+        text_store = Path(config.text_store_path)
+        text_path = text_store / f"{slug}.txt"
+
+        cached = await asyncio.to_thread(read_cached_text, text_path)
+        if cached is not None:
+            stored_fingerprint, cached_text = cached
+            if stored_fingerprint == content_hash:
+                _log.debug(
+                    "Idempotent: re-emitting indexed event without re-parsing",
+                    extra={"source_url": source_url},
+                )
+                document_id = _compute_document_id(
+                    source_url, content_hash, config.parser_version
+                )
+                extracted_text_ref = (
+                    cached_text
+                    if len(cached_text) < config.inline_text_max_chars
+                    else f"file://{text_path.resolve()}"
+                )
+                indexed_event = ModelDocumentIndexedKreuzbergEvent(
+                    correlation_id=event.correlation_id,
+                    emitted_at_utc=now,
+                    document_id=document_id,
+                    source_url=source_url,
+                    content_hash=content_hash,
+                    extracted_text_ref=extracted_text_ref,
+                    mime_type=_detect_mime_type(source_url),
+                    parser_version=config.parser_version,
+                )
+                await publish_callback(
+                    indexed_topic, indexed_event.model_dump(mode="json")
+                )
+                return
+
+        # ------------------------------------------------------------------
+        # Step 4: Call kreuzberg POST /extract
+        # ------------------------------------------------------------------
+        filename = Path(source_url).name
+        mime_type = _detect_mime_type(source_url)
+        timeout_seconds = config.timeout_ms / 1000.0
+
+        try:
+            result = await call_kreuzberg_extract(
+                kreuzberg_url=config.kreuzberg_url,
+                file_bytes=file_bytes,
+                filename=filename,
+                mime_type=mime_type,
+                timeout_seconds=timeout_seconds,
+            )
+        except KreuzbergTimeoutError:
+            _log.warning(
+                "kreuzberg request timed out",
+                extra={"source_url": source_url, "timeout_ms": config.timeout_ms},
+            )
+            failed_event = ModelDocumentParseFailedEvent(
+                correlation_id=event.correlation_id,
+                emitted_at_utc=now,
+                source_url=source_url,
+                content_hash=content_hash,
+                error_code="timeout",
+                error_detail=(
+                    f"kreuzberg extract request timed out after {config.timeout_ms} ms"
+                ),
+                parser_version=config.parser_version,
+            )
+            await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
+            return
+        except KreuzbergExtractionError as exc:
+            _log.warning(
+                "kreuzberg HTTP error",
+                extra={"source_url": source_url, "status_code": exc.status_code},
+            )
+            failed_event = ModelDocumentParseFailedEvent(
+                correlation_id=event.correlation_id,
+                emitted_at_utc=now,
+                source_url=source_url,
+                content_hash=content_hash,
+                error_code="parse_error",
+                error_detail=exc.detail,
+                parser_version=config.parser_version,
+            )
+            await publish_callback(failed_topic, failed_event.model_dump(mode="json"))
+            return
+
+        # ------------------------------------------------------------------
+        # Step 5: Extract text from response
+        # ------------------------------------------------------------------
+        extracted_text = result.extracted_text
+
+        # ------------------------------------------------------------------
+        # Step 6: Store text and compute extracted_text_ref
+        # ------------------------------------------------------------------
+        if len(extracted_text) < config.inline_text_max_chars:
+            extracted_text_ref = extracted_text
+        else:
+            await asyncio.to_thread(
+                write_cached_text, text_path, content_hash, extracted_text
+            )
+            extracted_text_ref = f"file://{text_path.resolve()}"
+
+        # Write cache even for inline text (for idempotency on next call)
+        await asyncio.to_thread(
+            write_cached_text, text_path, content_hash, extracted_text
+        )
+
+        # ------------------------------------------------------------------
+        # Step 7: Emit document-indexed event
+        # ------------------------------------------------------------------
+        document_id = _compute_document_id(
+            source_url, content_hash, config.parser_version
+        )
+        indexed_event = ModelDocumentIndexedKreuzbergEvent(
+            correlation_id=event.correlation_id,
+            emitted_at_utc=now,
+            document_id=document_id,
+            source_url=source_url,
+            content_hash=content_hash,
+            extracted_text_ref=extracted_text_ref,
+            mime_type=mime_type,
+            parser_version=config.parser_version,
+        )
+        await publish_callback(indexed_topic, indexed_event.model_dump(mode="json"))
+        _log.info(
+            "kreuzberg parse complete",
+            extra={
+                "source_url": source_url,
+                "document_id": str(document_id),
+                "extracted_text_len": len(extracted_text),
+            },
+        )

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/__init__.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Models for KreuzbergParseEffect node."""
+
+from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_config import (
+    ModelKreuzbergParseConfig,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_result import (
+    ModelKreuzbergParseResult,
+)
+
+__all__ = [
+    "ModelKreuzbergParseConfig",
+    "ModelKreuzbergParseResult",
+]

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Handler configuration model for KreuzbergParseEffect node."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
+    BaseModel
+):
+    """Configuration for HandlerKreuzbergParse.
+
+    All values may be sourced from environment variables or injected
+    directly. Frozen to prevent accidental mutation after construction.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    kreuzberg_url: str = Field(
+        default="http://localhost:8090",
+        description="Base URL of the kreuzberg Docker service",
+    )
+    text_store_path: str = Field(
+        ...,
+        description="Filesystem path where extracted text files are stored (KREUZBERG_TEXT_STORE_PATH)",
+    )
+    parser_version: str = Field(
+        ...,
+        description="Semver string identifying the kreuzberg parser version (e.g. '1.0.0')",
+    )
+    max_doc_bytes: int = Field(
+        default=50_000_000,
+        ge=1,
+        description="Maximum document size in bytes before emitting too_large parse failure (default 50 MB)",
+    )
+    timeout_ms: int = Field(
+        default=30_000,
+        ge=1,
+        description="HTTP request timeout in milliseconds for kreuzberg extract calls (default 30 s)",
+    )
+    inline_text_max_chars: int = Field(
+        default=4096,
+        ge=1,
+        description=(
+            "Maximum character length for storing extracted text inline in the event. "
+            "Texts longer than this threshold are written to disk and referenced via file://"
+        ),
+    )
+    publish_topic_indexed: str = Field(
+        default="onex.evt.omnimemory.document-indexed.v1",
+        description="Topic to publish ModelDocumentIndexedKreuzbergEvent messages to",
+    )
+    publish_topic_parse_failed: str = Field(
+        default="onex.evt.omnimemory.document-parse-failed.v1",
+        description="Topic to publish ModelDocumentParseFailedEvent messages to",
+    )

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -26,6 +26,14 @@ class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
         ...,
         description="Filesystem path where extracted text files are stored (KREUZBERG_TEXT_STORE_PATH)",
     )
+    document_root: str = Field(
+        default="/",
+        description=(
+            "Root directory that source_ref paths must be confined to. "
+            "Defaults to filesystem root (permissive — still prevents .. escapes from relative paths). "
+            "Set to a tighter path in production (KREUZBERG_DOCUMENT_ROOT)."
+        ),
+    )
     parser_version: str = Field(
         ...,
         description="Semver string identifying the kreuzberg parser version (e.g. '1.0.0')",

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -4,7 +4,9 @@
 # Copyright (c) 2025 OmniNode Team
 """Handler configuration model for KreuzbergParseEffect node."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
@@ -34,6 +36,16 @@ class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
             "Set to a tighter path in production (KREUZBERG_DOCUMENT_ROOT)."
         ),
     )
+
+    @field_validator("document_root")
+    @classmethod
+    def validate_document_root_exists(cls, v: str) -> str:
+        if not Path(v).is_dir():
+            raise ValueError(
+                f"document_root '{v}' does not exist or is not a directory"
+            )
+        return v
+
     parser_version: str = Field(
         ...,
         description="Semver string identifying the kreuzberg parser version (e.g. '1.0.0')",

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_result.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_result.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Summary result model for a single KreuzbergParseEffect run."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelKreuzbergParseResult(  # omnimemory-model-exempt: handler result
+    BaseModel
+):
+    """Summary of documents processed in a single handler invocation.
+
+    Returned by HandlerKreuzbergParse.process_event() aggregation when
+    used in batch mode, or inspected by tests for assertion purposes.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    indexed_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of document-indexed events successfully emitted",
+    )
+    failed_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of document-parse-failed events emitted (parse_error or timeout)",
+    )
+    skipped_too_large_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of documents rejected before kreuzberg call due to size > max_doc_bytes",
+    )
+    timeout_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of kreuzberg requests that timed out",
+    )

--- a/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_result.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/models/model_kreuzberg_parse_result.py
@@ -26,7 +26,13 @@ class ModelKreuzbergParseResult(  # omnimemory-model-exempt: handler result
     failed_count: int = Field(
         ...,
         ge=0,
-        description="Number of document-parse-failed events emitted (parse_error or timeout)",
+        description=(
+            "Number of document-parse-failed events emitted for parse_error or timeout "
+            "outcomes only. Does NOT include too_large outcomes, which are tracked "
+            "separately in skipped_too_large_count. Callers that need the total number "
+            "of document-parse-failed events emitted must sum "
+            "failed_count + skipped_too_large_count."
+        ),
     )
     skipped_too_large_count: int = Field(
         ...,

--- a/tests/audit/io_audit_whitelist.yaml
+++ b/tests/audit/io_audit_whitelist.yaml
@@ -36,3 +36,10 @@ files:
     reason: "Effect client uses httpx for embedding API calls; expected I/O boundary"
     allowed_rules:
       - "net-client"
+
+  - path: "src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py"
+    reason: "Kreuzberg effect client: httpx for API calls, Path.read_text/write_text for idempotency cache
+      (OMN-2733)"
+    allowed_rules:
+      - "net-client"
+      - "file-io"

--- a/tests/audit/transport_import_whitelist.yaml
+++ b/tests/audit/transport_import_whitelist.yaml
@@ -46,8 +46,14 @@ files:
     allowed_modules:
       - asyncpg
 
-  # Effect node client - effect nodes are the designated I/O boundary
+  # Effect node clients - effect nodes are the designated I/O boundary
   - path: "src/omnimemory/nodes/memory_retrieval_effect/clients/embedding_client.py"
     reason: "Effect client uses httpx for embedding API calls; expected I/O boundary"
+    allowed_modules:
+      - httpx
+
+  - path: "src/omnimemory/nodes/kreuzberg_parse_effect/clients/client_kreuzberg.py"
+    reason: "Kreuzberg effect client uses httpx for document extraction API calls; expected I/O boundary
+      (OMN-2733)"
     allowed_modules:
       - httpx

--- a/tests/integration/nodes/test_kreuzberg_parse_effect.py
+++ b/tests/integration/nodes/test_kreuzberg_parse_effect.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Integration tests for HandlerKreuzbergParse.
+
+These tests exercise the handler end-to-end using mocked kreuzberg client
+responses (via unittest.mock). They do NOT require a running Docker container.
+
+Test Categories:
+    - kreuzberg_extract: Successful extraction for PDF, DOCX, HTML, Markdown
+    - parse_failure: HTTP 422 error maps to document-parse-failed event
+    - idempotent_crawl: Second call with matching fingerprint skips re-parse
+
+Related Tickets:
+    - OMN-2733: Adopt kreuzberg as document parsing handler for omnimemory
+
+Usage:
+    pytest tests/integration/nodes/test_kreuzberg_parse_effect.py \\
+        -k "kreuzberg_extract or parse_failure or idempotent_crawl" -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.models.crawl.model_document_discovered_event import (
+    ModelDocumentDiscoveredEvent,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg import (
+    KreuzbergExtractionError,
+    KreuzbergExtractResult,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse import (
+    HandlerKreuzbergParse,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_config import (
+    ModelKreuzbergParseConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FAKE_FINGERPRINT = "b" * 64
+_FAKE_CONTENT_BLOB_REF = "sha256:" + "b" * 64
+_HANDLER_MOD = "omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    source_ref: str,
+    content_fingerprint: str = _FAKE_FINGERPRINT,
+) -> ModelDocumentDiscoveredEvent:
+    from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+    from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+    from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+
+    return ModelDocumentDiscoveredEvent(
+        correlation_id=uuid4(),
+        emitted_at_utc=datetime.now(tz=timezone.utc),
+        crawler_type=EnumCrawlerType.FILESYSTEM,
+        crawl_scope="omninode/omnimemory",
+        trigger_source="scheduled",
+        source_ref=source_ref,
+        source_type=EnumContextSourceType.REPO_DERIVED,
+        source_version=None,
+        content_fingerprint=content_fingerprint,
+        content_blob_ref=_FAKE_CONTENT_BLOB_REF,
+        token_estimate=42,
+        scope_ref="omninode/omnimemory",
+        detected_doc_type=EnumDetectedDocType.UNKNOWN_MD,
+        tags=[],
+        priority_hint=50,
+    )
+
+
+def _make_config(text_store_path: str) -> ModelKreuzbergParseConfig:
+    return ModelKreuzbergParseConfig(
+        kreuzberg_url="http://localhost:8090",
+        text_store_path=text_store_path,
+        parser_version="1.0.0",
+        max_doc_bytes=50_000_000,
+        timeout_ms=30_000,
+        inline_text_max_chars=4096,
+    )
+
+
+async def _run_handler(
+    event: ModelDocumentDiscoveredEvent,
+    config: ModelKreuzbergParseConfig,
+    extract_result: KreuzbergExtractResult | Exception,
+    file_bytes: bytes = b"fake file content",
+    cached: tuple[str, str] | None = None,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Run the handler with mocked filesystem I/O and kreuzberg client.
+
+    Patches:
+        - Path.read_bytes → returns file_bytes
+        - read_cached_text (in handler module) → returns cached
+        - write_cached_text (in handler module) → no-op
+        - call_kreuzberg_extract (in handler module) → returns/raises extract_result
+
+    Returns published events as list of (topic, payload) tuples.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+
+    async def _cb(topic: str, payload: dict[str, Any]) -> None:
+        published.append((topic, payload))
+
+    handler = HandlerKreuzbergParse(config=config)
+
+    if isinstance(extract_result, Exception):
+        mock_extract = AsyncMock(side_effect=extract_result)
+    else:
+        mock_extract = AsyncMock(return_value=extract_result)
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=file_bytes),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=cached),
+        patch(f"{_HANDLER_MOD}.write_cached_text"),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    return published
+
+
+# ---------------------------------------------------------------------------
+# kreuzberg_extract tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kreuzberg_extract_pdf(tmp_path: Path) -> None:
+    """Successful kreuzberg extraction for a PDF file."""
+    config = _make_config(str(tmp_path / "texts"))
+    event = _make_event(source_ref=str(tmp_path / "report.pdf"))
+    extracted = "PDF extracted text content"
+
+    published = await _run_handler(
+        event,
+        config,
+        KreuzbergExtractResult(extracted_text=extracted),
+        file_bytes=b"%PDF-1.4 fake",
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == extracted
+    assert payload["source_url"] == str(tmp_path / "report.pdf")
+    assert payload["parse_status"] == "ok"
+    assert payload["parser_version"] == "1.0.0"
+    assert "document_id" in payload
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kreuzberg_extract_docx(tmp_path: Path) -> None:
+    """Successful kreuzberg extraction for a DOCX file."""
+    config = _make_config(str(tmp_path / "texts"))
+    event = _make_event(source_ref=str(tmp_path / "document.docx"))
+    extracted = "DOCX paragraph one. Paragraph two."
+
+    published = await _run_handler(
+        event,
+        config,
+        KreuzbergExtractResult(extracted_text=extracted),
+        file_bytes=b"PK\x03\x04",  # ZIP/DOCX magic bytes
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == extracted
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kreuzberg_extract_html(tmp_path: Path) -> None:
+    """Successful kreuzberg extraction for an HTML file."""
+    config = _make_config(str(tmp_path / "texts"))
+    event = _make_event(source_ref=str(tmp_path / "page.html"))
+    extracted = "Page title. Body content."
+
+    published = await _run_handler(
+        event,
+        config,
+        KreuzbergExtractResult(extracted_text=extracted),
+        file_bytes=b"<html><body><p>Page title. Body content.</p></body></html>",
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == extracted
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kreuzberg_extract_md(tmp_path: Path) -> None:
+    """Successful kreuzberg extraction for a Markdown file."""
+    config = _make_config(str(tmp_path / "texts"))
+    event = _make_event(source_ref=str(tmp_path / "README.md"))
+    extracted = "# README\n\nThis is the readme."
+
+    published = await _run_handler(
+        event,
+        config,
+        KreuzbergExtractResult(extracted_text=extracted),
+        file_bytes=b"# README\n\nThis is the readme.",
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == extracted
+
+
+# ---------------------------------------------------------------------------
+# parse_failure tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_parse_failure_corrupted_pdf(tmp_path: Path) -> None:
+    """kreuzberg HTTP 422 maps to document-parse-failed with error_code=parse_error."""
+    config = _make_config(str(tmp_path / "texts"))
+    event = _make_event(source_ref=str(tmp_path / "corrupted.pdf"))
+
+    published = await _run_handler(
+        event,
+        config,
+        KreuzbergExtractionError(status_code=422, detail="Unprocessable Entity"),
+        file_bytes=b"%PDF-corrupted-not-valid",
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "parse_error"
+    assert payload["source_url"] == str(tmp_path / "corrupted.pdf")
+    assert "Unprocessable Entity" in str(payload["error_detail"])
+
+
+# ---------------------------------------------------------------------------
+# idempotent_crawl tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idempotent_crawl_no_duplicate_events(tmp_path: Path) -> None:
+    """Second call with identical event + fingerprint emits indexed event per call (no re-parse)."""
+    config = _make_config(str(tmp_path / "texts"))
+    fingerprint = _FAKE_FINGERPRINT
+    event = _make_event(
+        source_ref=str(tmp_path / "stable.md"),
+        content_fingerprint=fingerprint,
+    )
+
+    published: list[tuple[str, dict[str, Any]]] = []
+
+    async def _cb(topic: str, payload: dict[str, Any]) -> None:
+        published.append((topic, payload))
+
+    handler = HandlerKreuzbergParse(config=config)
+    cached_text = "stable document content"
+    mock_extract = AsyncMock()
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"stable content bytes"),
+        patch(
+            f"{_HANDLER_MOD}.read_cached_text",
+            return_value=(fingerprint, cached_text),
+        ),
+        patch(f"{_HANDLER_MOD}.write_cached_text"),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        # First call
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+        # Second call — same event, same fingerprint
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # kreuzberg must NOT be called for either invocation
+    mock_extract.assert_not_called()
+
+    # Both calls emit an indexed event (idempotent at parse level, not at emit level)
+    assert len(published) == 2, (
+        f"Expected 2 indexed events (one per call), got {len(published)}"
+    )
+    for topic, payload in published:
+        assert "document-indexed" in topic
+        assert payload["extracted_text_ref"] == cached_text

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/__init__.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for KreuzbergParseEffect node."""

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -34,6 +34,7 @@ from omnimemory.models.crawl.model_document_discovered_event import (
     ModelDocumentDiscoveredEvent,
 )
 from omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg import (
+    KreuzbergExtractionError,
     KreuzbergExtractResult,
     KreuzbergTimeoutError,
 )
@@ -155,7 +156,7 @@ async def _run_handler(
 async def test_too_large_file_emits_parse_failed(tmp_path: Path) -> None:
     """Documents exceeding max_doc_bytes emit parse-failed without calling kreuzberg."""
     config = _make_config(
-        text_store_path=str(tmp_path / "texts"),
+        text_store_path=str(tmp_path),
         max_doc_bytes=10,
     )
     source_ref = str(tmp_path / "big_doc.md")
@@ -195,7 +196,7 @@ async def test_too_large_file_emits_parse_failed(tmp_path: Path) -> None:
 async def test_successful_parse_inline_text(tmp_path: Path) -> None:
     """Short extracted text (<4096 chars) is stored inline in the event."""
     config = _make_config(
-        text_store_path=str(tmp_path / "texts"),
+        text_store_path=str(tmp_path),
         inline_text_max_chars=4096,
     )
     source_ref = str(tmp_path / "small_doc.md")
@@ -222,7 +223,7 @@ async def test_successful_parse_inline_text(tmp_path: Path) -> None:
 async def test_successful_parse_file_pointer(tmp_path: Path) -> None:
     """Long extracted text (>= inline_text_max_chars) is referenced via file://."""
     config = _make_config(
-        text_store_path=str(tmp_path / "texts"),
+        text_store_path=str(tmp_path),
         inline_text_max_chars=10,  # very small threshold
     )
     source_ref = str(tmp_path / "large_doc.md")
@@ -250,7 +251,7 @@ async def test_successful_parse_file_pointer(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_timeout_emits_parse_failed(tmp_path: Path) -> None:
     """KreuzbergTimeoutError from the client maps to error_code=timeout."""
-    config = _make_config(text_store_path=str(tmp_path / "texts"))
+    config = _make_config(text_store_path=str(tmp_path))
     source_ref = str(tmp_path / "timeout_doc.md")
     event = _make_discovered_event(source_ref=source_ref)
 
@@ -272,7 +273,7 @@ async def test_timeout_emits_parse_failed(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_idempotent_second_call_no_reparse(tmp_path: Path) -> None:
     """Second call with same fingerprint re-emits indexed event without calling kreuzberg."""
-    config = _make_config(text_store_path=str(tmp_path / "texts"))
+    config = _make_config(text_store_path=str(tmp_path))
     source_ref = str(tmp_path / "idempotent_doc.md")
     fingerprint = _FAKE_FINGERPRINT
     event = _make_discovered_event(
@@ -319,3 +320,29 @@ async def test_idempotent_second_call_no_reparse(tmp_path: Path) -> None:
     for topic, payload in published:
         assert "document-indexed" in topic
         assert payload["extracted_text_ref"] == cached_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kreuzberg_extraction_error_emits_parse_failed(tmp_path: Path) -> None:
+    """KreuzbergExtractionError from the client maps to error_code=parse_error."""
+    config = _make_config(text_store_path=str(tmp_path))
+    source_ref = str(tmp_path / "error_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    published = await _run_handler(
+        event=event,
+        config=config,
+        file_bytes=b"file content",
+        extract_result=KreuzbergExtractionError(
+            status_code=422,
+            detail="unsupported document format",
+        ),
+        cached=None,
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "parse_error"
+    assert payload["source_url"] == source_ref

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -93,15 +93,19 @@ def _make_config(
     text_store_path: str,
     max_doc_bytes: int = 50_000_000,
     inline_text_max_chars: int = 4096,
+    document_root: str | None = None,
 ) -> ModelKreuzbergParseConfig:
-    return ModelKreuzbergParseConfig(
-        kreuzberg_url="http://localhost:8090",
-        text_store_path=text_store_path,
-        parser_version="1.0.0",
-        max_doc_bytes=max_doc_bytes,
-        timeout_ms=30_000,
-        inline_text_max_chars=inline_text_max_chars,
-    )
+    kwargs: dict[str, object] = {
+        "kreuzberg_url": "http://localhost:8090",
+        "text_store_path": text_store_path,
+        "parser_version": "1.0.0",
+        "max_doc_bytes": max_doc_bytes,
+        "timeout_ms": 30_000,
+        "inline_text_max_chars": inline_text_max_chars,
+    }
+    if document_root is not None:
+        kwargs["document_root"] = document_root
+    return ModelKreuzbergParseConfig(**kwargs)
 
 
 async def _run_handler(
@@ -346,3 +350,47 @@ async def test_kreuzberg_extraction_error_emits_parse_failed(tmp_path: Path) -> 
     assert "parse-failed" in topic
     assert payload["error_code"] == "parse_error"
     assert payload["source_url"] == source_ref
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_source_ref_path_traversal_emits_parse_failed(tmp_path: Path) -> None:
+    """Path traversal attempt (source_ref outside document_root) emits parse-failed.
+
+    Validates CRITICAL-2: ValueError from _validate_source_path is caught and
+    converted into a structured document-parse-failed event with error_code=parse_error.
+    """
+    config = _make_config(
+        text_store_path=str(tmp_path),
+        document_root=str(tmp_path),
+    )
+    # source_ref points to a sibling directory — outside tmp_path
+    outside_path = tmp_path.parent / "outside" / "doc.pdf"
+    event = _make_discovered_event(source_ref=str(outside_path))
+
+    handler = HandlerKreuzbergParse(config=config)
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    mock_extract = AsyncMock()
+
+    with (
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # kreuzberg must NOT be called — rejection happens before file read
+    mock_extract.assert_not_called()
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "parse_error"
+    assert payload["source_url"] == str(outside_path)

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -511,7 +511,9 @@ async def test_empty_env_prefix_uses_bare_topic_names(tmp_path: Path) -> None:
         patch(f"{_HANDLER_MOD}.write_cached_text"),
         patch(
             f"{_HANDLER_MOD}.call_kreuzberg_extract",
-            AsyncMock(return_value=KreuzbergExtractResult(extracted_text="hello world")),
+            AsyncMock(
+                return_value=KreuzbergExtractResult(extracted_text="hello world")
+            ),
         ),
     ):
         await handler.process_event(

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerKreuzbergParse.
+
+Tests cover the kreuzberg parse handler's core behaviors:
+    - Hard limit: documents exceeding max_doc_bytes emit parse-failed without
+      calling kreuzberg.
+    - Successful inline parse: short extracted text stored directly in the event.
+    - Successful file-pointer parse: long extracted text stored on disk.
+    - Timeout: KreuzbergTimeoutError maps to error_code=timeout.
+    - Idempotency: second call with same fingerprint skips kreuzberg HTTP.
+
+All tests mock filesystem I/O and the kreuzberg client to avoid external dependencies.
+
+Related Tickets:
+    - OMN-2733: Adopt kreuzberg as document parsing handler for omnimemory
+
+Usage:
+    pytest tests/unit/nodes/test_kreuzberg_parse_effect/ -m unit -v
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.models.crawl.model_document_discovered_event import (
+    ModelDocumentDiscoveredEvent,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg import (
+    KreuzbergExtractResult,
+    KreuzbergTimeoutError,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse import (
+    HandlerKreuzbergParse,
+)
+from omnimemory.nodes.kreuzberg_parse_effect.models.model_kreuzberg_parse_config import (
+    ModelKreuzbergParseConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FAKE_FINGERPRINT = "a" * 64
+_FAKE_CONTENT_BLOB_REF = "sha256:" + "a" * 64
+
+# Module paths for patching — patch where names are looked up, not where defined
+_HANDLER_MOD = "omnimemory.nodes.kreuzberg_parse_effect.handler_kreuzberg_parse"
+_CLIENT_MOD = "omnimemory.nodes.kreuzberg_parse_effect.clients.client_kreuzberg"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_discovered_event(
+    source_ref: str,
+    content_fingerprint: str = _FAKE_FINGERPRINT,
+) -> ModelDocumentDiscoveredEvent:
+    from omnimemory.enums.crawl.enum_context_source_type import EnumContextSourceType
+    from omnimemory.enums.crawl.enum_crawler_type import EnumCrawlerType
+    from omnimemory.enums.crawl.enum_detected_doc_type import EnumDetectedDocType
+
+    return ModelDocumentDiscoveredEvent(
+        correlation_id=uuid4(),
+        emitted_at_utc=datetime.now(tz=timezone.utc),
+        crawler_type=EnumCrawlerType.FILESYSTEM,
+        crawl_scope="omninode/omnimemory",
+        trigger_source="scheduled",
+        source_ref=source_ref,
+        source_type=EnumContextSourceType.REPO_DERIVED,
+        source_version=None,
+        content_fingerprint=content_fingerprint,
+        content_blob_ref=_FAKE_CONTENT_BLOB_REF,
+        token_estimate=100,
+        scope_ref="omninode/omnimemory",
+        detected_doc_type=EnumDetectedDocType.UNKNOWN_MD,
+        tags=[],
+        priority_hint=50,
+    )
+
+
+def _make_config(
+    text_store_path: str,
+    max_doc_bytes: int = 50_000_000,
+    inline_text_max_chars: int = 4096,
+) -> ModelKreuzbergParseConfig:
+    return ModelKreuzbergParseConfig(
+        kreuzberg_url="http://localhost:8090",
+        text_store_path=text_store_path,
+        parser_version="1.0.0",
+        max_doc_bytes=max_doc_bytes,
+        timeout_ms=30_000,
+        inline_text_max_chars=inline_text_max_chars,
+    )
+
+
+async def _run_handler(
+    event: ModelDocumentDiscoveredEvent,
+    config: ModelKreuzbergParseConfig,
+    file_bytes: bytes,
+    extract_result: KreuzbergExtractResult | Exception,
+    cached: tuple[str, str] | None = None,
+) -> list[tuple[str, dict[str, object]]]:
+    """Run handler with all I/O patched. Returns list of (topic, payload) tuples.
+
+    Patches:
+        - Path.read_bytes → returns file_bytes
+        - read_cached_text (in handler module) → returns cached
+        - write_cached_text (in handler module) → no-op
+        - call_kreuzberg_extract (in handler module) → returns/raises extract_result
+    """
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    handler = HandlerKreuzbergParse(config=config)
+
+    if isinstance(extract_result, Exception):
+        mock_extract = AsyncMock(side_effect=extract_result)
+    else:
+        mock_extract = AsyncMock(return_value=extract_result)
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=file_bytes),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=cached),
+        patch(f"{_HANDLER_MOD}.write_cached_text"),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    return published
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_too_large_file_emits_parse_failed(tmp_path: Path) -> None:
+    """Documents exceeding max_doc_bytes emit parse-failed without calling kreuzberg."""
+    config = _make_config(
+        text_store_path=str(tmp_path / "texts"),
+        max_doc_bytes=10,
+    )
+    source_ref = str(tmp_path / "big_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+    handler = HandlerKreuzbergParse(config=config)
+
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    mock_extract = AsyncMock()
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"x" * 11),  # 11 > max=10
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # kreuzberg must NOT be called
+    mock_extract.assert_not_called()
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "too_large"
+    assert payload["source_url"] == source_ref
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_successful_parse_inline_text(tmp_path: Path) -> None:
+    """Short extracted text (<4096 chars) is stored inline in the event."""
+    config = _make_config(
+        text_store_path=str(tmp_path / "texts"),
+        inline_text_max_chars=4096,
+    )
+    source_ref = str(tmp_path / "small_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    published = await _run_handler(
+        event=event,
+        config=config,
+        file_bytes=b"# Hello\n",
+        extract_result=KreuzbergExtractResult(extracted_text="hello world"),
+        cached=None,
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == "hello world"
+    assert payload["parse_status"] == "ok"
+    assert payload["parser_version"] == "1.0.0"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_successful_parse_file_pointer(tmp_path: Path) -> None:
+    """Long extracted text (>= inline_text_max_chars) is referenced via file://."""
+    config = _make_config(
+        text_store_path=str(tmp_path / "texts"),
+        inline_text_max_chars=10,  # very small threshold
+    )
+    source_ref = str(tmp_path / "large_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    long_text = "x" * 20  # 20 chars > inline_text_max_chars=10
+    published = await _run_handler(
+        event=event,
+        config=config,
+        file_bytes=b"content bytes",
+        extract_result=KreuzbergExtractResult(extracted_text=long_text),
+        cached=None,
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    extracted_ref = str(payload["extracted_text_ref"])
+    assert extracted_ref.startswith("file://"), (
+        f"Expected file:// pointer, got: {extracted_ref!r}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_timeout_emits_parse_failed(tmp_path: Path) -> None:
+    """KreuzbergTimeoutError from the client maps to error_code=timeout."""
+    config = _make_config(text_store_path=str(tmp_path / "texts"))
+    source_ref = str(tmp_path / "timeout_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    published = await _run_handler(
+        event=event,
+        config=config,
+        file_bytes=b"file content",
+        extract_result=KreuzbergTimeoutError("timed out"),
+        cached=None,
+    )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "timeout"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_idempotent_second_call_no_reparse(tmp_path: Path) -> None:
+    """Second call with same fingerprint re-emits indexed event without calling kreuzberg."""
+    config = _make_config(text_store_path=str(tmp_path / "texts"))
+    source_ref = str(tmp_path / "idempotent_doc.md")
+    fingerprint = _FAKE_FINGERPRINT
+    event = _make_discovered_event(
+        source_ref=source_ref,
+        content_fingerprint=fingerprint,
+    )
+    handler = HandlerKreuzbergParse(config=config)
+
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    cached_text = "previously extracted text"
+    mock_extract = AsyncMock()
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"file content"),
+        patch(
+            f"{_HANDLER_MOD}.read_cached_text",
+            return_value=(fingerprint, cached_text),
+        ),
+        patch(f"{_HANDLER_MOD}.write_cached_text"),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        # First call
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+        # Second call — same event
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # kreuzberg must NOT be called since cache always hits
+    mock_extract.assert_not_called()
+
+    # Both calls should emit an indexed event
+    assert len(published) == 2
+    for topic, payload in published:
+        assert "document-indexed" in topic
+        assert payload["extracted_text_ref"] == cached_text

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -447,8 +447,10 @@ async def test_cache_write_oserror_too_large_emits_parse_failed(tmp_path: Path) 
     source_ref = str(tmp_path / "large_doc.md")
     event = _make_discovered_event(source_ref=source_ref)
 
-    large_text = "x" * (inline_max + 1)  # exceeds inline_max
-    assert len(large_text) >= inline_max
+    large_text = (
+        "x" * inline_max
+    )  # exactly at threshold — not inlineable (uses <, not <=)
+    assert len(large_text) == inline_max
 
     handler = HandlerKreuzbergParse(config=config)
     published: list[tuple[str, dict[str, object]]] = []

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -354,6 +354,136 @@ async def test_kreuzberg_extraction_error_emits_parse_failed(tmp_path: Path) -> 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_source_file_oserror_emits_parse_failed(tmp_path: Path) -> None:
+    """OSError on source file read emits parse-failed with error_code=parse_error."""
+    config = _make_config(text_store_path=str(tmp_path))
+    source_ref = str(tmp_path / "unreadable_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    handler = HandlerKreuzbergParse(config=config)
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    mock_extract = AsyncMock()
+
+    with (
+        patch("pathlib.Path.read_bytes", side_effect=OSError("disk error")),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+        patch(f"{_HANDLER_MOD}.call_kreuzberg_extract", mock_extract),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # kreuzberg must NOT be called when file read fails
+    mock_extract.assert_not_called()
+
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "parse_error"
+    assert payload["source_url"] == source_ref
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_write_oserror_inline_fallback(tmp_path: Path) -> None:
+    """OSError on cache write with short text falls back to inlining the text."""
+    inline_max = 4096
+    config = _make_config(
+        text_store_path=str(tmp_path),
+        inline_text_max_chars=inline_max,
+    )
+    source_ref = str(tmp_path / "short_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    short_text = "short extracted text"  # well under inline_max
+    assert len(short_text) < inline_max
+
+    handler = HandlerKreuzbergParse(config=config)
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"file content"),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+        patch(
+            f"{_HANDLER_MOD}.write_cached_text",
+            side_effect=OSError("disk full"),
+        ),
+        patch(
+            f"{_HANDLER_MOD}.call_kreuzberg_extract",
+            AsyncMock(return_value=KreuzbergExtractResult(extracted_text=short_text)),
+        ),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # Should still emit a document-indexed event with inline text
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "document-indexed" in topic
+    assert payload["extracted_text_ref"] == short_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_write_oserror_too_large_emits_parse_failed(tmp_path: Path) -> None:
+    """OSError on cache write with text too large to inline emits parse-failed."""
+    inline_max = 10  # very small threshold so our text is "too large"
+    config = _make_config(
+        text_store_path=str(tmp_path),
+        inline_text_max_chars=inline_max,
+    )
+    source_ref = str(tmp_path / "large_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    large_text = "x" * (inline_max + 1)  # exceeds inline_max
+    assert len(large_text) >= inline_max
+
+    handler = HandlerKreuzbergParse(config=config)
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"file content"),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+        patch(
+            f"{_HANDLER_MOD}.write_cached_text",
+            side_effect=OSError("disk full"),
+        ),
+        patch(
+            f"{_HANDLER_MOD}.call_kreuzberg_extract",
+            AsyncMock(return_value=KreuzbergExtractResult(extracted_text=large_text)),
+        ),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="dev",
+            publish_callback=_cb,
+        )
+
+    # Cache write failed and text too large to inline → parse-failed
+    assert len(published) == 1
+    topic, payload = published[0]
+    assert "parse-failed" in topic
+    assert payload["error_code"] == "parse_error"
+    assert payload["source_url"] == source_ref
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_source_ref_path_traversal_emits_parse_failed(tmp_path: Path) -> None:
     """Path traversal attempt (source_ref outside document_root) emits parse-failed.
 

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -486,6 +486,59 @@ async def test_cache_write_oserror_too_large_emits_parse_failed(tmp_path: Path) 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_empty_env_prefix_uses_bare_topic_names(tmp_path: Path) -> None:
+    """env_prefix='' publishes to the bare topic name with no leading dot or prefix.
+
+    Validates the falsy-env_prefix branch at handler lines 184-193:
+        indexed_topic = config.publish_topic_indexed  (not f"dev.{...}")
+    """
+    config = _make_config(
+        text_store_path=str(tmp_path),
+        inline_text_max_chars=4096,
+    )
+    source_ref = str(tmp_path / "bare_topic_doc.md")
+    event = _make_discovered_event(source_ref=source_ref)
+
+    handler = HandlerKreuzbergParse(config=config)
+    published: list[tuple[str, dict[str, object]]] = []
+
+    async def _cb(topic: str, payload: dict[str, object]) -> None:
+        published.append((topic, payload))
+
+    with (
+        patch("pathlib.Path.read_bytes", return_value=b"# Hello\n"),
+        patch(f"{_HANDLER_MOD}.read_cached_text", return_value=None),
+        patch(f"{_HANDLER_MOD}.write_cached_text"),
+        patch(
+            f"{_HANDLER_MOD}.call_kreuzberg_extract",
+            AsyncMock(return_value=KreuzbergExtractResult(extracted_text="hello world")),
+        ),
+    ):
+        await handler.process_event(
+            event=event,
+            env_prefix="",
+            publish_callback=_cb,
+        )
+
+    assert len(published) == 1
+    topic, payload = published[0]
+
+    bare_indexed_topic = config.publish_topic_indexed
+    prefixed_indexed_topic = f"dev.{bare_indexed_topic}"
+
+    # Must publish to the bare topic — no prefix, no leading dot
+    assert topic == bare_indexed_topic, (
+        f"Expected bare topic {bare_indexed_topic!r}, got {topic!r}"
+    )
+    assert topic != prefixed_indexed_topic, (
+        f"Topic must not be prefixed with 'dev.', got {topic!r}"
+    )
+    assert not topic.startswith("."), f"Topic must not start with '.', got {topic!r}"
+    assert payload["parse_status"] == "ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_source_ref_path_traversal_emits_parse_failed(tmp_path: Path) -> None:
     """Path traversal attempt (source_ref outside document_root) emits parse-failed.
 


### PR DESCRIPTION
## Summary

- **Fixes OMN-2717 gap**: `document-indexed.v1` now has a producer — the new `KreuzbergParseEffect` node wires kreuzberg as the parsing handler
- Adds `kreuzberg-parser` Docker service (`ghcr.io/kreuzberg-dev/kreuzberg:core`) to `docker-compose.yml`
- New ONEX Effect node `nodes/kreuzberg_parse_effect` with full handler, contract, models, and HTTP client isolation
- Idempotency via `sha256(source_url + content_hash + parser_version)` — duplicate crawl emits no duplicate events
- Hard limits: 50 MB size guard (no kreuzberg call), 30 s timeout → `document-parse-failed.v1`
- Extracted text stored inline if < 4096 chars; `file://` pointer to `KREUZBERG_TEXT_STORE_PATH/<sha256>.txt` otherwise

## Architecture notes

- httpx is confined to `clients/client_kreuzberg.py` (transport boundary per ARCH-002); added to all three audit whitelists + `validate_http_imports.py`
- `ModelDocumentIndexedKreuzbergEvent` and `ModelDocumentParseFailedEvent` added to `models/crawl/`; existing `ModelDocumentIndexedEvent` (OMN-2717 debounce) is untouched

## Test plan

- [ ] `poetry run pytest tests/unit/ -m unit` — 703 passed (5 new kreuzberg unit tests)
- [ ] `poetry run pytest tests/integration/ -k "kreuzberg_extract or parse_failure or idempotent_crawl"` — 6 passed
- [ ] `poetry run ruff check src/ tests/` — clean
- [ ] `pre-commit run --all-files` — all 25 hooks pass

Closes OMN-2733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Integrated Kreuzberg document extraction service to process documents and extract plain text, with configurable size limits, timeout handling, automatic caching for idempotency, and detailed parse failure tracking with specific error codes.

**Chores**
* Added Docker Compose configuration for deploying the Kreuzberg parser service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->