### PR TITLE
ci(standards): add version pin compliance check [OMN-4809]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,11 +380,43 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
+  # ---------------------------------------------------------------------------
+  # Phase 1 - Version Pin Compliance Check (OMN-4809)
+  # ---------------------------------------------------------------------------
+  # Verifies that this repo's dependency pins are compliant with the shared
+  # version matrix defined in omni_home/standards/version-matrix.yaml.
+  # Depends on OMN-4803 (check_version_pins.py must exist in omni_home main).
+  version-pin-check:
+    name: Version Pin Compliance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Checkout omni_home standards
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omni_home
+          path: omni_home
+          sparse-checkout: |
+            standards/
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check version pin compliance
+        run: python omni_home/standards/check_version_pins.py --repo omnimemory --root omni_home
+
   # Phase 3 - Aggregation
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [migration-freeze, lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, check-handshake, test]
+    needs: [migration-freeze, lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, check-handshake, test, version-pin-check]
     if: always()
 
     steps:


### PR DESCRIPTION
## Summary

Wires `check_version_pins.py` from omni_home into omnimemory CI as a Phase 1 `version-pin-check` job (OMN-4809).

- Checks out `OmniNode-ai/omni_home` (sparse: `standards/`) on each CI run
- Runs `python omni_home/standards/check_version_pins.py --repo omnimemory --root omni_home`
- Added to `ci-summary` needs

## Dependencies

Depends on OMN-4803 (omni_home PR #33) which creates `standards/check_version_pins.py`.

## Definition of Done

- [x] CI step added
- [x] Step wired into ci-summary
- [x] pre-commit passes
- [ ] CI green (pending OMN-4803 merge)

Linear: OMN-4809