### PR TITLE
feat(memory): wire HandlerQdrant into HandlerMemoryRetrieval production mode (OMN-4476)

### DIFF
--- a/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/handlers/handler_memory_retrieval.py
@@ -112,7 +112,7 @@ class HandlerMemoryRetrieval:
             config: The handler configuration. If None, defaults are used.
         """
         self._config = config or ModelHandlerMemoryRetrievalConfig()
-        self._qdrant_handler: HandlerQdrantMock | None = None
+        self._qdrant_handler: HandlerQdrantMock | object | None = None
         self._db_handler: HandlerDbMock | None = None
         self._graph_handler: HandlerGraphMock | None = None
         self._initialized = False
@@ -156,9 +156,31 @@ class HandlerMemoryRetrieval:
 
                 logger.info("Memory retrieval handler initialized with stub handlers")
             else:
-                # stub-ok: OMN-4475 — HandlerQdrant production wiring deferred to Task 5
-                raise NotImplementedError(
-                    "Production handlers not yet implemented. Set use_stub_handlers=True"
+                # Production mode: wire real HandlerQdrant; DB and graph remain stubs.
+                from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant import (
+                    HandlerQdrant,
+                )
+
+                assert (
+                    self._config.qdrant_config is not None
+                )  # enforced by model_validator
+                self._qdrant_handler = HandlerQdrant(self._config.qdrant_config)
+                # DB and graph handlers: not yet implemented. Using stub handlers.
+                # TODO: replace once HandlerDb and HandlerGraph are available (OMN-4476)
+                self._db_handler = HandlerDbMock(self._config.db_config)
+                self._graph_handler = HandlerGraphMock(self._config.graph_config)
+                logger.warning(
+                    "HandlerMemoryRetrieval: DB and graph subsystems are still using "
+                    "stub handlers. Qdrant (semantic search) is real. "
+                    "DB (full-text) and graph (relationships) remain stubs."
+                )
+                await asyncio.gather(
+                    self._qdrant_handler.initialize(),
+                    self._db_handler.initialize(),
+                    self._graph_handler.initialize(),
+                )
+                logger.info(
+                    "HandlerMemoryRetrieval initialized: Qdrant=real, DB=stub, Graph=stub"
                 )
 
             self._initialized = True

--- a/tests/unit/nodes/test_handler_memory_retrieval_wiring.py
+++ b/tests/unit/nodes/test_handler_memory_retrieval_wiring.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit test for HandlerMemoryRetrieval production wiring (OMN-4476).
+
+Verifies that use_stub_handlers=False wires HandlerQdrant (not a mock)
+for the Qdrant semantic search path.
+
+Ticket: OMN-4476
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_memory_retrieval import (
+    HandlerMemoryRetrieval,
+)
+from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant import (
+    HandlerQdrant,
+)
+from omnimemory.nodes.node_memory_retrieval_effect.models import (
+    ModelHandlerMemoryRetrievalConfig,
+    ModelHandlerQdrantConfig,
+)
+
+
+@pytest.mark.unit
+class TestHandlerMemoryRetrievalWiring:
+    """Tests for HandlerMemoryRetrieval production-mode handler wiring."""
+
+    @pytest.mark.asyncio
+    async def test_production_mode_wires_handler_qdrant(self) -> None:
+        """use_stub_handlers=False must wire HandlerQdrant for the Qdrant path."""
+        cfg = ModelHandlerMemoryRetrievalConfig(
+            use_stub_handlers=False,
+            qdrant_config=ModelHandlerQdrantConfig(
+                embedding_server_url="http://localhost:8100"
+            ),
+        )
+        with patch.object(HandlerQdrant, "initialize", new_callable=AsyncMock):
+            handler = HandlerMemoryRetrieval(cfg)
+            await handler.initialize()
+
+        assert handler._initialized is True
+        assert isinstance(handler._qdrant_handler, HandlerQdrant), (
+            "_qdrant_handler must be HandlerQdrant in production mode, not a mock"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stub_mode_wires_mock_handlers(self) -> None:
+        """use_stub_handlers=True must wire mock handlers."""
+        from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant_mock import (
+            HandlerQdrantMock,
+        )
+
+        cfg = ModelHandlerMemoryRetrievalConfig(use_stub_handlers=True)
+        handler = HandlerMemoryRetrieval(cfg)
+        await handler.initialize()
+
+        assert handler._initialized is True
+        assert isinstance(handler._qdrant_handler, HandlerQdrantMock), (
+            "_qdrant_handler must be HandlerQdrantMock in stub mode"
+        )


### PR DESCRIPTION
## Summary

- Removes `NotImplementedError` from `use_stub_handlers=False` path in `HandlerMemoryRetrieval`
- Wires `HandlerQdrant` as the real Qdrant handler in production mode
- DB and graph handlers remain `HandlerDbMock`/`HandlerGraphMock` with an explicit `logger.warning` naming the still-stubbed subsystems
- Adds a `# TODO` comment referencing follow-up handler work

## Test plan

- [ ] `test_production_mode_wires_handler_qdrant`: asserts `_qdrant_handler` is `HandlerQdrant` instance after `initialize()`
- [ ] `test_stub_mode_wires_mock_handlers`: asserts `_qdrant_handler` is `HandlerQdrantMock` in stub mode
- [ ] `uv run pytest tests/unit/nodes/ -v` passes (no regressions)

Ticket: OMN-4476
Parent epic: OMN-4470
Depends on: OMN-4475 (#142)