### PR TITLE
fix(ci): add merge_queue trigger to prevent queue deadlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-  merge_queue:
+  merge_group:
   workflow_dispatch:
 
 # Cancel previous runs when new commits are pushed to save CI resources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  merge_queue:
   workflow_dispatch:
 
 # Cancel previous runs when new commits are pushed to save CI resources


### PR DESCRIPTION
## Summary

- Adds `merge_queue:` trigger to `test.yml` so GitHub's merge queue can fire required CI checks on `gh-readonly-queue/main/*` branches
- Without this trigger, the merge queue enters a permanent `AWAITING_CHECKS` deadlock because no workflow responds to the `merge_queue` event

## Test plan

- [ ] Verify the workflow runs on the next merge queue entry (check Actions tab for `gh-readonly-queue/main/*` branch runs)
- [ ] Confirm `Test Summary` (the required status check aggregator) reports green on merge queue branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run for merge-group events in addition to existing push, pull request, and manual triggers, ensuring automated checks also execute when changes are merged via the merge queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->