### PR TITLE
ci(omnimemory): rename test-summary aggregator to ci-summary (OMN-4502)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,12 @@ jobs:
   #
   # Phase 2 - Full Test Suite (after Phase 1 completes):
   #   - test: Run all tests (depends on lint, pyright, onex-validation)
-  #   Note: check-handshake runs independently and is evaluated in test-summary,
+  #   Note: check-handshake runs independently and is evaluated in ci-summary,
   #   NOT in test's needs, because it may be skipped on fork PRs and GitHub Actions
   #   propagates skipped status to dependent jobs.
   #
   # Phase 3 - Aggregation:
-  #   - test-summary: Aggregates all job results
+  #   - ci-summary: Aggregates all job results
   #
   # CONFIGURATION SYNC NOTE:
   # These validations are synchronized with .pre-commit-config.yaml
@@ -381,8 +381,8 @@ jobs:
           retention-days: 7
 
   # Phase 3 - Aggregation
-  test-summary:
-    name: Test Summary
+  ci-summary:
+    name: CI Summary
     runs-on: ubuntu-latest
     needs: [migration-freeze, lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, check-handshake, test]
     if: always()


### PR DESCRIPTION
## Summary

Renames the terminal CI aggregator job from `test-summary` / "Test Summary" to `ci-summary` / "CI Summary" in `.github/workflows/test.yml`.

- Job key: `test-summary:` → `ci-summary:`
- Display name: `"Test Summary"` → `"CI Summary"`
- Two comment references in the workflow header updated to match

Zero stale `test-summary` / `Test Summary` references remain after this change.

## Definition of Done

- [x] `test-summary` renamed to `ci-summary` in test.yml (job key + display name)
- [x] Zero stale `test-summary` / `Test Summary` references remain
- [ ] PR created and CI passes ← in progress
- [ ] Branch protection updated to `["CI Summary"]` after merge

## Post-merge: Branch Protection Update

After this PR merges, run:

```bash
gh api repos/OmniNode-ai/omnimemory/branches/main/protection \
  --method PUT --input - <<'BPEOF'
{
  "required_status_checks": {
    "strict": false,
    "checks": [{"context": "CI Summary", "app_id": 15368}]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null
}
BPEOF

gh api repos/OmniNode-ai/omnimemory/branches/main/protection \
  --jq '.required_status_checks.checks | map(.context)'
# Expected: ["CI Summary"]
```

Closes OMN-4502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration with renamed job labels and aggregation references (test-summary → ci-summary).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->