### PR TITLE
chore(deps): bump omnibase-core >=0.20.0, omnibase-spi >=0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core>=0.19.0,<0.20.0",
-    "omnibase-spi>=0.12.0,<0.13.0",
-    "omnibase-infra>=0.10.0,<0.11.0",
+    "omnibase-core>=0.20.0,<0.21.0",
+    "omnibase-spi>=0.13.0,<0.14.0",
+    "omnibase-infra>=0.11.0,<0.12.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1287,6 +1287,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1308,6 +1320,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+plugins = [
+    { name = "mdit-py-plugins" },
 ]
 
 [[package]]
@@ -1396,6 +1416,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -1724,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.19.0"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1737,14 +1769,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/1a/9c69f09a87bac6497ba18fc33850aeeb2d2924808cb4b34d2f627cf9a287/omnibase_core-0.19.0.tar.gz", hash = "sha256:42386806ef88f13f4fbbf85762192e58d2b95f6608fc15b19fa525b12a4384bb", size = 8876823, upload-time = "2026-02-23T18:18:03.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/35/67b203cee3d34b77df0c0f656c1ebc8a5a854839abc7cfbafb495f007562/omnibase_core-0.20.0.tar.gz", hash = "sha256:2998f2a49d319ebd3e1b5dfce1d3e0095a0fe4ea6e7975c82b97cf1b9cfd7f5c", size = 8985271, upload-time = "2026-02-25T20:24:42.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/12/4fb0111b051ab8df059566cc5ead6c0fd5f24032f04221ce5fb9cab723dd/omnibase_core-0.19.0-py3-none-any.whl", hash = "sha256:6a62d7acda2510a9df1eb728e6f4ff835cae696d189ee7efb5bcddeca07fdb71", size = 4880896, upload-time = "2026-02-23T18:17:54.733Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/1dea13206e97d66c5c142fe4bfd138c73c7b926bae170931e284c0f9159d/omnibase_core-0.20.0-py3-none-any.whl", hash = "sha256:ee24fb550c321893774958b28a62b38be61de53e056af09d58b24d2454b448c3", size = 4962836, upload-time = "2026-02-25T20:24:45.1Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1787,25 +1819,26 @@ dependencies = [
     { name = "sqlparse" },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "textual" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/1a/5e3e196153dda9429bc67c1d043b40c9f7450d2359d4b2ee302251076c3e/omnibase_infra-0.10.0.tar.gz", hash = "sha256:a0a020f0602a0332d5843d66afce8ce839f99c9278e9d384b50fe0455f60eda1", size = 5809892, upload-time = "2026-02-23T22:59:51.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/f4/495d92f3c05d12c2eb09d719dd822b9df2d0563188f5715c1b966a2342a2/omnibase_infra-0.11.0.tar.gz", hash = "sha256:bfdc772fd312a549ea604c3010c1edd4ab41710c7a4934da16f8e60c90b1279d", size = 5905583, upload-time = "2026-02-25T20:50:14.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/c1/5647446591b84e1f9246842c029217727183885ce428b457c7741902e2d5/omnibase_infra-0.10.0-py3-none-any.whl", hash = "sha256:7a799e11c97c22013f012b98b50d7108bb96e013234ae88e26ba32c950fad703", size = 3303968, upload-time = "2026-02-23T22:59:43.662Z" },
+    { url = "https://files.pythonhosted.org/packages/35/55/755c364ffd065f22bce79c676aa77ef4c401560e0ba1087a6ec78c8868a0/omnibase_infra-0.11.0-py3-none-any.whl", hash = "sha256:7faa014e35578d8d7e1f92d67b3578fc00e219650d9f70966f6a6c4d28d2eb64", size = 3447824, upload-time = "2026-02-25T20:50:11.929Z" },
 ]
 
 [[package]]
 name = "omnibase-spi"
-version = "0.12.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ec/9b30c33e76f607dc0c4e49ff19a2d46aaaa0dab3c8a9d7c9425287039bb1/omnibase_spi-0.12.0.tar.gz", hash = "sha256:ba7af890401c0020c992ba4cec956bfc45b786cff6d57f97e1d9fcab2d0864df", size = 1050970, upload-time = "2026-02-23T18:39:42.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/8b/7e0409a69b8db3bbf75ae2b43f485ced33573581ba8f8963aef1421410cd/omnibase_spi-0.13.0.tar.gz", hash = "sha256:6564657cf2437dd9cf86bcba8e8b9256087c340697df9b89d523e92c4ba2786a", size = 1067817, upload-time = "2026-02-25T20:24:32.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/1e/13c1b234cb4e209e062a2dbbd81abb6c572740366c7cfc3ea2bedfde0806/omnibase_spi-0.12.0-py3-none-any.whl", hash = "sha256:ee1a3c0922ccb73a51fe31daebf012ede897764009169e562791a4fbfb317dd8", size = 716375, upload-time = "2026-02-23T18:39:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/90/528affc42ff5d65e5c52d62c53a74d8a5d41f3ed98b8283ddf8c05041148/omnibase_spi-0.13.0-py3-none-any.whl", hash = "sha256:2c5cb2675cdbdee110e302478161aa1207a3485bc03f2adfec88c152ce6a3c79", size = 731775, upload-time = "2026-02-25T20:24:33.818Z" },
 ]
 
 [[package]]
@@ -1868,9 +1901,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = ">=0.19.0,<0.20.0" },
-    { name = "omnibase-infra", specifier = ">=0.10.0,<0.11.0" },
-    { name = "omnibase-spi", specifier = ">=0.12.0,<0.13.0" },
+    { name = "omnibase-core", specifier = ">=0.20.0,<0.21.0" },
+    { name = "omnibase-infra", specifier = ">=0.11.0,<0.12.0" },
+    { name = "omnibase-spi", specifier = ">=0.13.0,<0.14.0" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },
@@ -3263,6 +3296,22 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/30/38b615f7d4b16f6fdd73e4dcd8913e2d880bbb655e68a076e3d91181a7ee/textual-6.2.1.tar.gz", hash = "sha256:4699d8dfae43503b9c417bd2a6fb0da1c89e323fe91c4baa012f9298acaa83e1", size = 1570645, upload-time = "2025-10-01T16:11:24.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/93/02c7adec57a594af28388d85da9972703a4af94ae1399542555cd9581952/textual-6.2.1-py3-none-any.whl", hash = "sha256:3c7190633cd4d8bfe6049ae66808b98da91ded2edb85cef54e82bf77b03d2a54", size = 710702, upload-time = "2025-10-01T16:11:22.161Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3311,6 +3360,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Dependency bump

Updates upstream pins:
- `omnibase-core`: bumped to `>=0.20.0,<0.21.0`
- `omnibase-spi`: bumped to `>=0.13.0,<0.14.0`

**Draft** — waiting for omnibase_core v0.20.0 and omnibase_spi v0.13.0 to publish to PyPI. Un-draft and update uv.lock once packages are available.

## Related releases
- OmniNode-ai/omnibase_core#565
- OmniNode-ai/omnibase_spi#92