### PR TITLE
feat(models): add ModelHandlerQdrantConfig; rename use_mock_handlers -> use_stub_handlers [OMN-4474]

### DIFF
--- a/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
@@ -140,9 +140,9 @@ class HandlerMemoryRetrieval:
             if self._initialized:
                 return
 
-            if self._config.use_mock_handlers:
-                # Initialize mock handlers
-                self._qdrant_handler = HandlerQdrantMock(self._config.qdrant_config)
+            if self._config.use_stub_handlers:
+                # Initialize stub (mock) handlers
+                self._qdrant_handler = HandlerQdrantMock(self._config.qdrant_mock_config)
                 self._db_handler = HandlerDbMock(self._config.db_config)
                 self._graph_handler = HandlerGraphMock(self._config.graph_config)
 
@@ -152,11 +152,11 @@ class HandlerMemoryRetrieval:
                     self._graph_handler.initialize(),
                 )
 
-                logger.info("Memory retrieval handler initialized with mock handlers")
+                logger.info("Memory retrieval handler initialized with stub handlers")
             else:
-                # TODO: Initialize real handlers from omnibase_infra
+                # stub-ok: OMN-4475 — HandlerQdrant production wiring deferred to Task 5
                 raise NotImplementedError(
-                    "Real handlers not yet implemented. Set use_mock_handlers=True"
+                    "Production handlers not yet implemented. Set use_stub_handlers=True"
                 )
 
             self._initialized = True

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
@@ -142,7 +142,9 @@ class HandlerMemoryRetrieval:
 
             if self._config.use_stub_handlers:
                 # Initialize stub (mock) handlers
-                self._qdrant_handler = HandlerQdrantMock(self._config.qdrant_mock_config)
+                self._qdrant_handler = HandlerQdrantMock(
+                    self._config.qdrant_mock_config
+                )
                 self._db_handler = HandlerDbMock(self._config.db_config)
                 self._graph_handler = HandlerGraphMock(self._config.graph_config)
 

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/__init__.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/__init__.py
@@ -15,6 +15,7 @@ from .model_embedding_client_config import ModelEmbeddingClientConfig
 from .model_handler_db_mock_config import ModelHandlerDbMockConfig
 from .model_handler_graph_mock_config import ModelHandlerGraphMockConfig
 from .model_handler_memory_retrieval_config import ModelHandlerMemoryRetrievalConfig
+from .model_handler_qdrant_config import ModelHandlerQdrantConfig
 from .model_handler_qdrant_mock_config import ModelHandlerQdrantMockConfig
 from .model_memory_retrieval_request import ModelMemoryRetrievalRequest
 from .model_memory_retrieval_response import (
@@ -32,5 +33,6 @@ __all__ = [
     "ModelHandlerDbMockConfig",
     "ModelHandlerGraphMockConfig",
     "ModelHandlerMemoryRetrievalConfig",
+    "ModelHandlerQdrantConfig",
     "ModelHandlerQdrantMockConfig",
 ]

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
@@ -8,14 +8,20 @@ HandlerMemoryRetrieval.
 
 .. versionadded:: 0.1.0
     Initial implementation for OMN-1387.
+.. versionchanged:: 0.1.0
+    OMN-4474: renamed use_mock_handlers -> use_stub_handlers; added
+    qdrant_config field for production Qdrant handler configuration.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .model_handler_db_mock_config import ModelHandlerDbMockConfig
 from .model_handler_graph_mock_config import ModelHandlerGraphMockConfig
+from .model_handler_qdrant_config import ModelHandlerQdrantConfig
 from .model_handler_qdrant_mock_config import ModelHandlerQdrantMockConfig
 
 __all__ = [
@@ -27,18 +33,28 @@ class ModelHandlerMemoryRetrievalConfig(BaseModel):
     """Configuration for the memory retrieval handler.
 
     Attributes:
-        qdrant_config: Configuration for the Qdrant handler.
+        qdrant_config: Production Qdrant handler configuration. Required when
+            use_stub_handlers is False.
+        qdrant_mock_config: Configuration for the mock Qdrant handler (used
+            when use_stub_handlers is True).
         db_config: Configuration for the Database handler.
         graph_config: Configuration for the Graph handler.
-        use_mock_handlers: Whether to use mock handlers. When False, real
-            handlers from omnibase_infra will be used (not yet implemented).
+        use_stub_handlers: Whether to use stub (mock) handlers. When False,
+            production handlers are used and qdrant_config must be provided.
+
+    Raises:
+        ValueError: If use_stub_handlers is False but qdrant_config is not provided.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    qdrant_config: ModelHandlerQdrantMockConfig = Field(
+    qdrant_config: ModelHandlerQdrantConfig | None = Field(
+        default=None,
+        description="Production Qdrant handler config — required when use_stub_handlers=False",
+    )
+    qdrant_mock_config: ModelHandlerQdrantMockConfig = Field(
         default_factory=ModelHandlerQdrantMockConfig,
-        description="Configuration for Qdrant semantic search handler",
+        description="Mock Qdrant handler config — used when use_stub_handlers=True",
     )
     db_config: ModelHandlerDbMockConfig = Field(
         default_factory=ModelHandlerDbMockConfig,
@@ -48,7 +64,23 @@ class ModelHandlerMemoryRetrievalConfig(BaseModel):
         default_factory=ModelHandlerGraphMockConfig,
         description="Configuration for Graph traversal handler",
     )
-    use_mock_handlers: bool = Field(
+    use_stub_handlers: bool = Field(
         default=True,
-        description="Use mock handlers (True) or real handlers (False)",
+        description="Use stub (mock) handlers (True) or production handlers (False)",
     )
+
+    @model_validator(mode="after")
+    def validate_qdrant_config_required_for_production(self) -> Self:
+        """Validate that qdrant_config is provided when use_stub_handlers is False.
+
+        Returns:
+            Self: The validated model instance.
+
+        Raises:
+            ValueError: If use_stub_handlers is False but qdrant_config is None.
+        """
+        if not self.use_stub_handlers and self.qdrant_config is None:
+            raise ValueError(
+                "qdrant_config is required when use_stub_handlers=False"
+            )
+        return self

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
@@ -72,7 +72,7 @@ class ModelHandlerMemoryRetrievalConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_qdrant_config_required_for_production(self) -> Self:
+    def validate_qdrant_config_required_for_production(self) -> Self:  # stub-ok  # fmt: skip
         """Validate that qdrant_config is provided when use_stub_handlers is False.
 
         Returns:
@@ -84,3 +84,11 @@ class ModelHandlerMemoryRetrievalConfig(BaseModel):
         if not self.use_stub_handlers and self.qdrant_config is None:
             raise ValueError("qdrant_config is required when use_stub_handlers=False")
         return self
+
+
+# Resolve forward reference for ModelHandlerQdrantConfig at runtime.
+# The TYPE_CHECKING import above satisfies static analysis; this import
+# is required so Pydantic can resolve the annotation during model_rebuild().
+from .model_handler_qdrant_config import ModelHandlerQdrantConfig  # noqa: TC001
+
+ModelHandlerMemoryRetrievalConfig.model_rebuild()

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_memory_retrieval_config.py
@@ -15,14 +15,16 @@ HandlerMemoryRetrieval.
 
 from __future__ import annotations
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .model_handler_db_mock_config import ModelHandlerDbMockConfig
 from .model_handler_graph_mock_config import ModelHandlerGraphMockConfig
-from .model_handler_qdrant_config import ModelHandlerQdrantConfig
 from .model_handler_qdrant_mock_config import ModelHandlerQdrantMockConfig
+
+if TYPE_CHECKING:
+    from .model_handler_qdrant_config import ModelHandlerQdrantConfig
 
 __all__ = [
     "ModelHandlerMemoryRetrievalConfig",
@@ -80,7 +82,5 @@ class ModelHandlerMemoryRetrievalConfig(BaseModel):
             ValueError: If use_stub_handlers is False but qdrant_config is None.
         """
         if not self.use_stub_handlers and self.qdrant_config is None:
-            raise ValueError(
-                "qdrant_config is required when use_stub_handlers=False"
-            )
+            raise ValueError("qdrant_config is required when use_stub_handlers=False")
         return self

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_qdrant_config.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_qdrant_config.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Configuration model for the production Qdrant handler.
+
+HandlerQdrant.
+
+.. versionadded:: 0.1.0
+    Initial implementation for OMN-4474.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = [
+    "ModelHandlerQdrantConfig",
+]
+
+
+class ModelHandlerQdrantConfig(BaseModel):
+    """Configuration for the production Qdrant handler.
+
+    Attributes:
+        qdrant_host: Hostname for the Qdrant server. Defaults to localhost.
+        qdrant_port: Port for the Qdrant server. Must be between 1 and 65535.
+        collection_name: Name of the Qdrant collection to use.
+        vector_size: Dimension of embedding vectors. Must match the embedding
+            model (Qwen3-Embedding-8B produces 4096-dim vectors).
+        embedding_server_url: URL of the embedding server. Required field;
+            must be a valid HTTP(S) URL.
+        embedding_timeout_seconds: Timeout for embedding requests in seconds.
+        embedding_max_retries: Maximum retries for embedding requests.
+        max_chunk_chars: Maximum characters per text chunk before splitting.
+            2000 chars approximates 500 tokens for most tokenizers.
+        qdrant_timeout_seconds: Timeout for Qdrant operations in seconds.
+
+    Raises:
+        ValueError: If embedding_server_url is missing or not a valid HTTP(S) URL.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
+
+    qdrant_host: str = Field(
+        default="localhost",
+        description="Hostname for the Qdrant server",
+    )
+    qdrant_port: int = Field(
+        default=6333,
+        ge=1,
+        le=65535,
+        description="Port for the Qdrant server",
+    )
+    collection_name: str = Field(
+        default="omnimemory_documents",
+        description="Name of the Qdrant collection to use",
+    )
+    vector_size: int = Field(
+        default=4096,
+        gt=0,
+        description="Dimension of embedding vectors — must match embedding model output",
+    )
+    embedding_server_url: str = Field(
+        description="URL of the embedding server — must be a valid HTTP(S) URL",
+    )
+    embedding_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description="Timeout for embedding requests in seconds",
+    )
+    embedding_max_retries: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        description="Maximum retries for embedding requests",
+    )
+    max_chunk_chars: int = Field(
+        default=2000,
+        gt=0,
+        description="Maximum characters per text chunk (2000 chars ≈ 500 tokens)",
+    )
+    qdrant_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description="Timeout for Qdrant operations in seconds",
+    )
+
+    @model_validator(mode="after")
+    def validate_embedding_server_url(self) -> Self:
+        """Validate that embedding_server_url is a valid HTTP(S) URL.
+
+        Returns:
+            Self: The validated model instance.
+
+        Raises:
+            ValueError: If embedding_server_url is not a valid HTTP(S) URL.
+        """
+        if not self.embedding_server_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"embedding_server_url must be a valid HTTP(S) URL, "
+                f"got: {self.embedding_server_url!r}"
+            )
+        return self

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -392,7 +392,7 @@ def create_lifecycle_dispatch_handler(
 # =============================================================================
 
 
-def create_memory_retrieval_dispatch_handler(
+def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handlers field name — fully implemented
     *,
     correlation_id: UUID | None = None,
 ) -> Callable[

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -401,8 +401,8 @@ def create_memory_retrieval_dispatch_handler(
 ]:
     """Create a dispatch handler for memory-retrieval-requested commands.
 
-    Delegates to HandlerMemoryRetrieval (initialized with mock backends via
-    use_mock_handlers=True). Returns a serialised JSON response string.
+    Delegates to HandlerMemoryRetrieval (initialized with stub backends via
+    use_stub_handlers=True). Returns a serialised JSON response string.
 
     The handler initialises HandlerMemoryRetrieval lazily on first call so
     that container startup is not blocked by backend initialisation.
@@ -426,7 +426,7 @@ def create_memory_retrieval_dispatch_handler(
     async def _get_retrieval_handler() -> HandlerMemoryRetrieval:
         nonlocal _retrieval_handler
         if _retrieval_handler is None:
-            config = ModelHandlerMemoryRetrievalConfig(use_mock_handlers=True)
+            config = ModelHandlerMemoryRetrievalConfig(use_stub_handlers=True)
             _retrieval_handler = HandlerMemoryRetrieval(config)
             await _retrieval_handler.initialize()
         return _retrieval_handler

--- a/tests/nodes/node_memory_retrieval_effect/test_memory_retrieval_effect.py
+++ b/tests/nodes/node_memory_retrieval_effect/test_memory_retrieval_effect.py
@@ -58,8 +58,8 @@ def handler() -> HandlerMemoryRetrieval:
         Configured HandlerMemoryRetrieval instance with mock handlers.
     """
     config = ModelHandlerMemoryRetrievalConfig(
-        use_mock_handlers=True,
-        qdrant_config=ModelHandlerQdrantMockConfig(embedding_dimension=1024),
+        use_stub_handlers=True,
+        qdrant_mock_config=ModelHandlerQdrantMockConfig(embedding_dimension=1024),
         db_config=ModelHandlerDbMockConfig(case_sensitive=False),
         graph_config=ModelHandlerGraphMockConfig(bidirectional=True),
     )

--- a/tests/unit/nodes/__init__.py
+++ b/tests/unit/nodes/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/nodes/test_model_handler_qdrant_config.py
+++ b/tests/unit/nodes/test_model_handler_qdrant_config.py
@@ -47,7 +47,9 @@ def test_rejects_invalid_url() -> None:
 def test_retrieval_config_requires_qdrant_config_when_not_stub() -> None:
     """ModelHandlerMemoryRetrievalConfig raises ValidationError when use_stub_handlers=False without qdrant_config."""
     with pytest.raises(ValidationError):
-        ModelHandlerMemoryRetrievalConfig(use_stub_handlers=False)  # missing qdrant_config
+        ModelHandlerMemoryRetrievalConfig(
+            use_stub_handlers=False
+        )  # missing qdrant_config
 
 
 @pytest.mark.unit
@@ -75,6 +77,10 @@ def test_retrieval_config_production_mode_with_qdrant_config() -> None:
 def test_qdrant_config_port_bounds() -> None:
     """ModelHandlerQdrantConfig rejects out-of-range ports."""
     with pytest.raises(ValidationError):
-        ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100", qdrant_port=0)
+        ModelHandlerQdrantConfig(
+            embedding_server_url="http://localhost:8100", qdrant_port=0
+        )
     with pytest.raises(ValidationError):
-        ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100", qdrant_port=65536)
+        ModelHandlerQdrantConfig(
+            embedding_server_url="http://localhost:8100", qdrant_port=65536
+        )

--- a/tests/unit/nodes/test_model_handler_qdrant_config.py
+++ b/tests/unit/nodes/test_model_handler_qdrant_config.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for ModelHandlerQdrantConfig and updated ModelHandlerMemoryRetrievalConfig.
+
+Tests for OMN-4474.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnimemory.nodes.node_memory_retrieval_effect.models import (
+    ModelHandlerMemoryRetrievalConfig,
+    ModelHandlerQdrantConfig,
+)
+
+
+@pytest.mark.unit
+def test_defaults_with_required_url() -> None:
+    """ModelHandlerQdrantConfig has correct defaults when embedding_server_url provided."""
+    cfg = ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100")
+    assert cfg.qdrant_host == "localhost"
+    assert cfg.qdrant_port == 6333
+    assert cfg.collection_name == "omnimemory_documents"
+    assert cfg.vector_size == 4096
+    assert cfg.max_chunk_chars == 2000
+
+
+@pytest.mark.unit
+def test_requires_embedding_server_url() -> None:
+    """ModelHandlerQdrantConfig raises ValidationError when embedding_server_url missing."""
+    with pytest.raises(ValidationError):
+        ModelHandlerQdrantConfig()  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_rejects_invalid_url() -> None:
+    """ModelHandlerQdrantConfig raises ValidationError for non-HTTP(S) URL."""
+    with pytest.raises(ValidationError):
+        ModelHandlerQdrantConfig(embedding_server_url="not-a-url")
+
+
+@pytest.mark.unit
+def test_retrieval_config_requires_qdrant_config_when_not_stub() -> None:
+    """ModelHandlerMemoryRetrievalConfig raises ValidationError when use_stub_handlers=False without qdrant_config."""
+    with pytest.raises(ValidationError):
+        ModelHandlerMemoryRetrievalConfig(use_stub_handlers=False)  # missing qdrant_config
+
+
+@pytest.mark.unit
+def test_retrieval_config_stub_mode_default() -> None:
+    """ModelHandlerMemoryRetrievalConfig defaults to stub mode with no qdrant_config required."""
+    cfg = ModelHandlerMemoryRetrievalConfig()
+    assert cfg.use_stub_handlers is True
+    assert cfg.qdrant_config is None
+
+
+@pytest.mark.unit
+def test_retrieval_config_production_mode_with_qdrant_config() -> None:
+    """ModelHandlerMemoryRetrievalConfig accepts use_stub_handlers=False when qdrant_config provided."""
+    qdrant_cfg = ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100")
+    cfg = ModelHandlerMemoryRetrievalConfig(
+        use_stub_handlers=False,
+        qdrant_config=qdrant_cfg,
+    )
+    assert cfg.use_stub_handlers is False
+    assert cfg.qdrant_config is not None
+    assert cfg.qdrant_config.embedding_server_url == "http://localhost:8100"
+
+
+@pytest.mark.unit
+def test_qdrant_config_port_bounds() -> None:
+    """ModelHandlerQdrantConfig rejects out-of-range ports."""
+    with pytest.raises(ValidationError):
+        ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100", qdrant_port=0)
+    with pytest.raises(ValidationError):
+        ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100", qdrant_port=65536)


### PR DESCRIPTION
## Summary

- Create `ModelHandlerQdrantConfig` production config model for Qdrant handler with all required fields (host, port, collection, vector_size, embedding URL, timeouts, chunk size) and HTTP(S) URL validator
- Rename `use_mock_handlers` → `use_stub_handlers` throughout for naming accuracy
- Add `qdrant_config: ModelHandlerQdrantConfig | None` to `ModelHandlerMemoryRetrievalConfig` with cross-field validator (required when `use_stub_handlers=False`)
- Rename `qdrant_config` → `qdrant_mock_config` in retrieval config to distinguish mock vs production path
- Update all callers in handler, runtime dispatch, and test fixtures
- Add 7 unit tests covering defaults, URL validation, port bounds, and cross-field validation

## Ticket

Closes OMN-4474

## Test Evidence

```
7 passed in 11.96s
975 passed (full unit suite, no regressions)
```

## Risk

Low — pure model addition and field rename. No behavioral change to existing mock path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production Qdrant database configuration support for memory retrieval.

* **Chores**
  * Renamed runtime/test terminology from "mock handlers" to "stub handlers".
  * Enforced validation that production Qdrant settings are required when running in production mode.

* **Tests**
  * Added unit tests covering Qdrant configuration, validation rules, and boundary checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->