### PR TITLE
release: omnimemory v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.7.1 (2026-03-13)
+
+### Features
+_(none)_
+
+### Bug Fixes
+- fix(cleanup): fix hardcoded Kafka fallback port 9092 → 19092 (OMN-4847) (#152)
+- fix(migrations): backfill NULL checksums and enforce NOT NULL on schema_migrations [OMN-4701] (#148)
+
+### Other Changes
+- chore(pre-commit): add kafka-no-hardcoded-fallback hook [OMN-4860] (#153)
+- chore(pre-commit): standardize ruff + yamlfmt versions [OMN-4858] (#151)
+- ci(standards): add version pin compliance check [OMN-4809] (#150)
+- chore(deps): bump omnibase-core/spi/infra pins to current approved versions [OMN-4799] (#149)
+- chore(deps): bump omnibase_infra to 0.18.0 (#147)
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.7.0"
+version = "0.7.1"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core>=0.25.1",
+    "omnibase-core==0.26.0",
     "omnibase-spi>=0.16.1",
-    "omnibase-infra>=0.18.0",
+    "omnibase-infra==0.19.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1756,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.25.1"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1771,14 +1771,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/3c/5cc0d4e722d62e464d8602db79811019e4e2421a68a567c48c1f9c7bebbf/omnibase_core-0.25.1.tar.gz", hash = "sha256:74c1c50f6014ca16dc13f7e11d8308df404be9660851a75bb6dad0b17bece812", size = 8460933, upload-time = "2026-03-12T13:14:27.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/2bbc00abdcab28ac37fc5eebe8301ffbcfaa11de9a69b01f2aba2145dcc1/omnibase_core-0.26.0.tar.gz", hash = "sha256:6352356afa7bfe9c2bf6a10cad5d2eac067033575aa5c83ed5becd5ec02c1675", size = 8464492, upload-time = "2026-03-13T12:22:29.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/49/594664b59269ecd0af7017954720dc6fefbe0b06bb5ffe3aff95991c5228/omnibase_core-0.25.1-py3-none-any.whl", hash = "sha256:4351e8c69aaba9c547cfff0b88eca1fef747be1d24a8a3bdfb9515363efa5842", size = 5168555, upload-time = "2026-03-12T13:14:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/02/4f3e7b31ebf641ccbf51f79aff3312359b742fe24d01a296422e88366174/omnibase_core-0.26.0-py3-none-any.whl", hash = "sha256:0e3d5e37fa131bb16d7039cb358d17e3265deadf4d9883ebd9c038f69bebb13b", size = 5170062, upload-time = "2026-03-13T12:22:33.146Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1825,9 +1825,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/17/9e63292f0014289b4586bb8cf8035fc7d902cae0b4577105da1a4073793b/omnibase_infra-0.18.0.tar.gz", hash = "sha256:49e29ae12f95389f70ce3a59eff0ac0c740a7315f0e7d6af8182114dde10e2ec", size = 6454576, upload-time = "2026-03-12T13:43:37.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/77/3844bc23931cb1e47e18d11a24dacbdf4b64b3fc4010efb5a5dde0a35d07/omnibase_infra-0.19.0.tar.gz", hash = "sha256:950c94fac13ff045e52250b4eaf6876e1e3cdde731edd3cff1d9ce3e1589d2c7", size = 6471466, upload-time = "2026-03-13T13:11:57.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/8c/f57c503c63e695e15ce510322c69756e24f5fc20e14cc5535d81553094dd/omnibase_infra-0.18.0-py3-none-any.whl", hash = "sha256:af34114148073a20e0cd256b633f9dd1303be68ff140630d03f442310f7a86bb", size = 3809231, upload-time = "2026-03-12T13:43:40.421Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1c/e2c86e0d84affb732017764157ddccef46cdf7fa204bd0d8f0313895be4d/omnibase_infra-0.19.0-py3-none-any.whl", hash = "sha256:6973efa1d901e2fb343fda26d2576f61bbdaf57a7fbfc00388bdaef6f70005a3", size = 3809222, upload-time = "2026-03-13T13:11:54.874Z" },
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1904,8 +1904,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = ">=0.25.1" },
-    { name = "omnibase-infra", specifier = ">=0.18.0" },
+    { name = "omnibase-core", specifier = "==0.26.0" },
+    { name = "omnibase-infra", specifier = "==0.19.0" },
     { name = "omnibase-spi", specifier = ">=0.16.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
## Release: omnimemory v0.7.1

Coordinated release run: `release-20260312-b960e3`

### Changes
- chore(pre-commit): add kafka-no-hardcoded-fallback hook [OMN-4860] (#153)
- fix(cleanup): fix hardcoded Kafka fallback port 9092 -> 19092 (OMN-4847) (#152)
- chore(pre-commit): standardize ruff + yamlfmt versions [OMN-4858] (#151)
- ci(standards): add version pin compliance check [OMN-4809] (#150)
- chore(deps): bump omnibase-core/spi/infra pins [OMN-4799] (#149)
- fix(migrations): backfill NULL checksums and enforce NOT NULL [OMN-4701] (#148)
- chore(deps): bump omnibase_infra to 0.18.0 (#147)

### Dependency pins
- omnibase-core==0.26.0
- omnibase-infra==0.19.0

### Release metadata
- Bump: patch
- Previous: v0.7.0
- Plan hash: sha256:c747d5215c4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.1

* **Bug Fixes**
  * Corrected Kafka fallback port configuration issue
  * Fixed and enforced data integrity in database migrations with checksum validation

* **Chores**
  * Updated core and infrastructure dependencies to specified versions
  * Enhanced pre-commit hooks with additional validation checks
  * Added version compliance verification to the CI pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->