### PR TITLE
docs(readme): infrastructure ownership + quick start for memory services [OMN-2784]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,55 @@
 - **Audit layer** — I/O audit logging via `audit/`
 - **Runtime plugin** — registered as `onex.domain_plugins` entry point (`PluginMemory`)
 
+## Infrastructure Ownership
+
+OmniMemory's `docker-compose.yml` owns the **memory-layer data services**. These are the services you need to run omnimemory locally:
+
+| Service | Container | Default Port | Purpose |
+|---------|-----------|--------------|---------|
+| Qdrant | `omnimemory-qdrant` | 6333 (HTTP), 6334 (gRPC) | Vector database for semantic memory |
+| Memgraph | `omnimemory-memgraph` | 7687 (Bolt), 7444 (HTTP) | Graph database for relationship/intent queries |
+| Valkey | `omnimemory-valkey` | 6379 | In-memory cache and session storage |
+| Kreuzberg | `omnimemory-kreuzberg-parser` | 8090 | Document text extraction service |
+
+**Not owned here** — these services are managed by other repositories:
+
+| Service | Owner Repository | Why |
+|---------|-----------------|-----|
+| Kafka / Redpanda | [`omnibase_infra`](https://github.com/OmniNode-ai/omnibase_infra) | Platform-wide event bus, shared by all services |
+| PostgreSQL | [`omnibase_infra`](https://github.com/OmniNode-ai/omnibase_infra) | Platform-wide relational database, shared by all services |
+
+If you need Kafka or Postgres, start the `omnibase_infra` stack first:
+```bash
+docker compose -f /path/to/omnibase_infra/docker/docker-compose.infra.yml up -d
+```
+
 ## Quick Start
+
+### Memory services only
+
+To run just the omnimemory data services (Qdrant, Memgraph, Valkey, Kreuzberg):
 
 ```bash
 git clone https://github.com/OmniNode-ai/omnimemory.git
 cd omnimemory
+
+# Start memory data services
+docker compose up -d
+
+# Verify all services are healthy
+docker compose ps
+```
+
+Default service ports (all configurable via `.env`):
+- Qdrant REST: `localhost:6333`
+- Memgraph Bolt: `localhost:7687`
+- Valkey: `localhost:6379`
+- Kreuzberg parser: `localhost:8090`
+
+### Install and run tests
+
+```bash
 uv sync
 uv run pytest tests/ -m unit
 ```


### PR DESCRIPTION
## Summary

- Adds **Infrastructure Ownership** section to README clarifying which services are managed by `omnimemory/docker-compose.yml` (Qdrant, Memgraph, Valkey, Kreuzberg) and which are explicitly NOT owned here (Kafka/Redpanda and PostgreSQL — both delegated to `omnibase_infra`)
- Expands **Quick Start** with a dedicated subsection showing how to bring up the memory data services via `docker compose up -d`, including default port reference
- Links to `omnibase_infra` for users who also need the platform event bus or relational database

## Changes

- `README.md`: New "Infrastructure Ownership" section with owned/not-owned tables; expanded Quick Start with docker compose instructions

## Test plan

- [ ] Verify rendered Markdown tables display correctly on GitHub
- [ ] Confirm all linked repository URLs resolve (`omnibase_infra`)
- [ ] Confirm default port numbers match `docker-compose.yml` service definitions

Fixes OMN-2784 (Part A — omnimemory README)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added infrastructure ownership documentation detailing service management across repositories.
  * Added quick-start guide for running memory data services using docker compose.
  * Added setup and testing instructions for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->