### PR TITLE
OMN-3834: add reinstall flags for ONEX internal deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       # SYNC: Pre-commit hook 'ruff-format' at pre-commit stage
       # Both pre-commit and CI use --check for consistent validation
@@ -138,7 +138,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       # SYNC: Pre-commit hook 'pyright-type-check' at pre-push stage
       # Uses pyrightconfig.json for project-level settings
@@ -159,7 +159,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       # SYNC: Pre-commit hook 'validate-pydantic-patterns' at pre-commit stage
       - name: Validate Pydantic patterns
@@ -251,7 +251,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       - name: Find and validate contract YAML files
         run: |
@@ -281,7 +281,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       - name: Run I/O audit
         run: uv run python -m omnimemory.audit
@@ -350,7 +350,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- Add `--reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra` to all `uv sync` steps in test.yml

## Why
Prevents stale UV cache from serving outdated versions of internal ONEX packages during CI runs.

## Test plan
- CI passes with fresh package resolution
- `uv sync` output shows downloaded packages

Part of Release Pipeline Resilience epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to optimize dependency installation process during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->