### PR TITLE
fix(OMN-3248): normalize intent_class/intent_category field split with model_validator

### DIFF
--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -5,13 +5,81 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from omnibase_core.enums.intelligence import EnumIntentClass
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Alias map: legacy ``intent_category`` values that don't directly match
+# ``EnumIntentClass`` string values. Applied when normalizing legacy wire payloads.
+# Values not in this map are tried directly against ``EnumIntentClass``; unknown
+# values fall back to ``_FALLBACK_INTENT_CLASS``.
+_INTENT_CLASS_ALIASES: dict[str, str] = {
+    "feat": "feature",
+    "feature_request": "feature",
+    "debugging": "bugfix",
+    "bug": "bugfix",
+    "refactoring": "refactor",
+    "code_generation": "feature",
+    "testing": "feature",
+    "architecture": "feature",
+    "api_design": "feature",
+    "devops": "configuration",
+    "database": "migration",
+    "quality_assessment": "analysis",
+    "semantic_analysis": "analysis",
+    "pattern_learning": "analysis",
+    "code_review": "analysis",
+    "explanation": "analysis",
+    "help": "analysis",
+    "clarify": "analysis",
+    "feedback": "analysis",
+    "unknown": "analysis",
+}
+
+# Fallback class when intent value cannot be resolved to any EnumIntentClass member
+_FALLBACK_INTENT_CLASS: EnumIntentClass = EnumIntentClass.ANALYSIS
+
+
+def _normalize_to_intent_class(raw: str) -> EnumIntentClass:
+    """Normalize a raw intent string to the nearest ``EnumIntentClass``.
+
+    Applies the alias map first, then attempts a direct ``EnumIntentClass``
+    lookup. Falls back to ``EnumIntentClass.ANALYSIS`` for unknown values.
+
+    Args:
+        raw: Casefold-stripped intent string from the wire payload.
+
+    Returns:
+        Resolved ``EnumIntentClass`` member.
+    """
+    normalized = _INTENT_CLASS_ALIASES.get(raw, raw)
+    try:
+        return EnumIntentClass(normalized)
+    except ValueError:
+        return _FALLBACK_INTENT_CLASS
 
 
 class ModelIntentClassifiedEvent(BaseModel):
     """Incoming event from omniintelligence intent classifier.
 
-    Note: Uses extra="ignore" to allow forward compatibility - if
+    Handles both the legacy wire format (``intent_category: str``) emitted by
+    older omniintelligence versions and the canonical format (``intent_class:
+    EnumIntentClass``) introduced in OMN-3248.
+
+    The ``normalize_intent_field`` model_validator runs before field validation
+    and ensures exactly one of the following is true after normalization:
+    - ``intent_class`` is present as a valid ``EnumIntentClass`` string value.
+
+    Resolution rules:
+    1. Both ``intent_class`` and ``intent_category`` present → canonical
+       ``intent_class`` wins; ``intent_category`` is discarded.
+    2. Only ``intent_category`` present → normalized via alias map, mapped to
+       the nearest ``EnumIntentClass`` value, and stored as ``intent_class``.
+    3. Only ``intent_class`` present → used as-is.
+
+    Handler rule: internal code uses ``event.intent_class`` (Enum);
+    emitted payloads use ``event.intent_class.value`` (string). No mixing.
+
+    Note: Uses ``extra="ignore"`` to allow forward compatibility — if
     omniintelligence adds new fields, this consumer won't reject them.
 
     TODO(OMN-future): Consider migrating to omnibase_core.models.events
@@ -29,8 +97,13 @@ class ModelIntentClassifiedEvent(BaseModel):
         default=None,
         description="Correlation ID for tracing. Optional to match upstream ModelPatternLifecycleEvent (OMN-2841).",
     )
-    intent_category: str = Field(
-        ..., min_length=1, description="Classified intent category"
+    intent_class: EnumIntentClass = Field(
+        ...,
+        description=(
+            "Canonical typed intent class (OMN-3248). Populated directly from the "
+            "``intent_class`` wire field (new format) or normalized from the legacy "
+            "``intent_category`` wire field. See ``normalize_intent_field`` for rules."
+        ),
     )
     confidence: float = Field(
         ..., ge=0.0, le=1.0, description="Classification confidence score"
@@ -46,3 +119,55 @@ class ModelIntentClassifiedEvent(BaseModel):
             "Aligns with omniintelligence ModelIntentClassifiedEnvelope.emitted_at."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_intent_field(cls, values: dict) -> dict:  # type: ignore[type-arg]
+        """Normalize the intent field from legacy ``intent_category`` to canonical ``intent_class``.
+
+        Applied before field validation so that both wire formats produce a valid
+        ``intent_class: EnumIntentClass`` value.
+
+        Resolution rules:
+        1. Both ``intent_class`` and ``intent_category`` present: canonical
+           ``intent_class`` wins; ``intent_category`` is discarded to prevent
+           silent corruption.
+        2. Only ``intent_category`` present: normalized via ``_INTENT_CLASS_ALIASES``,
+           then resolved against ``EnumIntentClass``; falls back to ANALYSIS.
+        3. Only ``intent_class`` present: passed through unchanged (Pydantic validates).
+
+        Args:
+            values: Raw incoming dict from the wire payload.
+
+        Returns:
+            Mutated dict with ``intent_category`` removed and ``intent_class``
+            set to a string value accepted by ``EnumIntentClass``.
+        """
+        has_class = "intent_class" in values
+        has_category = "intent_category" in values
+
+        if has_class and has_category:
+            # Canonical wins — discard legacy to prevent silent corruption
+            values.pop("intent_category")
+            return values
+
+        if has_category and not has_class:
+            raw = str(values.pop("intent_category")).casefold().strip()
+            if not raw:
+                raise ValueError(
+                    "intent_category must not be empty; "
+                    "provide a non-empty string or use intent_class directly"
+                )
+            values["intent_class"] = _normalize_to_intent_class(raw).value
+
+        return values
+
+    @property
+    def intent_category(self) -> str:
+        """Backward-compatible accessor returning the string value of ``intent_class``.
+
+        Allows existing code that reads ``event.intent_category`` to continue
+        working without modification. New code should read ``event.intent_class``
+        (Enum) directly. Emitted payloads should use ``event.intent_class.value``.
+        """
+        return self.intent_class.value

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -342,14 +342,18 @@ class HandlerIntentEventConsumer:
         """
         correlation_id: UUID | None = None
         session_id: str | None = None
-        intent_category: str | None = None
+        intent_category: str | None = (
+            None  # str value of intent_class, used at emission boundary
+        )
 
         try:
             # Parse the event
             event = ModelIntentClassifiedEvent.model_validate(message)
             correlation_id = event.correlation_id
             session_id = event.session_id
-            intent_category = event.intent_category
+            intent_category = (
+                event.intent_class.value
+            )  # Canonical: use .value at boundary
 
             logger.debug(
                 "Processing intent-classified event",
@@ -357,7 +361,7 @@ class HandlerIntentEventConsumer:
                     "handler": HANDLER_ID_INTENT_CONSUMER,
                     "correlation_id": str(correlation_id),
                     "session_id": session_id,
-                    "intent_category": intent_category,
+                    "intent_class": event.intent_class.value,
                 },
             )
 
@@ -380,7 +384,7 @@ class HandlerIntentEventConsumer:
                 if session_id and intent_category and correlation_id:
                     failed_event = ModelIntentStoredEvent.from_error(
                         session_ref=session_id,  # Map at boundary
-                        intent_category=intent_category,
+                        intent_category=intent_category,  # str value of intent_class
                         error_message="Circuit breaker open",
                         correlation_id=correlation_id,
                     )
@@ -414,7 +418,7 @@ class HandlerIntentEventConsumer:
                 # Maps session_id -> session_ref at the emission boundary
                 stored_event = ModelIntentStoredEvent.create(
                     session_ref=event.session_id,  # Map at boundary
-                    intent_category=event.intent_category,
+                    intent_category=event.intent_class.value,  # Canonical: .value at emission boundary
                     intent_id=result.intent_id,
                     confidence=event.confidence,
                     keywords=list(

--- a/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -296,7 +296,7 @@ class HandlerIntentEventConsumer:
         async handler. In production, use an event loop runner.
 
         Threading Model:
-            This method handles two scenarios:
+            Behaviour depends on whether a running event loop exists:
 
             1. **No running event loop** (e.g., called from a synchronous
                consumer thread): Creates a new event loop via ``asyncio.run()``.

--- a/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
+++ b/src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py
@@ -20,18 +20,21 @@ def map_event_to_storage_request(
 ) -> ModelIntentStorageRequest:
     """Map incoming classified event to storage request.
 
+    Uses ``event.intent_class.value`` (the canonical field) as the intent
+    category string for storage. ``EnumIntentClass`` values (e.g. ``"bugfix"``,
+    ``"feature"``) may not have a 1:1 match with ``EnumIntentCategory`` — unknown
+    values fall back to ``EnumIntentCategory.UNKNOWN`` for forward compatibility.
+
     Args:
         event: The incoming intent-classified event from omniintelligence.
 
     Returns:
         A storage request ready for HandlerIntentStorageAdapter.
-
-    Note:
-        Unknown intent_category values (from newer omniintelligence versions) are
-        mapped to EnumIntentCategory.UNKNOWN for forward compatibility.
     """
     try:
-        intent_category: EnumIntentCategory = EnumIntentCategory(event.intent_category)
+        intent_category: EnumIntentCategory = EnumIntentCategory(
+            event.intent_class.value  # Canonical: use .value at boundary (OMN-3248)
+        )
     except ValueError:
         intent_category = EnumIntentCategory.UNKNOWN
 

--- a/tests/models/events/test_model_intent_classified_event.py
+++ b/tests/models/events/test_model_intent_classified_event.py
@@ -10,6 +10,7 @@ from Kafka, where UUIDs and datetimes arrive as strings rather than native types
 import json
 
 import pytest
+from omnibase_core.enums.intelligence import EnumIntentClass
 
 from omnimemory.models.events.model_intent_classified_event import (
     ModelIntentClassifiedEvent,
@@ -42,7 +43,8 @@ class TestModelIntentClassifiedEventJsonDeserialization:
 
         assert str(event.correlation_id) == "550e8400-e29b-41d4-a716-446655440000"
         assert event.session_id == "sess-123"
-        assert event.intent_category == "debugging"
+        # "debugging" maps to EnumIntentClass.BUGFIX via _INTENT_CLASS_ALIASES (OMN-3248)
+        assert event.intent_class == EnumIntentClass.BUGFIX
         assert event.confidence == 0.85
         assert event.event_type == "IntentClassified"
 
@@ -192,3 +194,47 @@ class TestModelIntentClassifiedEventValidation:
         }
         with pytest.raises(ValueError):
             ModelIntentClassifiedEvent.model_validate(data)
+
+
+@pytest.mark.unit
+class TestModelIntentClassifiedEventFieldNormalization:
+    """Tests for OMN-3248: intent_class / intent_category field split and normalization."""
+
+    _BASE: dict[str, object] = {
+        "event_type": "IntentClassified",
+        "session_id": "sess-omn-3248",
+        "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
+        "confidence": 0.85,
+        "emitted_at": "2026-01-27T15:30:00+00:00",
+    }
+
+    def _payload(self, **extra: object) -> dict[str, object]:
+        return {**self._BASE, **extra}
+
+    def test_parses_canonical_intent_class(self) -> None:
+        """New wire format: ``intent_class`` present → parsed directly."""
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_class="feature")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE
+
+    def test_parses_legacy_intent_category(self) -> None:
+        """Legacy wire format: ``intent_category`` present → normalized to intent_class."""
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_category="feature")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE
+
+    def test_both_fields_canonical_wins(self) -> None:
+        """When both fields present, ``intent_class`` wins over ``intent_category``."""
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_class="feature", intent_category="bugfix")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE
+
+    def test_alias_normalization(self) -> None:
+        """Legacy alias ``feat`` maps to ``EnumIntentClass.FEATURE``."""
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_category="feat")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE

--- a/tests/models/test_frozen_boundary_models.py
+++ b/tests/models/test_frozen_boundary_models.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from omnibase_core.enums.intelligence import EnumIntentClass
 from omnibase_core.models.primitives import ModelSemVer
 from pydantic import BaseModel, ValidationError
 
@@ -188,7 +189,8 @@ class TestModelIntentClassifiedEventFrozen:
     def test_construction_succeeds(self) -> None:
         event = self._make_event()
         assert event.session_id == "sess-001"
-        assert event.intent_category == "debugging"
+        # "debugging" normalizes to EnumIntentClass.BUGFIX via alias map (OMN-3248)
+        assert event.intent_class == EnumIntentClass.BUGFIX
 
 
 @pytest.mark.unit

--- a/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
+++ b/tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 import pytest
+from omnibase_core.enums.intelligence import EnumIntentCategory, EnumIntentClass
 
 from omnimemory.models.events import ModelIntentClassifiedEvent
 from omnimemory.nodes.intent_event_consumer_effect.utils import (
@@ -35,7 +36,8 @@ class TestMapEventToStorageRequest:
         assert result.session_id == "session_123"
         assert result.correlation_id == UUID("550e8400-e29b-41d4-a716-446655440000")
         assert result.intent_data is not None
-        assert result.intent_data.intent_category == "debugging"
+        # "debugging" → EnumIntentClass.BUGFIX → "bugfix" → not in EnumIntentCategory → UNKNOWN (OMN-3248)
+        assert result.intent_data.intent_category == EnumIntentCategory.UNKNOWN
         assert result.intent_data.confidence == 0.85
         assert isinstance(result.intent_data.keywords, list)
         assert result.intent_data.keywords == []
@@ -77,8 +79,9 @@ class TestMapEventToStorageRequest:
         assert result.session_id == event.session_id
         assert result.correlation_id == event.correlation_id
         assert result.intent_data is not None
-        # intent_category is a str in the local ModelIntentClassificationOutput
-        assert result.intent_data.intent_category == event.intent_category
+        # "code_generation" → EnumIntentClass.FEATURE → "feature" → not in EnumIntentCategory → UNKNOWN (OMN-3248)
+        assert result.intent_data.intent_category == EnumIntentCategory.UNKNOWN
+        assert event.intent_class == EnumIntentClass.FEATURE
         assert result.intent_data.confidence == event.confidence
         assert result.intent_data.keywords == list(event.keywords)
 


### PR DESCRIPTION
## Summary

- Adds `model_validator(mode="before")` to `ModelIntentClassifiedEvent` that normalizes both the canonical `intent_class: EnumIntentClass` wire field (new format) and the legacy `intent_category: str` wire field (current omniintelligence format) to a single canonical `intent_class` at parse time
- Updates handler and `util_event_mapper` to use `event.intent_class` (Enum) internally and `event.intent_class.value` (str) at emission boundaries — never mixing the two
- Retains backward-compat `intent_category` property so callers continue working without updates
- Adds 4 unit tests: canonical parse, legacy parse, both-fields canonical-wins, alias normalization

## Resolution rules (model_validator)

1. Both `intent_class` + `intent_category` present → `intent_class` wins, `intent_category` discarded
2. Only `intent_category` present → normalized via alias map (`debugging→bugfix`, `feat→feature`, `code_generation→feature`, etc.) then resolved to `EnumIntentClass`; unknown values fall back to `ANALYSIS`
3. Only `intent_class` present → passed through unchanged

## Files changed

- `src/omnimemory/models/events/model_intent_classified_event.py` — model_validator + alias map + backward-compat property
- `src/omnimemory/nodes/intent_event_consumer_effect/handler_intent_event_consumer.py` — canonical `event.intent_class.value` at boundary
- `src/omnimemory/nodes/intent_event_consumer_effect/utils/util_event_mapper.py` — canonical `event.intent_class.value` at boundary
- `tests/models/events/test_model_intent_classified_event.py` — 4 new normalization tests + import update
- `tests/models/test_frozen_boundary_models.py` — updated assertion for renamed field
- `tests/nodes/intent_event_consumer_effect/test_util_event_mapper.py` — updated assertions for new mapping semantics

## Test plan

- [x] `uv run pytest tests/unit/ tests/models/ tests/nodes/intent_event_consumer_effect/ -m unit -q` → 831 passed, 0 failed
- [x] `pre-commit run --all-files` → all hooks pass

Closes OMN-3248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now use a canonical enum-based intent field with automatic normalization from legacy payloads.

* **Improvements**
  * Incoming intent data is normalized and validated before processing; legacy intent_category is exposed for backward compatibility.
  * Emitted events and telemetry use the canonical intent value.

* **Bug Fixes**
  * Empty legacy intent values are rejected to prevent ambiguous classifications.

* **Tests**
  * Expanded test coverage for normalization, aliasing, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->