### PR TITLE
chore(pre-commit): add kafka-no-hardcoded-fallback hook [OMN-4860]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -444,6 +444,19 @@ repos:
         stages: [pre-commit]
 
       # --------------------------------------------------------------------------
+      # Kafka Hardcoded Fallback Guard (OMN-4860, mirrors omnibase_infra OMN-3554)
+      # Validates: No hardcoded localhost:9092 or private-IP Kafka addresses in src/
+      # Purpose: Prevents reintroduction of hardcoded broker addresses after T2-M fix
+      # --------------------------------------------------------------------------
+      - id: kafka-no-hardcoded-fallback
+        name: Reject hardcoded Kafka broker address fallbacks
+        entry: bash scripts/validation/check_kafka_no_hardcoded_fallback.sh
+        language: system
+        pass_filenames: false
+        types: [python]
+        stages: [pre-commit]
+
+      # --------------------------------------------------------------------------
       # SPDX Header Enforcement (ONEX canonical)
       # Validates: All eligible source files carry MIT SPDX headers
       # Scope: src/, tests/, scripts/, examples/ (py, sh, bash, yml, yaml, toml)

--- a/scripts/validation/check_kafka_no_hardcoded_fallback.sh
+++ b/scripts/validation/check_kafka_no_hardcoded_fallback.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# OMN-4860: Reject hardcoded Kafka broker address fallbacks in omnimemory
+# Mirrors the omnibase_infra hook (OMN-3554) for ecosystem parity.
+#
+# Suppressions:
+#   # kafka-fallback-ok         — intentional test fixture default
+#   # noqa                      — general suppression
+#   # onex-allow-internal-ip    — intentional private-IP reference
+
+set -euo pipefail
+
+FAILED=0
+
+# R1: os.getenv("KAFKA_*", non-empty) pattern in src/
+MATCHES=$(grep -rn --include="*.py" \
+    --exclude-dir=".venv" \
+    --exclude-dir="node_modules" \
+    -E "os\.getenv\([[:space:]]*[\"']KAFKA_[^\"']+[\"'][[:space:]]*,[[:space:]]*[\"'][^\"']+[\"']" \
+    src/ 2>/dev/null | \
+    grep -v "# kafka-fallback-ok" | \
+    grep -v "# noqa" || true)
+
+if [ -n "$MATCHES" ]; then
+    echo "ERROR: Hardcoded Kafka bootstrap fallback detected in src/:"
+    echo "$MATCHES"
+    echo ""
+    echo "FIX: Replace os.getenv(\"KAFKA_...\", \"fallback\") with:"
+    echo "  os.environ[\"KAFKA_BOOTSTRAP_SERVERS\"]  # fails loudly when unset"
+    echo "  os.getenv(\"KAFKA_BOOTSTRAP_SERVERS\")   # returns None when unset"
+    echo "  If intentional (test fixture): add # kafka-fallback-ok"
+    FAILED=1
+fi
+
+# R2: Private-IP Kafka broker addresses (Kafka-specific ports only) in src/
+IP_MATCHES=$(grep -rn --include="*.py" \
+    --exclude-dir=".venv" \
+    --exclude-dir="node_modules" \
+    -E "192\.168\.[0-9]+\.[0-9]+:(9092|19092|29092|29093)" \
+    src/ 2>/dev/null | \
+    grep -v "# kafka-fallback-ok" | \
+    grep -v "# noqa" | \
+    grep -v "# onex-allow-internal-ip" || true)
+
+if [ -n "$IP_MATCHES" ]; then
+    echo "ERROR: Hardcoded private-IP Kafka broker address in src/:"
+    echo "$IP_MATCHES"
+    echo ""
+    echo "FIX: Use KAFKA_BOOTSTRAP_SERVERS env var."
+    echo "  If intentional (test fixture): add # kafka-fallback-ok"
+    FAILED=1
+fi
+
+# R3: localhost:9092 hardcoded in src/ (the canonical bad pattern)
+LOCALHOST_MATCHES=$(grep -rn --include="*.py" \
+    --exclude-dir=".venv" \
+    --exclude-dir="node_modules" \
+    -E "localhost:9092" \
+    src/ 2>/dev/null | \
+    grep -v "# kafka-fallback-ok" | \
+    grep -v "# noqa" || true)
+
+if [ -n "$LOCALHOST_MATCHES" ]; then
+    echo "ERROR: Hardcoded localhost:9092 Kafka broker in src/:"
+    echo "$LOCALHOST_MATCHES"
+    echo ""
+    echo "FIX: Use KAFKA_BOOTSTRAP_SERVERS env var instead of localhost:9092."
+    echo "  Docker services use redpanda:9092 (internal DNS)."
+    echo "  Host scripts use localhost:19092 (external port)."
+    echo "  If intentional: add # kafka-fallback-ok"
+    FAILED=1
+fi
+
+exit $FAILED

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -61,7 +61,7 @@ Example::
         db_dsn=os.environ["OMNIMEMORY_DB_URL"],
         valkey_host="localhost",
         valkey_port=6379,
-        kafka_bootstrap_servers="localhost:19092",
+        kafka_bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
     )
     handler = HandlerSubscription(container)
     await handler.initialize(config)
@@ -299,7 +299,7 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
         description="Optional Valkey password",
     )
     kafka_bootstrap_servers: str = Field(
-        default="localhost:19092",
+        ...,
         description="Event bus bootstrap servers, comma-separated (Kafka endpoint)",
     )
     cache_ttl_seconds: int = Field(

--- a/tests/integration/test_node_agent_coordinator.py
+++ b/tests/integration/test_node_agent_coordinator.py
@@ -307,6 +307,7 @@ async def orchestrator_node(
         db_dsn=test_db_dsn,
         valkey_host=test_valkey_host,
         valkey_port=test_valkey_port,
+        kafka_bootstrap_servers="localhost:19092",  # kafka-fallback-ok
     )
     node = NodeAgentCoordinatorOrchestrator(config)
     await node.initialize()
@@ -735,6 +736,7 @@ class TestOrchestratorErrorHandling:
             db_dsn=test_db_dsn,
             valkey_host=test_valkey_host,
             valkey_port=test_valkey_port,
+            kafka_bootstrap_servers="localhost:19092",  # kafka-fallback-ok
         )
         node = NodeAgentCoordinatorOrchestrator(config)
 

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -326,6 +326,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "no-env-file",
             "validate-string-versions",
             "no-hardcoded-bolt-fallback",
+            "kafka-no-hardcoded-fallback",
             "validate-spdx-headers",
             "check-stub-implementations",
         }


### PR DESCRIPTION
## Summary
- Add `kafka-no-hardcoded-fallback` pre-commit hook to omnimemory, mirroring the omnibase_infra hook (OMN-3554)
- Fix two existing hardcoded `localhost:9092` violations in `handler_subscription.py` (required field + env var lookup)
- Hook blocks: `os.getenv("KAFKA_*", "fallback")` patterns, private-IP Kafka addresses, and `localhost:9092` in `src/`

## Test plan
- [x] `pre-commit run kafka-no-hardcoded-fallback --all-files` exits 0
- [x] `pre-commit run --all-files` passes (excluding pre-existing Poetry env issues)
- [x] mypy and pyright pass (pre-push hooks)

Part of Epic 6: Pre-commit Hook Parity (OMN-4833)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced pre-commit validation to detect hardcoded Kafka bootstrap server configurations in the codebase.
  * Kafka bootstrap servers configuration is now mandatory and requires explicit assignment; default values are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->