### PR TITLE
release: omnimemory v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-02-28
+
+### Added
+- Contract topic validation tests for `intent_query_effect` (OMN-1538, #95)
+- AI-slop checker Phase 2 rollout (#97)
+
+### Changed
+- Replace omninode_bridge db references with omnimemory in docs (#96)
+- Replace Step N narration with intent comments in handler docs (#98)
+
+### Dependencies
+- `omnibase-core` bumped to >=0.22.0,<0.23.0 (was ==0.21.0)
+- `omnibase-spi` bumped to >=0.15.0,<0.16.0 (was ==0.14.0)
+- `omnibase-infra` bumped to >=0.13.0,<0.14.0 (was >=0.11.0,<0.12.0)
+- Removed `[tool.uv] override-dependencies` (no longer needed with omnibase-infra>=0.13.0)
+
 ## [0.6.0] - 2026-02-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.6.0"
+version = "0.6.1"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.21.0",
-    "omnibase-spi==0.14.0",
-    "omnibase-infra>=0.11.0,<0.12.0",
+    "omnibase-core>=0.22.0,<0.23.0",
+    "omnibase-spi>=0.15.0,<0.16.0",
+    "omnibase-infra>=0.13.0,<0.14.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -347,9 +347,4 @@ markers = [
 ]
 
 [tool.uv]
-override-dependencies = [
-    # omnibase-infra==0.11.0 caps these at <0.14.0 / <0.21.0; override to allow
-    # the pinned versions required by coordinated platform release release-20260227-eceed7
-    "omnibase-spi==0.14.0",
-    "omnibase-core==0.21.0",
-]
+# No override-dependencies needed — omnibase-infra>=0.13.0 now allows omnibase-core>=0.22.0 and omnibase-spi>=0.15.0.

--- a/src/omnimemory/__init__.py
+++ b/src/omnimemory/__init__.py
@@ -25,7 +25,7 @@ Usage:
     >>> # Use domain-specific models for memory operations
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "OmniNode-ai"
 __email__ = "contact@omninode.ai"
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,6 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
-[manifest]
-overrides = [
-    { name = "omnibase-core", specifier = "==0.21.0" },
-    { name = "omnibase-spi", specifier = "==0.14.0" },
-]
-
 [[package]]
 name = "aenum"
 version = "3.1.16"
@@ -1762,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1772,17 +1766,18 @@ dependencies = [
     { name = "dependency-injector" },
     { name = "httpx" },
     { name = "jsonschema" },
+    { name = "omnibase-spi" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/7b/0048cd126d25b5171d078ff7ee20af431d97ad625181d97a5eb07757b4e7/omnibase_core-0.21.0.tar.gz", hash = "sha256:6f15aba73e9da7df6a8341b2ea9f69f196c6a9e88af02937017e19c7b07956c1", size = 9127789, upload-time = "2026-02-27T15:30:41.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/8f/762e10b69fa910310a4521c16a50eb6400bb9c30b90613a4f03c175e759f/omnibase_core-0.22.0.tar.gz", hash = "sha256:b6b1d785d27088964c27546ee81b73cf4c0f257b472bee45fc433e8e816c5c95", size = 9137855, upload-time = "2026-03-01T01:20:12.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/2f/88610605739be6b464bac6df5e1911054e7abb1ca239efed246c69966858/omnibase_core-0.21.0-py3-none-any.whl", hash = "sha256:c17ad9789a7dac6d044c38f2a7cbd1f52a88325d2adf3294993fca8ceb45d2ab", size = 5089223, upload-time = "2026-02-27T15:30:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d6/9406adf0776ba0c58d80848b4e90344486482de2392b4e67cf55e000bd74/omnibase_core-0.22.0-py3-none-any.whl", hash = "sha256:8300b25cc5c61bc14fb377dee7aaa0caa77819a9f4920a211aa4a4d3880ea60a", size = 5091098, upload-time = "2026-03-01T01:20:10.06Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.11.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1828,28 +1823,28 @@ dependencies = [
     { name = "textual" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/f4/495d92f3c05d12c2eb09d719dd822b9df2d0563188f5715c1b966a2342a2/omnibase_infra-0.11.0.tar.gz", hash = "sha256:bfdc772fd312a549ea604c3010c1edd4ab41710c7a4934da16f8e60c90b1279d", size = 5905583, upload-time = "2026-02-25T20:50:14.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3b/edd95fa712f8ba95f097342ca40297161de2558a31f1ea602bdcdc8ab926/omnibase_infra-0.13.0.tar.gz", hash = "sha256:1a87691d465baf497504a61622a08406d8443207d4c5ee73223a0ad94f42efa9", size = 6097049, upload-time = "2026-03-01T02:25:56.728Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/55/755c364ffd065f22bce79c676aa77ef4c401560e0ba1087a6ec78c8868a0/omnibase_infra-0.11.0-py3-none-any.whl", hash = "sha256:7faa014e35578d8d7e1f92d67b3578fc00e219650d9f70966f6a6c4d28d2eb64", size = 3447824, upload-time = "2026-02-25T20:50:11.929Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1c/aaed69e3a7469315d1af90580f7148dd6e1d5f5b197a1ea847a3621090f0/omnibase_infra-0.13.0-py3-none-any.whl", hash = "sha256:c252069a04e9d6be8e7bab94543a9c265b55766a3974fd5560aa58541b70682c", size = 3593834, upload-time = "2026-03-01T02:25:59.084Z" },
 ]
 
 [[package]]
 name = "omnibase-spi"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/69/357eaec8435f96bac5b4c6e9186ea3292c8666975cef8d3b0af113c2cfc2/omnibase_spi-0.14.0.tar.gz", hash = "sha256:27d5789a78d27708f3f83a35228c48fa4eaab689e8ad31682729b0e83f615dca", size = 1070767, upload-time = "2026-02-27T14:54:19.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/53/cb1ff1f3fd19fa52f5324241d00c06fca2096bac2a151fb5bc51edef379e/omnibase_spi-0.15.0.tar.gz", hash = "sha256:12077a559032b819373ddf8073b33a5b1c80d7333b398b0d9ccd2b9b975d1009", size = 1113303, upload-time = "2026-03-01T00:01:46.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/3d/43301afa2adb30790c9f35919abab035499a915fced46190f72bb6113904/omnibase_spi-0.14.0-py3-none-any.whl", hash = "sha256:a1ba54d0840cd58008b6d93d804bb60e3ded37e9187e12730b82527ccd150dcc", size = 731827, upload-time = "2026-02-27T14:54:17.832Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/c9b2469692a6111c6c7aab23dbe55863adc6c7e084524098792c1614bd30/omnibase_spi-0.15.0-py3-none-any.whl", hash = "sha256:3082b4ef55c874dd4fd25b03bd5011ee9ef2b1c46521737196d985286f6b6046", size = 731825, upload-time = "2026-03-01T00:01:45.22Z" },
 ]
 
 [[package]]
 name = "omninode-memory"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1907,9 +1902,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.21.0" },
-    { name = "omnibase-infra", specifier = ">=0.11.0,<0.12.0" },
-    { name = "omnibase-spi", specifier = "==0.14.0" },
+    { name = "omnibase-core", specifier = ">=0.22.0,<0.23.0" },
+    { name = "omnibase-infra", specifier = ">=0.13.0,<0.14.0" },
+    { name = "omnibase-spi", specifier = ">=0.15.0,<0.16.0" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },


### PR DESCRIPTION
Coordinated release v0.6.1 — run release-20260228-a9b3f1. Patch bump: 2 commits including contract topic validation tests for intent_query_effect and docs update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rolled out AI-slop checker Phase 2.

* **Tests**
  * Added contract topic validation tests.

* **Documentation**
  * Updated documentation references and narration in handler guides.

* **Chores**
  * Updated dependencies to compatible version ranges.
  * Bumped version to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->