### PR TITLE
chore(hooks): add remote stub detection hook; annotate deferred stubs with stub-ok [OMN-4472]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@
 repos:
   # Stub implementation detection — sourced from omnibase_core (OMN-4472)
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: 30a06f85bb5849902d33c8d0bdb90fc6cba0c346
+    rev: 30a06f85bb5849902d33c8d0bdb90fc6cba0c346  # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
   # YAML formatting (standard across ecosystem)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,11 @@
 #   pre-commit run --all-files --hook-stage pre-push  # Run pre-push hooks
 
 repos:
+  # Stub implementation detection — sourced from omnibase_core (OMN-4472)
+  - repo: https://github.com/OmniNode-ai/omnibase_core
+    rev: 30a06f85bb5849902d33c8d0bdb90fc6cba0c346
+    hooks:
+      - id: check-stub-implementations
   # YAML formatting (standard across ecosystem)
   # Configuration in .yamlfmt file (ecosystem-aligned settings)
   - repo: https://github.com/google/yamlfmt

--- a/scripts/validation/validate_naming.py
+++ b/scripts/validation/validate_naming.py
@@ -356,7 +356,7 @@ def detect_expected_prefix_from_bases(
     return None, None
 
 
-def validate_file(filepath: Path) -> list[Violation]:
+def validate_file(filepath: Path) -> list[Violation]:  # stub-ok: docstring uses ModelXxx/ServiceXxx as naming examples, not TODO markers
     """Validate a single Python file.
 
     Validates:

--- a/scripts/validation/validate_secrets.py
+++ b/scripts/validation/validate_secrets.py
@@ -306,7 +306,7 @@ def _check_line_level_skip_patterns(
     return False, None
 
 
-def _check_skip_patterns(
+def _check_skip_patterns(  # stub-ok: docstring uses 'xxxx' as example secret string, not a FIXME marker
     line: str,
     patterns: list[tuple[re.Pattern[str], str]],
     filepath: Path,

--- a/src/omnimemory/enums/enum_error_code.py
+++ b/src/omnimemory/enums/enum_error_code.py
@@ -31,15 +31,21 @@ except ImportError:
 
         def get_component(self) -> str:
             """Get the component identifier for this error code."""
-            raise NotImplementedError("Subclasses must implement get_component()")
+            raise NotImplementedError(  # stub-ok: abstract-base-fallback
+                "Subclasses must implement get_component()"
+            )
 
         def get_number(self) -> int:
             """Get the numeric identifier for this error code."""
-            raise NotImplementedError("Subclasses must implement get_number()")
+            raise NotImplementedError(  # stub-ok: abstract-base-fallback
+                "Subclasses must implement get_number()"
+            )
 
         def get_description(self) -> str:
             """Get a human-readable description for this error code."""
-            raise NotImplementedError("Subclasses must implement get_description()")
+            raise NotImplementedError(  # stub-ok: abstract-base-fallback
+                "Subclasses must implement get_description()"
+            )
 
         def get_exit_code(self) -> int:
             """Get the appropriate CLI exit code for this error."""

--- a/src/omnimemory/handlers/adapters/adapter_valkey.py
+++ b/src/omnimemory/handlers/adapters/adapter_valkey.py
@@ -449,7 +449,9 @@ class AdapterValkey:
         """
         return f"{self._config.key_prefix}{key}"
 
-    async def _ensure_awaited(self, result: _T | Awaitable[_T]) -> _T:
+    async def _ensure_awaited(  # stub-ok: redis-py-awaitable-helper-deferred
+        self, result: _T | Awaitable[_T]
+    ) -> _T:
         """Ensure a Redis result is awaited if it's an awaitable.
 
         **Why This Helper Exists**

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -389,7 +389,7 @@ class PluginMemory:
                 duration_seconds=duration,
             )
 
-    async def wire_dispatchers(
+    async def wire_dispatchers(  # stub-ok: dispatcher-wiring-todo-deferred
         self,
         config: ModelDomainPluginConfig,
     ) -> ModelDomainPluginResult:

--- a/src/omnimemory/tools/stubs/contract_validator.py
+++ b/src/omnimemory/tools/stubs/contract_validator.py
@@ -67,7 +67,7 @@ class ProtocolContractValidator:
         "orchestrator_generic": (),
     }
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # stub-ok: contract-validator-stub-init
         """Initialize the contract validator."""
 
     def validate_contract_file(

--- a/src/omnimemory/utils/observability.py
+++ b/src/omnimemory/utils/observability.py
@@ -1107,7 +1107,7 @@ class MetricsRegistry:
 
             return cls._instance
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # stub-ok: singleton-noop-init-by-design
         """No-op init - all initialization done in __new__ under lock."""
         # Initialization is done in __new__ to ensure thread safety
 

--- a/src/omnimemory/utils/pii_detector.py
+++ b/src/omnimemory/utils/pii_detector.py
@@ -83,7 +83,9 @@ class PIIDetector:
         )
         return pattern
 
-    def _initialize_patterns(self) -> dict[PIIType, list[ModelPIIPatternConfig]]:
+    def _initialize_patterns(  # stub-ok: pii-url-person-address-deferred
+        self,
+    ) -> dict[PIIType, list[ModelPIIPatternConfig]]:
         """Initialize regex patterns for different PII types using configuration.
 
         Note: The following PIIType values do NOT have patterns implemented:
@@ -196,7 +198,9 @@ class PIIDetector:
             ],
         }
 
-    def _load_common_names(self) -> set[str]:
+    def _load_common_names(  # stub-ok: pii-person-name-detection-deferred
+        self,
+    ) -> set[str]:
         """Load common first and last names for person name detection.
 
         TODO: This name database is loaded but not actively used for detection.

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -327,6 +327,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "validate-string-versions",
             "no-hardcoded-bolt-fallback",
             "validate-spdx-headers",
+            "check-stub-implementations",
         }
     )
 


### PR DESCRIPTION
## Summary

- Adds `check-stub-implementations` remote hook from `omnibase_core` (pinned to `30a06f85bb5849902d33c8d0bdb90fc6cba0c346`)
- Annotates 9 legitimately deferred stubs with `# stub-ok: <reason>` across 6 files
- Part of OMN-4470 (ONEX Stub Resolution — Full Platform)

## Files Changed

- `.pre-commit-config.yaml` — add remote hook block
- `enums/enum_error_code.py` — abstract base fallback stubs
- `handlers/adapters/adapter_valkey.py` — redis-py awaitable helper
- `runtime/plugin.py` — dispatcher wiring deferred
- `tools/stubs/contract_validator.py` — stub contract validator init
- `utils/observability.py` — singleton noop init by design
- `utils/pii_detector.py` — PII URL/person/address detection deferred

## Risk

Low. Only adds `# stub-ok` comments and a pre-commit hook config entry. No logic changes.

## Test Evidence

```
✅ Stub Implementation Check PASSED — Checked 297 file(s) - no stub implementations found
✅ pre-commit run check-stub-implementations --all-files — PASSED (remote hook)
✅ All other pre-commit hooks — PASSED
```

## Rollback

Revert `.pre-commit-config.yaml` — remove the hook block. No code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pre-commit hook to detect stub implementations, improving code quality checks.
  * Added inline annotations across several modules to document deferred work and clarify intent for developers.
* **Tests**
  * Updated test expectations to exclude the new stub-detection hook from alignment checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->