### PR TITLE
build(deps): bump omnibase-core to >=0.23.0,<0.24.0 and omnibase-infra to >=0.15.0,<0.16.0 [OMN-3565]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-03-04
+
+### Dependencies
+- `omnibase-core` bumped to >=0.23.0,<0.24.0 (was >=0.22.0,<0.23.0) (OMN-3565)
+- `omnibase-infra` bumped to >=0.14.0,<0.15.0 (was >=0.13.0,<0.14.0) (OMN-3565)
+
 ## [0.6.1] - 2026-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 - `omnibase-core` bumped to >=0.23.0,<0.24.0 (was >=0.22.0,<0.23.0) (OMN-3565)
-- `omnibase-infra` bumped to >=0.14.0,<0.15.0 (was >=0.13.0,<0.14.0) (OMN-3565)
+- `omnibase-infra` bumped to >=0.15.0,<0.16.0 (was >=0.14.0,<0.15.0) (OMN-3565)
 
 ## [0.6.1] - 2026-02-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.6.1"
+version = "0.6.2"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core>=0.22.0,<0.23.0",
+    "omnibase-core>=0.23.0,<0.24.0",
     "omnibase-spi>=0.15.0,<0.16.0",
-    "omnibase-infra>=0.14.0,<0.15.0",
+    "omnibase-infra>=0.15.0,<0.16.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -347,4 +347,4 @@ markers = [
 ]
 
 [tool.uv]
-# No override-dependencies needed — omnibase-infra>=0.14.0 allows omnibase-core>=0.22.0 and omnibase-spi>=0.15.0.
+# No override-dependencies needed — omnibase-infra>=0.14.0 + omnibase-core>=0.23.0 resolve cleanly.

--- a/src/omnimemory/__init__.py
+++ b/src/omnimemory/__init__.py
@@ -25,7 +25,7 @@ Usage:
     >>> # Use domain-specific models for memory operations
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __author__ = "OmniNode-ai"
 __email__ = "contact@omninode.ai"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1756,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.22.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1770,14 +1770,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/8f/762e10b69fa910310a4521c16a50eb6400bb9c30b90613a4f03c175e759f/omnibase_core-0.22.0.tar.gz", hash = "sha256:b6b1d785d27088964c27546ee81b73cf4c0f257b472bee45fc433e8e816c5c95", size = 9137855, upload-time = "2026-03-01T01:20:12.275Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/6e/d44ecfe3f9fc85c08e39f950413e87645380da865a9cb79d721371bf1ace/omnibase_core-0.23.0.tar.gz", hash = "sha256:919928039fe804a6679c47318d499ec6b38916ad24c21b8378e5780ff244e1a7", size = 9147438, upload-time = "2026-03-03T17:31:16.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/d6/9406adf0776ba0c58d80848b4e90344486482de2392b4e67cf55e000bd74/omnibase_core-0.22.0-py3-none-any.whl", hash = "sha256:8300b25cc5c61bc14fb377dee7aaa0caa77819a9f4920a211aa4a4d3880ea60a", size = 5091098, upload-time = "2026-03-01T01:20:10.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e1/bfadc5bf65dd642ebc76df6e0194e9f0d2ec2a64f8472453a528631be97a/omnibase_core-0.23.0-py3-none-any.whl", hash = "sha256:3c4272a6017252132d23cd3273b6855c7193f2ed9cf77b29deaeebe36259e970", size = 5094157, upload-time = "2026-03-03T17:31:13.829Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1823,9 +1823,9 @@ dependencies = [
     { name = "textual" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/93/825706f4ba385c9b959070a8cf7c16bcdfa276aaeec099a0788fa9a93f28/omnibase_infra-0.14.0.tar.gz", hash = "sha256:baf378dce5f29cb9b9b5b19f01739951ac85b34b4e2e9fc1afc8b995e3d276cb", size = 6195010, upload-time = "2026-03-03T18:44:11.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ac/5db4e11b6612ebcdf2168b948d5c01c01647bb24f263b49a7cdc86b66592/omnibase_infra-0.15.0.tar.gz", hash = "sha256:8799f13cb04a38f7ca38c778a195bf9879c8fb4dc805f06e0df872b1f874c8ec", size = 6235605, upload-time = "2026-03-03T23:42:23.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/12/7b0f652eb20c52970d0599c95501c4c0feb5fdeac21881ae3b7358f51cf6/omnibase_infra-0.14.0-py3-none-any.whl", hash = "sha256:2a52e5e65286167586fd1eb45c9fcc8d30feed3a99a798f35dfd8d12f832f4b4", size = 3636286, upload-time = "2026-03-03T18:44:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/0c318a7766d75f7bd8274b142d182d73dd9d92e9c1055f8bdf112234bc61/omnibase_infra-0.15.0-py3-none-any.whl", hash = "sha256:43ce7f9a37014de7cec506f5246a956522ed8783118e1a52c52675239ac141c8", size = 3686742, upload-time = "2026-03-03T23:42:21.942Z" },
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1902,8 +1902,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = ">=0.22.0,<0.23.0" },
-    { name = "omnibase-infra", specifier = ">=0.14.0,<0.15.0" },
+    { name = "omnibase-core", specifier = ">=0.23.0,<0.24.0" },
+    { name = "omnibase-infra", specifier = ">=0.15.0,<0.16.0" },
     { name = "omnibase-spi", specifier = ">=0.15.0,<0.16.0" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
## Summary

- Bumps `omnibase-core` constraint: `>=0.22.0,<0.23.0` → `>=0.23.0,<0.24.0`
- Bumps `omnibase-infra` constraint: `>=0.14.0,<0.15.0` → `>=0.15.0,<0.16.0`
- Releases omnimemory **v0.6.2**

## Why

The `Kafka Boundary Compat (OMN-3256)` CI job in `omnibase_infra` installs omnibase_infra, omniintelligence, and omnimemory in one env to validate cross-repo Pydantic model round-trips. It was failing because:

```
omnibase-infra==0.15.0 requires omnibase-core>=0.23.0,<0.24.0
omninode-memory==0.6.1 requires omnibase-core>=0.22.0,<0.23.0
→ version conflict — cannot install both
```

This bumps omnimemory to align with the current omnibase-core 0.23.x generation.

## Test plan

- [x] `uv run pytest -m unit -q` — 1068 tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `uv lock` resolves cleanly with omnibase-core 0.23.x and omnibase-infra 0.15.x

Closes OMN-3565