### PR TITLE
chore(omnimemory): add AI-slop checker (Phase 2 rollout)

### DIFF
--- a/.github/required-checks.yaml
+++ b/.github/required-checks.yaml
@@ -14,7 +14,7 @@
 #
 # Applied via: gh api repos/OmniNode-ai/omnimemory/branches/main/protection -X PUT
 # Mode: strict (branch must be up-to-date before merging)
-# Total required checks: 10
+# Total required checks: 11
 
 required_checks:
   # -- Phase 1: Quick Validation (parallel, ~2-5 min) -------------------------
@@ -67,6 +67,13 @@ required_checks:
     conditional: true
     condition: "Skipped on fork PRs (forks may not have access to cross-repo checkout)"
     rationale: "Cross-repo architecture handshake with omnibase_core is current"
+
+  - name: "AI-Slop Pattern Check (strict, PR diff)"
+    workflow: test.yml
+    job_id: ai-slop-check
+    conditional: true
+    condition: "Skipped when no Python/Markdown files changed in the PR diff"
+    rationale: "Prevents AI-generated slop patterns from entering the codebase (OMN-2972)"
 
   # -- Phase 2: Full Test Suite ------------------------------------------------
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,4 +25,4 @@ jobs:
       #   - mypy             -> lint job (pre-push stage, not triggered here anyway)
       - uses: pre-commit/action@v3.0.1
         env:
-          SKIP: contract-linter,io-audit
+          SKIP: contract-linter,io-audit,check-ai-slop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,3 +433,30 @@ jobs:
             echo "Tests: $test"
             exit 1
           fi
+
+  ai-slop-check:
+    name: AI-Slop Pattern Check (strict, PR diff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compute changed Python/Markdown files vs PR base
+        id: changed
+        run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            git fetch origin "${{ github.base_ref }}" --no-tags --depth=1
+            FILES=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.py' '*.md' | tr '\n' ' ')
+          else
+            FILES=$(git diff --name-only HEAD~1 -- '*.py' '*.md' 2>/dev/null | tr '\n' ' ')
+          fi
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+      - name: Check changed files for AI-slop patterns (strict)
+        run: |
+          FILES="${{ steps.changed.outputs.files }}"
+          if [ -z "$FILES" ]; then exit 0; fi
+          python scripts/validation/check_ai_slop.py --strict $FILES

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -375,6 +375,13 @@ repos:
           found (add # onex-allow-internal-ip to suppress)" && exit 1 || exit 0'
         pass_filenames: false
         stages: [pre-commit]
+      - id: check-ai-slop
+        name: Check for AI-slop patterns
+        language: system
+        entry: uv run python scripts/validation/check_ai_slop.py
+        types_or: [python, markdown]
+        pass_filenames: true
+        stages: [pre-commit]
 
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]

--- a/scripts/validate_ci_precommit_alignment.py
+++ b/scripts/validate_ci_precommit_alignment.py
@@ -71,6 +71,8 @@ EXPECTED_ALIGNMENTS: list[tuple[str, str, str]] = [
     ),
     ("contract-linter", "contract-validation", "contract_linter"),
     ("io-audit", "io-audit", "io_audit"),
+    # AI-slop pattern checker
+    ("check-ai-slop", "ai-slop-check", "check_ai_slop.py"),
 ]
 
 

--- a/scripts/validation/check_ai_slop.py
+++ b/scripts/validation/check_ai_slop.py
@@ -156,11 +156,7 @@ class _DocstringVisitor(ast.NodeVisitor):
                 return SUPPRESSION_MARKER in lines[lineno - 1]
             return False
 
-        return (
-            _check(def_lineno)
-            or _check(docstring_lineno)
-            or _check(def_lineno - 1)
-        )
+        return _check(def_lineno) or _check(docstring_lineno) or _check(def_lineno - 1)
 
     # ------------------------------------------------------------------
     # Docstring checker
@@ -459,7 +455,9 @@ def main(argv: list[str] | None = None) -> int:
     # Filter by severity
     if not args.report:
         all_violations = [
-            v for v in all_violations if v.severity in (SEVERITY_ERROR, SEVERITY_WARNING)
+            v
+            for v in all_violations
+            if v.severity in (SEVERITY_ERROR, SEVERITY_WARNING)
         ]
 
     if args.json_output:

--- a/scripts/validation/check_ai_slop.py
+++ b/scripts/validation/check_ai_slop.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ONEX AI-Slop Pattern Checker
+
+This pre-commit hook and CI gate detects AI-generated boilerplate ("slop") patterns
+in Python and Markdown files. Uses AST analysis for docstring patterns and line-based
+regex for non-docstring patterns.
+
+Checks performed:
+- ERROR: sycophancy (sycophantic docstring openers: "Excellent", "Great", "Sure")
+- ERROR: rest_docstring (reST-style :param:, :type:, :returns:, :rtype:)
+- WARNING: boilerplate_docstring ("This module/class/function provides/implements/contains")
+- WARNING: step_narration ("# Step N:" comments)
+- WARNING: md_separator (four-or-more = signs used as markdown separators in docstrings)
+- INFO: obvious_comment (self-evident inline comments, report mode only)
+
+Suppression:
+    Add `# ai-slop-ok: reason` on:
+    - The def/class line
+    - The docstring's opening triple-quote line
+    - The line immediately preceding the def/class line
+
+Exit codes:
+    0 - No violations (or only INFO/WARNING in non-strict mode)
+    1 - ERROR violations found
+    2 - WARNING violations found (--strict mode only)
+
+Usage:
+    python scripts/validation/check_ai_slop.py [files...]
+    python scripts/validation/check_ai_slop.py --strict [files...]
+    python scripts/validation/check_ai_slop.py --report src/
+
+Linear ticket: OMN-2971
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+SEVERITY_ERROR = "ERROR"
+SEVERITY_WARNING = "WARNING"
+SEVERITY_INFO = "INFO"
+
+CHECK_SYCOPHANCY = "sycophancy"
+CHECK_REST_DOCSTRING = "rest_docstring"
+CHECK_BOILERPLATE_DOCSTRING = "boilerplate_docstring"
+CHECK_STEP_NARRATION = "step_narration"
+CHECK_MD_SEPARATOR = "md_separator"
+CHECK_OBVIOUS_COMMENT = "obvious_comment"
+
+SUPPRESSION_MARKER = "ai-slop-ok"
+
+# Sycophantic openers (case-insensitive, must be at start of docstring content)
+_SYCOPHANCY_RE = re.compile(
+    r"^\s*(Excellent|Great|Sure|Certainly|Absolutely|Of course|Happy to|"
+    r"I would be|Gladly|Wonderful|Perfect|Fantastic|Awesome)[!,. ]",
+    re.IGNORECASE,
+)
+
+# reST docstring markers
+_REST_RE = re.compile(r"^\s*:(param|type|returns?|rtype|raises?|var|ivar|cvar)\b")
+
+# Boilerplate "This <thing> provides/implements/contains/is responsible for"
+_BOILERPLATE_RE = re.compile(
+    r"^\s*This\s+(module|class|function|method|file|script|node|handler|service)"
+    r"\s+(provides?|implements?|contains?|is responsible for|handles?|manages?|offers?)",
+    re.IGNORECASE,
+)
+
+# Step narration: "# Step N:" or "# Step N -"
+_STEP_NARRATION_RE = re.compile(r"#\s*Step\s+\d+\s*[:\-]", re.IGNORECASE)
+
+# Markdown separator: 4+ = characters in a docstring line
+_MD_SEPARATOR_RE = re.compile(r"={4,}")
+
+
+class SlopViolation:
+    """A single AI-slop violation found in a file."""
+
+    def __init__(
+        self,
+        filename: str,
+        line: int,
+        check: str,
+        severity: str,
+        message: str,
+        source_line: str = "",
+    ) -> None:
+        self.filename = filename
+        self.line = line
+        self.check = check
+        self.severity = severity
+        self.message = message
+        self.source_line = source_line
+
+    def __repr__(self) -> str:
+        return (
+            f"SlopViolation({self.filename}:{self.line} [{self.severity}] "
+            f"{self.check}: {self.message})"
+        )
+
+    def format_line(self) -> str:
+        return (
+            f"{self.filename}:{self.line}: [{self.severity}] "
+            f"{self.check}: {self.message}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AST visitor — handles docstring patterns
+# ---------------------------------------------------------------------------
+
+
+class _DocstringVisitor(ast.NodeVisitor):
+    """
+    AST-based visitor that extracts docstrings from functions, classes, and
+    modules and checks them for AI-slop patterns.
+
+    Uses AST so that the opener line is correctly resolved even when the
+    triple-quote and the first content line are on different lines.
+    """
+
+    def __init__(self, filename: str, source_lines: list[str]) -> None:
+        self.filename = filename
+        self.source_lines = source_lines
+        self.violations: list[SlopViolation] = []
+
+    # ------------------------------------------------------------------
+    # Suppression helpers
+    # ------------------------------------------------------------------
+
+    def _has_suppression(self, def_lineno: int, docstring_lineno: int) -> bool:
+        """
+        Return True if any of the three suppression locations contain the
+        suppression marker:
+          1. The def/class line itself (1-indexed)
+          2. The docstring's opening triple-quote line
+          3. The line immediately preceding the def/class line
+        """
+        lines = self.source_lines
+        n = len(lines)
+
+        def _check(lineno: int) -> bool:
+            if 1 <= lineno <= n:
+                return SUPPRESSION_MARKER in lines[lineno - 1]
+            return False
+
+        return (
+            _check(def_lineno)
+            or _check(docstring_lineno)
+            or _check(def_lineno - 1)
+        )
+
+    # ------------------------------------------------------------------
+    # Docstring checker
+    # ------------------------------------------------------------------
+
+    def _check_docstring(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Module,
+        def_lineno: int,
+    ) -> None:
+        """Extract and check the docstring of a node."""
+        docstring = ast.get_docstring(node, clean=False)
+        if not docstring:
+            return
+
+        # Find the AST Constant node that IS the docstring
+        if not node.body:
+            return
+        first_stmt = node.body[0]
+        if not isinstance(first_stmt, ast.Expr):
+            return
+        if not isinstance(first_stmt.value, ast.Constant):
+            return
+        if not isinstance(first_stmt.value.value, str):
+            return
+
+        docstring_lineno: int = first_stmt.value.lineno  # opening triple-quote line
+
+        if self._has_suppression(def_lineno, docstring_lineno):
+            return
+
+        # Check each line of the docstring for patterns
+        doc_lines = docstring.splitlines()
+        for offset, doc_line in enumerate(doc_lines):
+            actual_lineno = docstring_lineno + offset
+
+            # Sycophancy (ERROR)
+            if _SYCOPHANCY_RE.match(doc_line):
+                self.violations.append(
+                    SlopViolation(
+                        filename=self.filename,
+                        line=actual_lineno,
+                        check=CHECK_SYCOPHANCY,
+                        severity=SEVERITY_ERROR,
+                        message=f"Sycophantic opener: {doc_line.strip()!r}",
+                        source_line=doc_line,
+                    )
+                )
+
+            # reST docstring (ERROR)
+            if _REST_RE.match(doc_line):
+                self.violations.append(
+                    SlopViolation(
+                        filename=self.filename,
+                        line=actual_lineno,
+                        check=CHECK_REST_DOCSTRING,
+                        severity=SEVERITY_ERROR,
+                        message=f"reST-style docstring marker: {doc_line.strip()!r}",
+                        source_line=doc_line,
+                    )
+                )
+
+            # Boilerplate opener (WARNING)
+            if _BOILERPLATE_RE.match(doc_line):
+                self.violations.append(
+                    SlopViolation(
+                        filename=self.filename,
+                        line=actual_lineno,
+                        check=CHECK_BOILERPLATE_DOCSTRING,
+                        severity=SEVERITY_WARNING,
+                        message=f"Boilerplate docstring opener: {doc_line.strip()!r}",
+                        source_line=doc_line,
+                    )
+                )
+
+            # Markdown separator (WARNING)
+            if _MD_SEPARATOR_RE.search(doc_line):
+                self.violations.append(
+                    SlopViolation(
+                        filename=self.filename,
+                        line=actual_lineno,
+                        check=CHECK_MD_SEPARATOR,
+                        severity=SEVERITY_WARNING,
+                        message=f"Markdown-style separator in docstring: {doc_line.strip()!r}",
+                        source_line=doc_line,
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # AST visit methods
+    # ------------------------------------------------------------------
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._check_docstring(node, 1)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_docstring(node, node.lineno)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._check_docstring(node, node.lineno)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._check_docstring(node, node.lineno)
+        self.generic_visit(node)
+
+
+# ---------------------------------------------------------------------------
+# Line-based checks (non-docstring patterns)
+# ---------------------------------------------------------------------------
+
+
+def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
+    """
+    Line-based regex checks for patterns that don't require AST analysis.
+    Only applies outside of docstrings (we use a simple heuristic: skip
+    lines inside triple-quoted strings by tracking quote depth).
+    """
+    violations: list[SlopViolation] = []
+
+    in_triple_quote = False
+    triple_char = ""
+
+    for lineno, line in enumerate(source_lines, start=1):
+        stripped = line.rstrip()
+
+        # Toggle triple-quote tracking (simple heuristic)
+        # Count occurrences of """ and '''
+        for tq in ('"""', "'''"):
+            count = stripped.count(tq)
+            if count:
+                if not in_triple_quote:
+                    if count % 2 == 1:
+                        in_triple_quote = True
+                        triple_char = tq
+                elif tq == triple_char:
+                    if count % 2 == 1:
+                        in_triple_quote = False
+                        triple_char = ""
+
+        if in_triple_quote:
+            continue
+
+        # Step narration: "# Step N:" outside docstrings
+        comment_match = re.search(r"#(.+)", stripped)
+        if comment_match:
+            comment_text = comment_match.group(0)
+            if _STEP_NARRATION_RE.search(comment_text):
+                # Check for suppression on this line
+                if SUPPRESSION_MARKER not in stripped:
+                    violations.append(
+                        SlopViolation(
+                            filename=filename,
+                            line=lineno,
+                            check=CHECK_STEP_NARRATION,
+                            severity=SEVERITY_WARNING,
+                            message=f"Step narration comment: {comment_text.strip()!r}",
+                            source_line=stripped,
+                        )
+                    )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# File-level checker
+# ---------------------------------------------------------------------------
+
+
+def check_file(filepath: str | Path) -> list[SlopViolation]:
+    """
+    Check a single Python file for AI-slop patterns.
+
+    Returns a list of SlopViolation instances (may be empty).
+    """
+    path = Path(filepath)
+    violations: list[SlopViolation] = []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [
+            SlopViolation(
+                filename=str(filepath),
+                line=0,
+                check="file_read",
+                severity=SEVERITY_ERROR,
+                message=f"Cannot read file: {exc}",
+            )
+        ]
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError as exc:
+        return [
+            SlopViolation(
+                filename=str(filepath),
+                line=exc.lineno or 0,
+                check="syntax_error",
+                severity=SEVERITY_ERROR,
+                message=f"Syntax error: {exc.msg}",
+            )
+        ]
+
+    source_lines = source.splitlines()
+
+    # AST-based docstring checks
+    visitor = _DocstringVisitor(filename=str(filepath), source_lines=source_lines)
+    visitor.visit(tree)
+    violations.extend(visitor.violations)
+
+    # Line-based checks (step narration, etc.)
+    violations.extend(_check_lines(str(filepath), source_lines))
+
+    # Sort by line number
+    violations.sort(key=lambda v: v.line)
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    Main entry point for the AI-slop checker.
+
+    Returns:
+        0 - No violations (or only WARNING/INFO in non-strict mode)
+        1 - ERROR violations found
+        2 - WARNING violations found (--strict mode only)
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Check Python/Markdown files for AI-slop patterns."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files or directories to check. When no files are given, exits 0.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat WARNING violations as blocking (exit code 2).",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Report mode: include INFO violations, scan directories recursively.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON.",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Collect files
+    files: list[Path] = []
+    for f in args.files:
+        p = Path(f)
+        if p.is_dir():
+            files.extend(p.rglob("*.py"))
+            if args.report:
+                files.extend(p.rglob("*.md"))
+        elif p.exists():
+            files.append(p)
+
+    all_violations: list[SlopViolation] = []
+    for filepath in files:
+        if filepath.suffix == ".py":
+            all_violations.extend(check_file(filepath))
+        # Markdown files: no AST checks, only line-based (step_narration)
+        elif filepath.suffix == ".md":
+            try:
+                source_lines = filepath.read_text(encoding="utf-8").splitlines()
+                all_violations.extend(_check_lines(str(filepath), source_lines))
+            except OSError as exc:
+                all_violations.append(
+                    SlopViolation(
+                        filename=str(filepath),
+                        line=0,
+                        check="file_read",
+                        severity=SEVERITY_ERROR,
+                        message=f"Cannot read file: {exc}",
+                    )
+                )
+
+    # Filter by severity
+    if not args.report:
+        all_violations = [
+            v for v in all_violations if v.severity in (SEVERITY_ERROR, SEVERITY_WARNING)
+        ]
+
+    if args.json_output:
+        import json
+
+        output: list[dict[str, str | int]] = [
+            {
+                "filename": v.filename,
+                "line": v.line,
+                "check": v.check,
+                "severity": v.severity,
+                "message": v.message,
+            }
+            for v in all_violations
+        ]
+        print(json.dumps(output, indent=2))
+    else:
+        for v in all_violations:
+            print(v.format_line(), file=sys.stderr)
+
+    has_errors = any(v.severity == SEVERITY_ERROR for v in all_violations)
+    has_warnings = any(v.severity == SEVERITY_WARNING for v in all_violations)
+
+    if has_errors:
+        return 1
+    if args.strict and has_warnings:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -570,7 +570,7 @@ class TestAlignmentCount:
         Update the expected count here when legitimately adding or removing
         alignment entries.
         """
-        expected_count = 17
+        expected_count = 18
         assert len(EXPECTED_ALIGNMENTS) == expected_count, (
             f"EXPECTED_ALIGNMENTS has {len(EXPECTED_ALIGNMENTS)} entries, "
             f"expected {expected_count}. If you added or removed entries, "


### PR DESCRIPTION
## Summary

Phase 2 rollout of the AI-slop checker infrastructure from OMN-2971.

- Copies `scripts/validation/check_ai_slop.py` from omnibase_core
- Adds `check-ai-slop` pre-commit hook for local development
- Adds `ai-slop-check` CI job (strict mode, PR diff only)

## What the checker does

Detects AI-generated boilerplate patterns in Python and Markdown:
- **ERROR**: Sycophantic docstring openers (Excellent, Great, Sure, Certainly...)
- **ERROR**: reST-style docstrings (`:param:`, `:type:`, `:returns:`)
- **WARNING**: Boilerplate openers ("This module provides/implements...")
- **WARNING**: Step narration comments ("# Step 1:")

Suppression: add `# ai-slop-ok: reason` to suppress false positives.

## Part of

OMN-2972 (Anti-AI-Slop Infrastructure Phase 2 — roll out to 7 repos)
Parent epic: OMN-2970

## CI behavior

The CI job runs in strict mode on changed files only (not full repo scan), so it won't block unrelated existing files.