### PR TITLE
feat(migrations): add Dockerfile.migrate and CI workflow for omnimemory-migrate ECR image

### DIFF
--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+name: Build and push migration image to ECR
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deployment/docker/Dockerfile.migrate'
+      - 'deployment/database/migrations/**'
+      - '.github/workflows/build-and-push-migrate-image.yml'
+  workflow_dispatch:
+concurrency:
+  group: build-migrate-${{ github.ref }}
+  cancel-in-progress: false
+permissions:
+  id-token: write
+  contents: read
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REPOSITORY: omnimemory-migrate
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/omninode-github-actions-role
+          role-session-name: gha-build-migrate-omnimemory
+          aws-region: ${{ env.AWS_REGION }}
+      - run: aws sts get-caller-identity
+      - uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push
+        env:
+          IMAGE_URI: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          docker build -f deployment/docker/Dockerfile.migrate -t "${IMAGE_URI}:${COMMIT_SHA}" -t "${IMAGE_URI}:latest" .
+          docker push "${IMAGE_URI}:${COMMIT_SHA}"
+          docker push "${IMAGE_URI}:latest"

--- a/deployment/docker/Dockerfile.migrate
+++ b/deployment/docker/Dockerfile.migrate
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 OmniNode Team
+#
+# Dockerfile.migrate — omnimemory database migration image
+#
+# Ownership: omnimemory repo owns all migration SQL artifacts.
+# This image is pulled by the k8s/migrations/omnimemory-migrate.yaml
+# initContainer and used by the omnimemory migration Job.
+#
+# Build context: repo root (docker build -f deployment/docker/Dockerfile.migrate .)
+#
+# Note: omnimemory migrations are at deployment/database/migrations/ (no forward/ subdir).
+
+FROM alpine:3.19
+
+COPY deployment/database/migrations/*.sql /migrations/


### PR DESCRIPTION
Adds `deployment/docker/Dockerfile.migrate` and CI workflow for building the `omnimemory-migrate` ECR image. Part of cloud environment recovery Phase 2.