### PR TITLE
ci: CI resilience fixes [OMN-3662]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -389,7 +389,7 @@ repos:
       - id: check-ai-slop
         name: Check for AI-slop patterns
         language: system
-        entry: uv run python scripts/validation/check_ai_slop.py
+        entry: uv run python scripts/validation/check_ai_slop.py --strict
         types_or: [python, markdown]
         pass_filenames: true
         stages: [pre-commit]


### PR DESCRIPTION
## Summary
- **Fix 1**: Add `--strict` to AI-slop pre-commit hook (OMN-3663)
- **Fix 3**: Verify/add Dependabot `github-actions` config (OMN-3665)

## Test plan
- [ ] Dependabot github-actions entry present
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for GitHub Actions with a limit of 5 open pull requests.
  * Enhanced pre-commit validation checks with stricter code quality enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->