### PR TITLE
fix: relax ONEX version bounds (OMN-3710)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.6.2"
+version = "0.6.3"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core>=0.23.0,<0.24.0",
-    "omnibase-spi>=0.15.0,<0.16.0",
-    "omnibase-infra>=0.15.0,<0.16.0",
+    "omnibase-core>=0.23.0,<0.25.0",
+    "omnibase-spi>=0.15.0,<0.17.0",
+    "omnibase-infra>=0.15.0,<0.17.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)


### PR DESCRIPTION
## Summary
- Relaxes omnibase-core/spi/infra bounds to allow 2 minor bumps (`<0.25.0`/`<0.17.0`)
- Bumps version to 0.6.3

## Test plan
- [ ] `uv lock` succeeds
- [ ] CI passes

Closes OMN-3710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.3
  * Updated dependency constraints to support compatible package versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->