### PR TITLE
OMN-3831: replace hardcoded __version__ with importlib.metadata

### DIFF
--- a/src/omnimemory/__init__.py
+++ b/src/omnimemory/__init__.py
@@ -25,7 +25,13 @@ Usage:
     >>> # Use domain-specific models for memory operations
 """
 
-__version__ = "0.6.2"
+# Do not hardcode versions here; version is sourced from distribution metadata.
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("omninode-memory")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
 __author__ = "OmniNode-ai"
 __email__ = "contact@omninode.ai"
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "X.Y.Z"` with `importlib.metadata.version()` pattern
- Uses `PackageNotFoundError` fallback to `"0.0.0-dev"` for un-installed source checkouts
- Single source of truth: version now comes from `pyproject.toml` via distribution metadata

## Why
During v0.24.0 release, `pyproject.toml` was bumped but `__init__.py` was not, causing `version_compatibility.py` to see stale versions and failing CI for all downstream repos.

## Test plan
- `uv run python -c "import omnimemory; print(omnimemory.__version__)"` returns installed version
- `grep -r '__version__ = "' src/` returns only the `"0.0.0-dev"` fallback
- All existing tests pass

Part of Release Pipeline Resilience epic.