### PR TITLE
docs(handler): replace Step N narration with intent comments [OMN-2973]

### DIFF
--- a/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -193,9 +193,7 @@ class HandlerKreuzbergParse:
         )
         now = datetime.now(tz=timezone.utc)
 
-        # ------------------------------------------------------------------
-        # Step 1: Validate source path is within document root
-        # ------------------------------------------------------------------
+        # Reject paths outside document_root before any filesystem access
         document_root = Path(config.document_root)
         if str(document_root) == "/":
             _log.warning(
@@ -226,11 +224,8 @@ class HandlerKreuzbergParse:
                 timeout_count=0,
             )
 
-        # ------------------------------------------------------------------
-        # Step 2: Idempotency check — skip re-parse if text already stored.
-        # This check uses only source_url (for the cache slug) and
-        # event.content_fingerprint, so no file read is required yet.
-        # ------------------------------------------------------------------
+        # Idempotency: skip kreuzberg call if we already have a matching cache entry.
+        # Cache lookup uses only source_url slug and content_fingerprint — no file read yet.
         slug = _source_url_slug(source_url)
         text_store = Path(config.text_store_path)
         text_path = text_store / f"{slug}.txt"
@@ -271,9 +266,7 @@ class HandlerKreuzbergParse:
                     timeout_count=0,
                 )
 
-        # ------------------------------------------------------------------
-        # Step 3: Read file bytes (deferred until after idempotency check)
-        # ------------------------------------------------------------------
+        # Deferred file read: only read bytes if idempotency check missed (cache cold or stale)
         try:
             file_bytes: bytes = await asyncio.to_thread(validated_path.read_bytes)
         except OSError as exc:
@@ -298,9 +291,7 @@ class HandlerKreuzbergParse:
                 timeout_count=0,
             )
 
-        # ------------------------------------------------------------------
-        # Step 4: Hard limit — too large
-        # ------------------------------------------------------------------
+        # Reject oversized documents before calling kreuzberg to avoid wasting HTTP bandwidth
         if len(file_bytes) > config.max_doc_bytes:
             _log.warning(
                 "Document too large for kreuzberg",
@@ -330,9 +321,6 @@ class HandlerKreuzbergParse:
                 timeout_count=0,
             )
 
-        # ------------------------------------------------------------------
-        # Step 5: Call kreuzberg POST /extract
-        # ------------------------------------------------------------------
         filename = validated_path.name
         mime_type = _detect_mime_type(source_url)
         timeout_seconds = config.timeout_ms / 1000.0
@@ -390,15 +378,9 @@ class HandlerKreuzbergParse:
                 timeout_count=0,
             )
 
-        # ------------------------------------------------------------------
-        # Step 6: Extract text from response
-        # ------------------------------------------------------------------
         extracted_text = result.extracted_text
 
-        # ------------------------------------------------------------------
-        # Step 7: Store text and compute extracted_text_ref
-        # ------------------------------------------------------------------
-        # Write cache for idempotency on next call (always, regardless of branch).
+        # Write cache for idempotency on next call regardless of inline vs file-ref branch.
         try:
             await asyncio.to_thread(
                 write_cached_text, text_path, content_hash, extracted_text
@@ -441,9 +423,6 @@ class HandlerKreuzbergParse:
                     timeout_count=0,
                 )
 
-        # ------------------------------------------------------------------
-        # Step 8: Emit document-indexed event
-        # ------------------------------------------------------------------
         document_id = _compute_document_id(
             source_url, content_hash, config.parser_version
         )

--- a/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
+++ b/src/omnimemory/nodes/memory_lifecycle_orchestrator/handlers/handler_memory_archive.py
@@ -856,7 +856,7 @@ class HandlerMemoryArchive:
                 ),
             )
 
-        # Step 1: Read memory content (with optimistic lock check)
+        # Read memory with optimistic lock check: returns None on revision mismatch
         try:
             memory = await self._read_memory(
                 command.memory_id,
@@ -932,7 +932,7 @@ class HandlerMemoryArchive:
                 ),
             )
 
-        # Step 2: Validate state - only EXPIRED memories can be archived
+        # Guard: only EXPIRED memories may be archived; reject any other lifecycle state
         if memory.lifecycle_state != EnumLifecycleState.EXPIRED:
             return ModelMemoryArchiveResult(
                 memory_id=command.memory_id,
@@ -943,7 +943,7 @@ class HandlerMemoryArchive:
                 ),
             )
 
-        # Step 3: Build archive record
+        # Build immutable archive record from memory snapshot before any I/O
         record = ModelArchiveRecord(
             memory_id=memory.id,
             content=memory.content,
@@ -955,17 +955,17 @@ class HandlerMemoryArchive:
             metadata=memory.metadata,
         )
 
-        # Step 4: Serialize and compress (offloaded to thread pool for large payloads)
+        # Offload compression to thread pool to avoid blocking the event loop on large payloads
         compressed_bytes = await self._serialize_for_archive_async(record)
 
-        # Step 5: Determine archive path
         archive_path = command.archive_path or self._get_archive_path(
             command.memory_id,
             now,
         )
 
-        # Step 5b: Validate archive path to prevent directory traversal attacks
-        # Custom paths must be within the allowed archive base directory
+        # Validate custom archive paths to prevent directory traversal attacks.
+        # Generated paths (via _get_archive_path) are always within the base; only
+        # caller-supplied paths need validation.
         if command.archive_path is not None:
             validation_error = self._validate_archive_path(command.archive_path)
             if validation_error is not None:
@@ -983,7 +983,7 @@ class HandlerMemoryArchive:
                     error_message=validation_error,
                 )
 
-        # Step 6: Write atomically
+        # Atomic write: temp file → fsync → rename (prevents partial/corrupt archives)
         try:
             bytes_written = await self._write_archive_atomic(
                 archive_path,
@@ -1005,7 +1005,7 @@ class HandlerMemoryArchive:
                 error_message=f"Archive write failed: {e}",
             )
 
-        # Step 7: Update database state
+        # Update DB state AFTER successful filesystem write — archive file is the source of truth
         try:
             updated = await self._mark_archived(
                 command.memory_id,


### PR DESCRIPTION
## Summary

Part of OMN-2973 (Phase 3: Anti-AI-Slop Remediation — Quick Wins).

Removes step-numbered banners from two omnimemory handler files and replaces with comments explaining WHY.

**handler_memory_archive.py** (Steps 1-7 in `execute_archive`):
- Step 1 → optimistic lock read returns None on revision mismatch
- Step 2 → guard: EXPIRED-only constraint explanation
- Step 3 → build immutable snapshot before any I/O
- Step 4 → offload compression to thread pool (avoid blocking event loop)
- Step 5/5b → archive path resolution and traversal prevention scope
- Step 6 → atomic write pattern (temp → fsync → rename)
- Step 7 → DB updated AFTER filesystem write (ordering rationale)

**handler_kreuzberg_parse.py** (Steps 1-8 + banner dividers in `process_event`):
- All `# --- Step N: Desc ---` banner blocks removed
- Replaced with rationale: path rejection before filesystem access, cache-before-parse ordering, deferred file read, bandwidth waste prevention

## Test plan

- [x] `uv run pytest tests/unit/nodes/test_kreuzberg_parse_effect/ tests/unit/nodes/test_memory_lifecycle_orchestrator/ -q` — 243 passed