### PR TITLE
fix(omnimemory): make correlation_id Optional in ModelIntentClassifiedEvent [OMN-2841]

### DIFF
--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -25,7 +25,10 @@ class ModelIntentClassifiedEvent(BaseModel):
         "IntentClassified", description="Event type discriminator for message routing"
     )
     session_id: str = Field(..., min_length=1, description="Session identifier")
-    correlation_id: UUID = Field(..., description="Correlation ID for tracing")
+    correlation_id: UUID | None = Field(
+        default=None,
+        description="Correlation ID for tracing. Optional to match upstream ModelPatternLifecycleEvent (OMN-2841).",
+    )
     intent_category: str = Field(
         ..., min_length=1, description="Classified intent category"
     )

--- a/tests/models/events/test_model_intent_classified_event.py
+++ b/tests/models/events/test_model_intent_classified_event.py
@@ -98,6 +98,44 @@ class TestModelIntentClassifiedEventJsonDeserialization:
 
         assert event.keywords == ()
 
+    def test_accepts_null_correlation_id(self) -> None:
+        """Ensure null correlation_id is accepted (OMN-2841).
+
+        omniintelligence publishes ModelPatternLifecycleEvent with
+        correlation_id: UUID | None. This consumer must not fail when
+        the upstream omits correlation_id or sends null.
+        """
+        data = {
+            "event_type": "IntentClassified",
+            "session_id": "sess-null-corr",
+            "correlation_id": None,
+            "intent_category": "debugging",
+            "confidence": 0.9,
+            "timestamp": "2026-01-27T18:00:00+00:00",
+        }
+        event = ModelIntentClassifiedEvent.model_validate(data)
+
+        assert event.correlation_id is None
+        assert event.session_id == "sess-null-corr"
+
+    def test_accepts_absent_correlation_id(self) -> None:
+        """Ensure missing correlation_id defaults to None (OMN-2841).
+
+        If the upstream event omits the field entirely, deserialization
+        must succeed with correlation_id defaulting to None.
+        """
+        data = {
+            "event_type": "IntentClassified",
+            "session_id": "sess-no-corr",
+            "intent_category": "debugging",
+            "confidence": 0.88,
+            "timestamp": "2026-01-27T18:30:00+00:00",
+        }
+        event = ModelIntentClassifiedEvent.model_validate(data)
+
+        assert event.correlation_id is None
+        assert event.session_id == "sess-no-corr"
+
 
 @pytest.mark.unit
 class TestModelIntentClassifiedEventValidation:


### PR DESCRIPTION
## Summary

- `ModelIntentClassifiedEvent.correlation_id` was typed as `UUID` (required), but the upstream omniintelligence `ModelPatternLifecycleEvent` publishes `correlation_id: UUID | None` (optional with `default=None`)
- When omniintelligence emits an event with `correlation_id=null` or omits the field entirely, omnimemory deserialization was failing with a validation error
- Fix: change the consumer field to `UUID | None` with `default=None` to match the upstream contract
- No change required to omniintelligence — the producer already has the correct `UUID | None` typing

## Changes

- `src/omnimemory/models/events/model_intent_classified_event.py`: `correlation_id: UUID` → `UUID | None` with `default=None`
- `tests/models/events/test_model_intent_classified_event.py`: add `test_accepts_null_correlation_id` and `test_accepts_absent_correlation_id`

## Test plan

- [x] `pytest tests/models/events/test_model_intent_classified_event.py` — 10 passed (2 new tests added)
- [x] `pytest tests/unit/` — 943 passed, no regressions
- [x] `pre-commit run --all-files` — all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Correlation ID field is now optional in event models. Events can be created and processed without a correlation ID, improving compatibility with external event sources that may not provide this field and eliminating validation errors in such scenarios. This change enhances overall system flexibility when handling events from diverse operational sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->