### PR TITLE
OMN-3704: Add no-env-file pre-commit hook to omnimemory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -394,6 +394,27 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # --------------------------------------------------------------------------
+      # Environment File Protection (OMN-3695.5)
+      # Validates: No .env files staged (except .env.example)
+      # Purpose: Prevents accidental commits of .env files to the repository.
+      #          All environment config must go in ~/.omnibase/.env (shared single
+      #          source of truth across all repos).
+      # --------------------------------------------------------------------------
+      - id: no-env-file
+        name: Reject committed .env files (except .env.example)
+        entry: >
+          bash -c ' BLOCKED_FILES=$(git diff --cached --name-only | grep -E "(^|/)\\.env([._-].+)?$" |
+          grep -v "\\.env\\.example" || true); if [ -n "$BLOCKED_FILES" ]; then
+            echo "BLOCKED: .env file staged — use ~/.omnibase/.env instead. Run: git reset HEAD <file>";
+            echo "$BLOCKED_FILES";
+            exit 1;
+          fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -323,6 +323,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "onex-validate-clean-root",
             "no-internal-ips",
             "no-planning-docs",
+            "no-env-file",
         }
     )
 


### PR DESCRIPTION
## Summary

Add `no-env-file` pre-commit hook to prevent accidental commits of .env files.

## Changes

- Added no-env-file hook to .pre-commit-config.yaml
- Hook blocks staging of .env files (except .env.example)
- Enforces the shared single-source-of-truth principle: all environment config must use ~/.omnibase/.env
- Hook matches any .env variant patterns (.env_test, .env-custom, .env.production, etc.)

## Hook Details

The hook:
- Runs at pre-commit stage
- Checks git diff cached files for .env patterns
- Blocks files matching regex: `(^|/)\.env([._-].+)?$`
- Allows .env.example as a reference template
- Provides clear error message with fix instructions

## Testing

- All pre-commit hooks pass (28 checks)
- Verified hook correctly blocks .env variants
- Verified hook allows .env.example
- Hook loads and runs successfully

## Related Tickets

Closes #OMN-3695.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a repository safeguard that blocks staging of .env files (except .env.example) and reports any detected files to prevent accidental commits of sensitive environment data.
* **Tests**
  * Updated test coverage to recognize the new safeguard in the set of formatting/cleanup hooks so alignment checks treat it appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->