### PR TITLE
fix(ci): skip contract validation on merge-queue branch names (OMN-4308)

### DIFF
--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -71,7 +71,19 @@ jobs:
           WORKFLOW_INPUT_BRANCH: ${{ inputs.branch-name }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          # merge_group events run on gh-readonly-queue/... branches with no PR head ref.
+          # Contract validation is not meaningful in this context — skip immediately.
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            echo "resolved_branch=" >> "$GITHUB_OUTPUT"
+            echo "skip_validation=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::merge_group event — contract validation skipped (validated on PR branch instead)."
+            exit 0
+          fi
+
+          echo "skip_validation=false" >> "$GITHUB_OUTPUT"
+
           # Prefer workflow_dispatch input, then PR head ref, then ref name
           if [[ -n "$WORKFLOW_INPUT_BRANCH" ]]; then
             BRANCH="$WORKFLOW_INPUT_BRANCH"
@@ -85,6 +97,7 @@ jobs:
 
       - name: Run contract validation
         id: validate-contract
+        if: steps.resolve-branch.outputs.skip_validation != 'true'
         uses: OmniNode-ai/onex_change_control/.github/actions/validate-contract@main
         with:
           branch-name: ${{ steps.resolve-branch.outputs.resolved_branch }}
@@ -95,7 +108,12 @@ jobs:
         env:
           TICKET_ID: ${{ steps.validate-contract.outputs.ticket-id }}
           VALIDATION_STATUS: ${{ steps.validate-contract.outputs.validation-status }}
+          SKIP_VALIDATION: ${{ steps.resolve-branch.outputs.skip_validation }}
         run: |
+          if [[ "$SKIP_VALIDATION" == "true" ]]; then
+            echo "::notice::Contract validation SKIPPED — merge_group event."
+            exit 0
+          fi
           case "$VALIDATION_STATUS" in
             passed)
               echo "::notice::Contract validation PASSED for ticket $TICKET_ID"


### PR DESCRIPTION
## Summary

Fixes Contract Validation CI failures when PRs enter the GitHub merge queue. When GitHub enqueues a PR, it renames the branch to `gh-readonly-queue/main/pr-NNN-<sha>`, which contains no `OMN-XXXX` ticket ID. The workflow was then calling the composite action with this branch name, resulting in a CI failure.

**Changes:**
- Detect `merge_group` event in the `resolve-branch` step and set `skip_validation=true`
- Guard the `validate-contract` step with `if: steps.resolve-branch.outputs.skip_validation != 'true'`
- Report step reads `SKIP_VALIDATION` env var and exits 0 immediately on merge-queue runs

Validation on the original PR branch (`pull_request` event) is fully unaffected.

**Root cause:** `omnibase_infra` already had this fix applied. This PR brings the remaining repos to parity.

Observed failing in OMN-4113 (PRs #630, #631, #632 in omnibase_core).

## Test plan

- [ ] Verify Contract Validation passes (skips) on a PR going through the merge queue
- [ ] Verify Contract Validation still validates correctly on a normal `pull_request` event with an OMN-XXXX branch name
- [ ] Verify Contract Validation still skips gracefully on a `pull_request` event with no ticket ID in the branch name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contract validation workflow with conditional skipping logic for merge group events, optimizing CI/CD pipeline execution time.
  * Introduced skip flags and early exit mechanisms in validation steps to prevent redundant processing.
  * Preserves complete validation coverage and existing behavior for all standard merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->