### PR TITLE
test(omn-1538): add contract topic validation tests for intent_query_effect

### DIFF
--- a/tests/unit/runtime/test_contract_topics.py
+++ b/tests/unit/runtime/test_contract_topics.py
@@ -492,3 +492,115 @@ class TestNoHardcodedTopics:
             "get_topic_suffixes should have been removed from "
             "RegistryIntentQueryEffect -- topics are now contract-driven"
         )
+
+    def test_registry_has_no_topic_string_constants(self) -> None:
+        """RegistryIntentQueryEffect must not define any topic string constants.
+
+        Topic strings must live in contract.yaml, not in Python registry code.
+        This validates OMN-1538 acceptance criterion: no hardcoded topic strings
+        in Python code.
+        """
+        import inspect
+
+        from omnimemory.nodes.intent_query_effect.registry import (
+            RegistryIntentQueryEffect,
+        )
+
+        source = inspect.getsource(RegistryIntentQueryEffect)
+        # Topic strings follow the pattern onex.<kind>.<service>.<event>.<version>
+        assert "onex.cmd." not in source, (
+            "Found hardcoded onex.cmd.* topic in RegistryIntentQueryEffect -- "
+            "topics must be declared in contract.yaml"
+        )
+        assert "onex.evt." not in source, (
+            "Found hardcoded onex.evt.* topic in RegistryIntentQueryEffect -- "
+            "topics must be declared in contract.yaml"
+        )
+
+
+# =============================================================================
+# Tests: OMN-1538 -- Topic validation at contract load time
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestContractTopicValidation:
+    """Validate that intent_query_effect contract topics conform to ONEX naming.
+
+    Acceptance criterion (OMN-1538, AC3): Topics validated against ONEX
+    convention at contract load time via ModelEventBusSubcontract.
+    """
+
+    def test_intent_query_effect_subscribe_topics_are_valid_onex_names(self) -> None:
+        """Subscribe topics in intent_query_effect contract must pass ONEX validation."""
+        from omnibase_core.validation import validate_topic_suffix
+
+        topics = collect_subscribe_topics_from_contracts(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        assert len(topics) >= 1, (
+            "intent_query_effect must declare at least 1 subscribe topic"
+        )
+        for topic in topics:
+            result = validate_topic_suffix(topic)
+            assert result.is_valid, (
+                f"Subscribe topic '{topic}' in intent_query_effect contract.yaml "
+                f"does not conform to ONEX naming convention: {result.error_message}"
+            )
+
+    def test_intent_query_effect_publish_topics_are_valid_onex_names(self) -> None:
+        """Publish topics in intent_query_effect contract must pass ONEX validation."""
+        from omnibase_core.validation import validate_topic_suffix
+
+        result = collect_publish_topics_for_dispatch(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        assert result, "intent_query_effect must declare at least 1 publish topic"
+        for _key, topic in result.items():
+            validation = validate_topic_suffix(topic)
+            assert validation.is_valid, (
+                f"Publish topic '{topic}' in intent_query_effect contract.yaml "
+                f"does not conform to ONEX naming convention: {validation.error_message}"
+            )
+
+    def test_intent_query_effect_subscribe_topic_is_cmd_kind(self) -> None:
+        """Subscribe topics for intent_query_effect must be .cmd. (command) topics."""
+        topics = collect_subscribe_topics_from_contracts(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        for topic in topics:
+            assert ".cmd." in topic, (
+                f"Subscribe topic '{topic}' must use .cmd. kind "
+                f"(intent_query_effect subscribes to commands)"
+            )
+
+    def test_intent_query_effect_publish_topic_is_evt_kind(self) -> None:
+        """Publish topics for intent_query_effect must be .evt. (event) topics."""
+        result = collect_publish_topics_for_dispatch(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        for _key, topic in result.items():
+            assert ".evt." in topic, (
+                f"Publish topic '{topic}' must use .evt. kind "
+                f"(intent_query_effect publishes response events)"
+            )
+
+    def test_intent_query_effect_subscribe_topic_has_omnimemory_domain(self) -> None:
+        """Subscribe topic must be in omnimemory domain."""
+        topics = collect_subscribe_topics_from_contracts(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        for topic in topics:
+            assert "omnimemory" in topic, (
+                f"Subscribe topic '{topic}' must be in the omnimemory domain"
+            )
+
+    def test_intent_query_effect_publish_topic_has_omnimemory_domain(self) -> None:
+        """Publish topic must be in omnimemory domain."""
+        result = collect_publish_topics_for_dispatch(
+            node_packages=["omnimemory.nodes.intent_query_effect"],
+        )
+        for _key, topic in result.items():
+            assert "omnimemory" in topic, (
+                f"Publish topic '{topic}' must be in the omnimemory domain"
+            )


### PR DESCRIPTION
## Summary

Closes OMN-1538 — migrate omnimemory to contract-driven topic declaration.

The contract migration itself was completed as part of OMN-2213 (contract-driven topic discovery for omnimemory). This PR closes the test gap for the OMN-1538 acceptance criteria.

**What was already done (OMN-2213):**
- `intent_query_effect/contract.yaml` declares `event_bus.publish_topics` and `event_bus.subscribe_topics` (single source of truth)
- `registry_intent_query_effect.py` has no hardcoded topic strings; `get_topic_suffixes()` removed
- `runtime/contract_topics.py` provides contract-driven topic discovery via `importlib.resources`
- All nodes included in `_OMNIMEMORY_EVENT_BUS_NODE_PACKAGES` for discovery

**What this PR adds:**
- `TestNoHardcodedTopics.test_registry_has_no_topic_string_constants` — asserts no `onex.cmd.*` / `onex.evt.*` strings exist in `RegistryIntentQueryEffect` source
- `TestContractTopicValidation` — 6 new tests that validate `intent_query_effect` contract topics against ONEX naming convention via `validate_topic_suffix` (OMN-1537), assert `.cmd.` / `.evt.` kind, and assert `omnimemory` domain membership

**Acceptance criteria satisfied:**
- [x] All node contracts declare `publish_topics` / `subscribe_topics`
- [x] No hardcoded topic strings in Python code
- [x] Topics validated against ONEX convention at contract load time
- [x] Tests use contract-declared topics

## Test plan

- [x] `uv run pytest tests/unit/runtime/test_contract_topics.py -v` — 59 passed
- [x] `uv run pytest tests/ -m unit` — 1058 passed
- [x] `pre-commit run --all-files` — all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for contract topic validation, ensuring proper naming conventions, topic type validation (commands vs events), and domain compliance verification.
  * Implements validation checks for topic string hardcoding and publish topic dispatch key mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->