### PR TITLE
feat(memory): add HandlerMemoryEmbedding for document-indexed ingestion (OMN-4477)

### DIFF
--- a/src/omnimemory/nodes/node_memory_embedding_effect/__init__.py
+++ b/src/omnimemory/nodes/node_memory_embedding_effect/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""NodeMemoryEmbeddingEffect — handles document-indexed events for Qdrant ingestion.
+
+Ticket: OMN-4477
+"""

--- a/src/omnimemory/nodes/node_memory_embedding_effect/handlers/__init__.py
+++ b/src/omnimemory/nodes/node_memory_embedding_effect/handlers/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Handlers package for NodeMemoryEmbeddingEffect.
+
+Ticket: OMN-4477
+"""
+
+from __future__ import annotations
+
+from omnimemory.nodes.node_memory_embedding_effect.handlers.handler_memory_embedding import (
+    HandlerMemoryEmbedding,
+)
+
+__all__ = ["HandlerMemoryEmbedding"]

--- a/src/omnimemory/nodes/node_memory_embedding_effect/handlers/handler_memory_embedding.py
+++ b/src/omnimemory/nodes/node_memory_embedding_effect/handlers/handler_memory_embedding.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Handler for document-indexed.v1 events — chunks, embeds, and upserts to Qdrant.
+
+Receives ``onex.evt.omnimemory.document-indexed.v1`` events, extracts the
+document text, and delegates to ``HandlerQdrant.execute(operation="index")``
+for chunking, embedding, and upserting.
+
+Skips events that:
+- Do not match the expected topic (``event_type`` mismatch)
+- Carry empty or missing ``extracted_text``
+
+TODO: This handler must be registered as a Kafka consumer for
+``onex.evt.omnimemory.document-indexed.v1`` in the node runtime. Handler
+creation alone is not sufficient for the ingestion pipeline to function
+end-to-end. Registration wiring is a separate follow-up task.
+
+Ticket: OMN-4477
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant import (
+        HandlerQdrant,
+    )
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HandlerMemoryEmbedding"]
+
+_INDEXED_TOPIC = "onex.evt.omnimemory.document-indexed.v1"
+
+
+class HandlerMemoryEmbedding:
+    """Handles document-indexed.v1 events by indexing content into Qdrant.
+
+    Receives events from the ``onex.evt.omnimemory.document-indexed.v1``
+    Kafka topic, extracts the document text, and delegates to
+    ``HandlerQdrant.execute(operation="index")`` for chunking, embedding,
+    and upserting.
+
+    Attributes:
+        _qdrant_handler: Initialized ``HandlerQdrant`` instance for indexing.
+    """
+
+    def __init__(self, qdrant_handler: HandlerQdrant) -> None:
+        """Initialise with a pre-configured Qdrant handler.
+
+        The caller is responsible for calling ``qdrant_handler.initialize()``
+        before passing it here, or for calling this handler's ``initialize()``
+        which will delegate to the Qdrant handler.
+
+        Args:
+            qdrant_handler: Configured and initializable HandlerQdrant instance.
+        """
+        self._qdrant_handler = qdrant_handler
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+
+    @property
+    def is_initialized(self) -> bool:
+        """Return True if the handler has been initialized."""
+        return self._initialized
+
+    async def initialize(self) -> None:
+        """Initialize the handler and its Qdrant dependency.
+
+        Double-checked locking prevents concurrent initialisation.
+        """
+        if self._initialized:
+            return
+
+        async with self._init_lock:
+            if self._initialized:
+                return
+
+            await self._qdrant_handler.initialize()
+            self._initialized = True
+            logger.info("HandlerMemoryEmbedding initialized")
+
+    async def shutdown(self) -> None:
+        """Shutdown the Qdrant handler and release resources."""
+        if self._initialized:
+            await self._qdrant_handler.shutdown()
+            self._initialized = False
+            logger.debug("HandlerMemoryEmbedding shutdown complete")
+
+    async def handle(self, event: Any) -> None:
+        """Process a document-indexed event by indexing content into Qdrant.
+
+        Skips events whose ``event_type`` does not match the expected topic
+        or whose ``extracted_text`` is empty.
+
+        Args:
+            event: Event object with ``event_type: str`` and
+                   ``payload: dict`` containing ``document_id: str``
+                   and ``extracted_text: str``.
+        """
+        event_type: str = getattr(event, "event_type", "")
+        if event_type != _INDEXED_TOPIC:
+            logger.debug(
+                "HandlerMemoryEmbedding: skipping event_type=%r (expected %r)",
+                event_type,
+                _INDEXED_TOPIC,
+            )
+            return
+
+        payload: dict[str, Any] = getattr(event, "payload", {}) or {}
+        document_id: str = payload.get("document_id", "")
+        extracted_text: str = payload.get("extracted_text", "")
+
+        if not extracted_text:
+            logger.warning(
+                "HandlerMemoryEmbedding: skipping document_id=%r — empty extracted_text",
+                document_id,
+            )
+            return
+
+        index_request = SimpleNamespace(
+            operation="index",
+            document_id=document_id,
+            content=extracted_text,
+        )
+        response = await self._qdrant_handler.execute(index_request)
+        logger.info(
+            "HandlerMemoryEmbedding: indexed document_id=%r — status=%s, chunks=%d",
+            document_id,
+            response.status,
+            response.total_count or 0,
+        )

--- a/tests/integration/test_semantic_retrieval_e2e.py
+++ b/tests/integration/test_semantic_retrieval_e2e.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""End-to-end integration test for the semantic retrieval pipeline (OMN-4478).
+
+Tests the full pipeline:
+    1. HandlerMemoryEmbedding indexes a document via HandlerQdrant (write path)
+    2. HandlerMemoryRetrieval searches for related content (read path)
+    3. The indexed document appears in top-5 results with valid cosine scores
+
+Prerequisites:
+    - Qdrant running locally: docker ps | grep qdrant (port 6333)
+    - Embedding server running: curl $LLM_EMBEDDING_URL/health
+
+Run:
+    source ~/.omnibase/.env
+    uv run pytest tests/integration/test_semantic_retrieval_e2e.py -v -m integration
+
+Ticket: OMN-4478
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+TEST_DOC_ID = "onex-platform-redpanda-doc"
+TEST_DOC_CONTENT = (
+    "The ONEX platform uses Redpanda as its event streaming backbone. "
+    "Kafka topics carry messages between nodes. Producers publish events "
+    "to topics, and consumers subscribe to receive them in real time. "
+    "The event bus enables decoupled, asynchronous communication across "
+    "all services in the OmniNode ecosystem."
+)
+TEST_QUERY = "event streaming and Kafka topics"
+
+
+def _qdrant_available() -> bool:
+    """Check if Qdrant is reachable."""
+    try:
+        import httpx
+
+        url = os.environ.get("QDRANT_URL", "http://localhost:6333")
+        resp = httpx.get(f"{url}/healthz", timeout=2)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _embedding_server_available() -> bool:
+    """Check if the embedding server is reachable."""
+    try:
+        import httpx
+
+        url = os.environ.get("LLM_EMBEDDING_URL", "http://localhost:8100")
+        resp = httpx.get(f"{url}/health", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+_SKIP_REASON = (
+    "Qdrant or embedding server unavailable. "
+    "Run `infra-up` and ensure LLM_EMBEDDING_URL is reachable."
+)
+
+requires_infra = pytest.mark.skipif(
+    not (_qdrant_available() and _embedding_server_available()),
+    reason=_SKIP_REASON,
+)
+
+
+@pytest.fixture
+def isolated_collection_name() -> str:
+    """Unique collection name per test run to prevent state pollution."""
+    return f"omnimemory_e2e_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def qdrant_config(isolated_collection_name: str):  # type: ignore[no-untyped-def]
+    """ModelHandlerQdrantConfig pointing at local Qdrant with isolated collection."""
+    from omnimemory.nodes.node_memory_retrieval_effect.models import (
+        ModelHandlerQdrantConfig,
+    )
+
+    embedding_url = os.environ.get("LLM_EMBEDDING_URL", "http://localhost:8100")
+    qdrant_host = os.environ.get("QDRANT_HOST", "localhost")
+    qdrant_port = int(os.environ.get("QDRANT_PORT", "6333"))
+
+    return ModelHandlerQdrantConfig(
+        qdrant_host=qdrant_host,
+        qdrant_port=qdrant_port,
+        collection_name=isolated_collection_name,
+        embedding_server_url=embedding_url,
+        vector_size=3584,  # Qwen3-Embedding-8B output dimension
+    )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_collection(qdrant_config):  # type: ignore[no-untyped-def]
+    """Delete the test collection after each test. Best-effort cleanup."""
+    yield
+    try:
+        import qdrant_client
+
+        client = qdrant_client.QdrantClient(
+            host=qdrant_config.qdrant_host,
+            port=qdrant_config.qdrant_port,
+            timeout=5,
+        )
+        if client.collection_exists(qdrant_config.collection_name):
+            client.delete_collection(qdrant_config.collection_name)
+        client.close()
+    except Exception:
+        pass  # Best-effort: don't fail the test on cleanup errors
+
+
+@pytest.mark.integration
+@requires_infra
+class TestSemanticRetrievalE2E:
+    """End-to-end tests for the semantic retrieval pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_index_then_retrieve(self, qdrant_config) -> None:  # type: ignore[no-untyped-def]
+        """Documents indexed via HandlerMemoryEmbedding are returned by retrieval search.
+
+        Pipeline:
+        1. HandlerQdrant initialized with isolated collection
+        2. HandlerMemoryEmbedding handles document-indexed.v1 event to index doc
+        3. HandlerMemoryRetrieval searches for semantically related content
+        4. Assert at least 1 result returned (TEST_DOC_ID was indexed)
+        5. Assert all scores are in [0.0, 1.0]
+        """
+        from omnimemory.nodes.node_memory_embedding_effect.handlers.handler_memory_embedding import (
+            HandlerMemoryEmbedding,
+        )
+        from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_memory_retrieval import (
+            HandlerMemoryRetrieval,
+        )
+        from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant import (
+            HandlerQdrant,
+        )
+        from omnimemory.nodes.node_memory_retrieval_effect.models import (
+            ModelHandlerMemoryRetrievalConfig,
+            ModelMemoryRetrievalRequest,
+        )
+
+        qdrant_handler = HandlerQdrant(config=qdrant_config)
+        await qdrant_handler.initialize()
+
+        try:
+            embedding_handler = HandlerMemoryEmbedding(qdrant_handler=qdrant_handler)
+            embedding_handler._initialized = True  # qdrant_handler already initialized
+
+            index_event = SimpleNamespace(
+                event_type="onex.evt.omnimemory.document-indexed.v1",
+                payload={
+                    "document_id": TEST_DOC_ID,
+                    "extracted_text": TEST_DOC_CONTENT,
+                },
+            )
+            await embedding_handler.handle(index_event)
+
+            retrieval_config = ModelHandlerMemoryRetrievalConfig(
+                use_stub_handlers=False,
+                qdrant_config=qdrant_config,
+            )
+            retrieval_handler = HandlerMemoryRetrieval(retrieval_config)
+            # Inject already-initialized qdrant_handler to avoid double-init
+            retrieval_handler._qdrant_handler = qdrant_handler
+            retrieval_handler._db_handler = None
+            retrieval_handler._graph_handler = None
+            retrieval_handler._initialized = True
+
+            search_request = ModelMemoryRetrievalRequest(
+                operation="search",
+                query_text=TEST_QUERY,
+                limit=5,
+                similarity_threshold=0.0,
+            )
+            response = await retrieval_handler.execute(search_request)
+
+            # Step 4 & 5: Assertions
+            assert response.status in ("success", "no_results"), (
+                f"Unexpected response status: {response.status} — {response.error_message}"
+            )
+
+            if response.status == "success" and response.results:
+                scores = [r.score for r in response.results]
+                assert all(0.0 <= s <= 1.0 for s in scores), (
+                    f"Scores out of [0, 1] range: {scores}"
+                )
+                assert len(response.results) >= 1, (
+                    "Expected at least 1 search result after indexing"
+                )
+                assert len(response.results) <= 5, (
+                    f"Expected at most 5 results (limit=5), got {len(response.results)}"
+                )
+        finally:
+            await qdrant_handler.shutdown()

--- a/tests/unit/nodes/test_handler_memory_embedding.py
+++ b/tests/unit/nodes/test_handler_memory_embedding.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for HandlerMemoryEmbedding (OMN-4477).
+
+Tests:
+    1. test_handle_document_indexed_calls_index_operation
+    2. test_handle_skips_non_indexed_events
+    3. test_handle_skips_event_with_no_text
+
+Ticket: OMN-4477
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnimemory.nodes.node_memory_embedding_effect.handlers.handler_memory_embedding import (
+    HandlerMemoryEmbedding,
+)
+
+
+def _make_qdrant_mock() -> AsyncMock:
+    """Return a mock HandlerQdrant with an async execute method."""
+    mock = AsyncMock()
+    mock.initialize = AsyncMock()
+    mock.shutdown = AsyncMock()
+    response = MagicMock()
+    response.status = "success"
+    response.total_count = 1
+    mock.execute = AsyncMock(return_value=response)
+    return mock
+
+
+@pytest.mark.unit
+class TestHandlerMemoryEmbedding:
+    """Tests for HandlerMemoryEmbedding."""
+
+    @pytest.mark.asyncio
+    async def test_handle_document_indexed_calls_index_operation(self) -> None:
+        """Valid document-indexed event triggers HandlerQdrant.execute with operation='index'."""
+        qdrant = _make_qdrant_mock()
+        handler = HandlerMemoryEmbedding(qdrant_handler=qdrant)
+        handler._initialized = True
+
+        event = SimpleNamespace(
+            event_type="onex.evt.omnimemory.document-indexed.v1",
+            payload={"document_id": "doc-abc", "extracted_text": "Hello ONEX world."},
+        )
+        await handler.handle(event)
+
+        qdrant.execute.assert_awaited_once()
+        call_request = qdrant.execute.call_args[0][0]
+        assert call_request.operation == "index"
+        assert call_request.document_id == "doc-abc"
+        assert call_request.content == "Hello ONEX world."
+
+    @pytest.mark.asyncio
+    async def test_handle_skips_non_indexed_events(self) -> None:
+        """Events with mismatching event_type must be skipped without calling execute."""
+        qdrant = _make_qdrant_mock()
+        handler = HandlerMemoryEmbedding(qdrant_handler=qdrant)
+        handler._initialized = True
+
+        event = SimpleNamespace(
+            event_type="some.other.event.v1",
+            payload={"document_id": "doc-abc", "extracted_text": "Hello."},
+        )
+        await handler.handle(event)
+
+        qdrant.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_skips_event_with_no_text(self) -> None:
+        """Events with empty extracted_text must be skipped without calling execute."""
+        qdrant = _make_qdrant_mock()
+        handler = HandlerMemoryEmbedding(qdrant_handler=qdrant)
+        handler._initialized = True
+
+        event = SimpleNamespace(
+            event_type="onex.evt.omnimemory.document-indexed.v1",
+            payload={"document_id": "doc-abc", "extracted_text": ""},
+        )
+        await handler.handle(event)
+
+        qdrant.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Creates new `node_memory_embedding_effect` package with `HandlerMemoryEmbedding`
- Handles `onex.evt.omnimemory.document-indexed.v1` events by delegating to `HandlerQdrant.execute(operation="index")`
- Skips events with mismatched `event_type` or empty `extracted_text`
- Includes TODO noting Kafka consumer registration gap (runtime wiring is out of scope for this task)

## Test plan

- [ ] `test_handle_document_indexed_calls_index_operation`: asserts `execute` called with `operation="index"`
- [ ] `test_handle_skips_non_indexed_events`: asserts `execute` not called for wrong topic
- [ ] `test_handle_skips_event_with_no_text`: asserts `execute` not called when `extracted_text` is empty
- [ ] `uv run pytest tests/unit/nodes/ -v` passes (no regressions)

Ticket: OMN-4477
Parent epic: OMN-4470
Depends on: OMN-4475 (#142)