### PR TITLE
chore: add no-planning-docs pre-commit hook [OMN-3620]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -368,11 +368,9 @@ repos:
       - id: no-planning-docs
         name: Block planning docs (belong in omni_home/docs/plans/)
         entry: >
-          bash -c 'PLAN_FILES=$(git diff --cached --name-only -- "docs/plans/");
-          if [ -n "$PLAN_FILES" ]; then
-          echo "ERROR: Planning docs must live in omni_home/docs/plans/, not in this repo:";
-          echo "$PLAN_FILES"; echo "";
-          echo "Move your file to: /Volumes/PRO-G40/Code/omni_home/docs/plans/";
+          bash -c 'PLAN_FILES=$(git diff --cached --name-only -- "docs/plans/"); if [ -n "$PLAN_FILES"
+          ]; then echo "ERROR: Planning docs must live in omni_home/docs/plans/, not in this repo:"; echo
+          "$PLAN_FILES"; echo ""; echo "Move your file to: /Volumes/PRO-G40/Code/omni_home/docs/plans/";
           exit 1; fi'
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -365,6 +365,19 @@ repos:
         files: ^(src/omnimemory/nodes/|src/omnimemory/audit/)
         stages: [pre-commit]
 
+      - id: no-planning-docs
+        name: Block planning docs (belong in omni_home/docs/plans/)
+        entry: >
+          bash -c 'PLAN_FILES=$(git diff --cached --name-only -- "docs/plans/");
+          if [ -n "$PLAN_FILES" ]; then
+          echo "ERROR: Planning docs must live in omni_home/docs/plans/, not in this repo:";
+          echo "$PLAN_FILES"; echo "";
+          echo "Move your file to: /Volumes/PRO-G40/Code/omni_home/docs/plans/";
+          exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
       - id: no-internal-ips
         name: Block hardcoded internal IPs
         language: system

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -322,6 +322,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "debug-statements",
             "onex-validate-clean-root",
             "no-internal-ips",
+            "no-planning-docs",
         }
     )
 


### PR DESCRIPTION
## Summary
- Adds `no-planning-docs` pre-commit hook to `.pre-commit-config.yaml`
- Blocks commits that add files under `docs/plans/` (these belong in `omni_home/docs/plans/`)
- No false positives on existing files (verified with `pre-commit run --all-files`)

## Test plan
- [x] `pre-commit run no-planning-docs --all-files` passes on clean tree
- [x] No existing `docs/plans/` directory in repo

Closes OMN-3620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit check to block planning documentation placed in the repository’s tracked paths, preventing accidental commits.
  * Updated CI/test alignment to account for the new check.
  * Improves developer workflow validation to keep planning docs organized and reduce accidental misplacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->