### PR TITLE
fix(cleanup): fix hardcoded Kafka fallback port 9092 → 19092

### DIFF
--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -61,7 +61,7 @@ Example::
         db_dsn=os.environ["OMNIMEMORY_DB_URL"],
         valkey_host="localhost",
         valkey_port=6379,
-        kafka_bootstrap_servers="localhost:9092",
+        kafka_bootstrap_servers="localhost:19092",
     )
     handler = HandlerSubscription(container)
     await handler.initialize(config)
@@ -299,7 +299,7 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
         description="Optional Valkey password",
     )
     kafka_bootstrap_servers: str = Field(
-        default="localhost:9092",
+        default="localhost:19092",
         description="Event bus bootstrap servers, comma-separated (Kafka endpoint)",
     )
     cache_ttl_seconds: int = Field(


### PR DESCRIPTION
## Summary
- **OMN-4847 (T2-M)**: Replace hardcoded `localhost:9092` fallback with `localhost:19092` (local Docker Redpanda port) in handler_subscription.py

## Test Plan
- `grep -n "localhost:9092" src/omnimemory/handlers/handler_subscription.py` returns zero
- `pre-commit run --all-files` passes

Part of Epic: OMN-4829 (Ollama / Dead-Endpoint Purge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default event bus connection address from localhost:9092 to localhost:19092.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->