### PR TITLE
fix(migrations): backfill NULL checksums + enforce NOT NULL on schema_migrations [OMN-4701]

### DIFF
--- a/deployment/database/migrations/005_backfill_null_checksums.sql
+++ b/deployment/database/migrations/005_backfill_null_checksums.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- MIGRATION: Backfill NULL checksums and enforce NOT NULL on schema_migrations
+-- =============================================================================
+-- Ticket: OMN-4701 (OMN-4653 root cause fix — omnimemory DB)
+-- Version: 1.0.0
+--
+-- PURPOSE:
+--   The live omnimemory DB has 4 NULL checksum rows in schema_migrations.
+--   These rows were applied before checksum tracking was implemented.
+--
+--   This migration:
+--   1. Backfills NULL checksums with a sentinel prefix so they are
+--      identifiable as pre-checksum-era rows.
+--   2. Enforces NOT NULL on the checksum column to prevent future nulls.
+--
+-- SAFETY:
+--   Wrapped in a transaction. Idempotent: UPDATE only touches NULL rows.
+--   ALTER TABLE SET NOT NULL is safe once all rows have a non-null checksum.
+-- =============================================================================
+
+BEGIN;
+
+-- Step 1: Backfill all NULL checksum rows with a stable sentinel value.
+UPDATE schema_migrations
+SET checksum = 'backfilled:pre-checksum-era:' || version
+WHERE checksum IS NULL;
+
+-- Step 2: Enforce NOT NULL now that all rows have a value.
+ALTER TABLE schema_migrations
+    ALTER COLUMN checksum SET NOT NULL;
+
+-- Step 3: Document the column contract with a comment.
+COMMENT ON COLUMN schema_migrations.checksum IS
+    'SHA-256 of migration file at apply time. '
+    'Prefix "backfilled:pre-checksum-era:" = applied before checksum tracking '
+    '(2026-03-12 backfill, OMN-4653 / OMN-4701).';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Adds migration `005_backfill_null_checksums.sql` to backfill 4 NULL `checksum` rows in the live `omnimemory.schema_migrations` table
- Enforces `NOT NULL` on the `checksum` column after backfill
- This migration triggers a new ECR image build (`omnimemory-migrate`) — the image tag in `omninode_infra/k8s/migrations/omnimemory-migrate.yaml` will be updated in a companion PR after CI publishes the new image

### What the migration does

1. `UPDATE ... SET checksum = 'backfilled:pre-checksum-era:' || version WHERE checksum IS NULL` — idempotent sentinel
2. `ALTER TABLE ... ALTER COLUMN checksum SET NOT NULL` — enforces the contract going forward
3. Adds `COMMENT` documenting backfill date and ticket

## Risk

LOW — wrapped in a transaction, idempotent UPDATE, `schema_migrations` is internal bookkeeping only.

## Test Evidence

Pre-commit hooks pass (migration freeze check, trim whitespace).

## Rollback

The backfill is safe to leave in place even on revert — it only fills NULL rows with a stable sentinel value.

Linear: OMN-4701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema integrity with a migration that backfills missing data and enforces stricter column constraints to ensure data reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->