### PR TITLE
chore: relax omnibase-core constraint to >=0.24.0,<0.25.0 (unblocks OMN-4033)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.6.4"
+version = "0.6.5"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
@@ -59,7 +59,7 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.24.0",
+    "omnibase-core>=0.24.0,<0.25.0",
     "omnibase-spi==0.15.1",
     "omnibase-infra==0.16.0",
 

--- a/uv.lock
+++ b/uv.lock
@@ -1846,7 +1846,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1904,7 +1904,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.24.0" },
+    { name = "omnibase-core", specifier = ">=0.24.0,<0.25.0" },
     { name = "omnibase-infra", specifier = "==0.16.0" },
     { name = "omnibase-spi", specifier = "==0.15.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },


### PR DESCRIPTION
## Summary

- Relaxes `omnibase-core` version constraint from `==0.24.0` to `>=0.24.0,<0.25.0`
- Bumps package version from `0.6.4` to `0.6.5`
- Required to unblock OMN-4033 (remove duplicate EnumMessageCategory from omnibase_infra)

## Context

OMN-4033 removes the local `EnumMessageCategory` class from omnibase_infra and replaces it
with a re-export from `omnibase_core.enums`. This requires `omnibase-core==0.24.1` because:

1. `0.24.0` `from_topic()` uses substring matching that misses ONEX short topic forms (`evt`, `cmd`, `intent`)
2. `0.24.1` restores segment-based matching (released in OMN-4015 PR #619)

The infra-omnimemory Kafka boundary compat test installs both packages together. With infra
requiring `core==0.24.1` and omnimemory requiring `core==0.24.0` (exact pin), the test
installation fails. Using a range `>=0.24.0,<0.25.0` allows uv to resolve `0.24.1` when
both packages are co-installed.

## Test plan

- [ ] Omnimemory unit tests pass
- [ ] Infra Kafka Boundary Compat CI passes after this merges