### PR TITLE
fix(OMN-3248): normalize uppercase intent_class wire values in model_validator

### DIFF
--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -74,7 +74,10 @@ class ModelIntentClassifiedEvent(BaseModel):
        ``intent_class`` wins; ``intent_category`` is discarded.
     2. Only ``intent_category`` present → normalized via alias map, mapped to
        the nearest ``EnumIntentClass`` value, and stored as ``intent_class``.
-    3. Only ``intent_class`` present → used as-is.
+    3. Only ``intent_class`` present → casefolded and normalized via alias map
+       so that uppercase wire values (e.g. ``'FEATURE'`` from the legacy
+       omniintelligence enum) are accepted alongside the canonical lowercase
+       omnibase_core values (e.g. ``'feature'``).
 
     Handler rule: internal code uses ``event.intent_class`` (Enum);
     emitted payloads use ``event.intent_class.value`` (string). No mixing.
@@ -131,10 +134,15 @@ class ModelIntentClassifiedEvent(BaseModel):
         Resolution rules:
         1. Both ``intent_class`` and ``intent_category`` present: canonical
            ``intent_class`` wins; ``intent_category`` is discarded to prevent
-           silent corruption.
+           silent corruption. The retained ``intent_class`` value is still
+           casefolded so uppercase legacy values (e.g. ``'FEATURE'``) are
+           accepted.
         2. Only ``intent_category`` present: normalized via ``_INTENT_CLASS_ALIASES``,
            then resolved against ``EnumIntentClass``; falls back to ANALYSIS.
-        3. Only ``intent_class`` present: passed through unchanged (Pydantic validates).
+        3. Only ``intent_class`` present: casefolded and normalized via
+           ``_INTENT_CLASS_ALIASES`` so that uppercase wire values from the
+           legacy omniintelligence enum (e.g. ``'FEATURE'``) are accepted
+           alongside canonical lowercase omnibase_core values (``'feature'``).
 
         Args:
             values: Raw incoming dict from the wire payload.
@@ -147,8 +155,15 @@ class ModelIntentClassifiedEvent(BaseModel):
         has_category = "intent_category" in values
 
         if has_class and has_category:
-            # Canonical wins — discard legacy to prevent silent corruption
+            # Canonical wins — discard legacy to prevent silent corruption.
+            # Still casefold the retained value to handle uppercase legacy enums.
             values.pop("intent_category")
+            raw_class = str(values["intent_class"])
+            if hasattr(values["intent_class"], "value"):
+                raw_class = values["intent_class"].value  # type: ignore[union-attr]
+            values["intent_class"] = _normalize_to_intent_class(
+                raw_class.casefold().strip()
+            ).value
             return values
 
         if has_category and not has_class:
@@ -159,6 +174,17 @@ class ModelIntentClassifiedEvent(BaseModel):
                     "provide a non-empty string or use intent_class directly"
                 )
             values["intent_class"] = _normalize_to_intent_class(raw).value
+            return values
+
+        if has_class:
+            # Casefold to handle uppercase values from legacy omniintelligence enum
+            # (e.g. 'FEATURE' → 'feature') while preserving canonical lowercase values.
+            raw_class = str(values["intent_class"])
+            if hasattr(values["intent_class"], "value"):
+                raw_class = values["intent_class"].value  # type: ignore[union-attr]
+            values["intent_class"] = _normalize_to_intent_class(
+                raw_class.casefold().strip()
+            ).value
 
         return values
 

--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -160,7 +160,7 @@ class ModelIntentClassifiedEvent(BaseModel):
             values.pop("intent_category")
             raw_class = str(values["intent_class"])
             if hasattr(values["intent_class"], "value"):
-                raw_class = values["intent_class"].value  # type: ignore[union-attr]
+                raw_class = values["intent_class"].value
             values["intent_class"] = _normalize_to_intent_class(
                 raw_class.casefold().strip()
             ).value
@@ -181,7 +181,7 @@ class ModelIntentClassifiedEvent(BaseModel):
             # (e.g. 'FEATURE' → 'feature') while preserving canonical lowercase values.
             raw_class = str(values["intent_class"])
             if hasattr(values["intent_class"], "value"):
-                raw_class = values["intent_class"].value  # type: ignore[union-attr]
+                raw_class = values["intent_class"].value
             values["intent_class"] = _normalize_to_intent_class(
                 raw_class.casefold().strip()
             ).value

--- a/tests/models/events/test_model_intent_classified_event.py
+++ b/tests/models/events/test_model_intent_classified_event.py
@@ -238,3 +238,43 @@ class TestModelIntentClassifiedEventFieldNormalization:
             self._payload(intent_category="feat")
         )
         assert m.intent_class == EnumIntentClass.FEATURE
+
+    def test_uppercase_intent_class_normalized(self) -> None:
+        """Uppercase ``intent_class`` values from legacy omniintelligence enum are accepted.
+
+        The legacy omniintelligence local EnumIntentClass used uppercase values
+        (e.g. ``FEATURE = "FEATURE"``), while the canonical omnibase_core enum
+        uses lowercase (``FEATURE = "feature"``).  The model_validator must
+        casefold the wire value so both are accepted (OMN-3248 boundary fix).
+        """
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_class="FEATURE")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE
+
+    def test_all_uppercase_intent_class_values_normalized(self) -> None:
+        """All eight uppercase intent_class values from legacy wire format are accepted."""
+        cases: list[tuple[str, EnumIntentClass]] = [
+            ("REFACTOR", EnumIntentClass.REFACTOR),
+            ("BUGFIX", EnumIntentClass.BUGFIX),
+            ("FEATURE", EnumIntentClass.FEATURE),
+            ("ANALYSIS", EnumIntentClass.ANALYSIS),
+            ("CONFIGURATION", EnumIntentClass.CONFIGURATION),
+            ("DOCUMENTATION", EnumIntentClass.DOCUMENTATION),
+            ("MIGRATION", EnumIntentClass.MIGRATION),
+            ("SECURITY", EnumIntentClass.SECURITY),
+        ]
+        for wire_value, expected in cases:
+            m = ModelIntentClassifiedEvent.model_validate(
+                self._payload(intent_class=wire_value)
+            )
+            assert m.intent_class == expected, (
+                f"Expected {expected!r} for wire value {wire_value!r}, got {m.intent_class!r}"
+            )
+
+    def test_both_fields_canonical_wins_with_uppercase(self) -> None:
+        """When both fields present, uppercase ``intent_class`` wins and is normalized."""
+        m = ModelIntentClassifiedEvent.model_validate(
+            self._payload(intent_class="FEATURE", intent_category="bugfix")
+        )
+        assert m.intent_class == EnumIntentClass.FEATURE


### PR DESCRIPTION
## Summary

- Closes the remaining case-sensitivity gap left by #108: the legacy omniintelligence local enum used uppercase values (`FEATURE = "FEATURE"`) while omnibase_core uses lowercase (`FEATURE = "feature"`)
- The `normalize_intent_field` model_validator now applies `casefold` + `_normalize_to_intent_class` to **all three branches** (class-only, category-only, both-present), so `'FEATURE'`, `'feature'`, and legacy aliases all resolve correctly
- Adds 3 new unit tests covering uppercase normalization for all 8 enum members and the both-fields-present + uppercase case

## Context

PR #108 fixed the field-name split (`intent_class` vs `intent_category`) but did not handle the case mismatch. The `intent_class`-only path passed the value straight through to Pydantic, which rejected uppercase strings like `'FEATURE'` because `EnumIntentClass` (from omnibase_core) only accepts lowercase values.

This was caught by the Kafka boundary compat test in omnibase_infra (`test_kafka_boundary_compat.py`) which exercises the full producer→consumer round-trip. Removing the xfail on that test (follow-up PR in omnibase_infra) required this fix first.

## Test plan

- [x] All 17 existing + new unit tests pass (`TestModelIntentClassifiedEventFieldNormalization`)
- [x] Pre-commit passes (ruff, mypy, ONEX hooks)
- [x] omnibase_infra boundary compat test passes clean after this fix (verified locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event classification now accepts legacy uppercase values and consistently normalizes them while keeping canonical values authoritative when both fields are present.
  * Precedence when multiple classification fields are provided has been clarified and made more robust.

* **Tests**
  * Added tests covering uppercase legacy value normalization and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->