### PR TITLE
chore: wire onex-validate-links pre-commit hook [OMN-5086]

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,6 +23,7 @@ jobs:
       #   - contract-linter  -> contract-validation job
       #   - io-audit         -> io-audit job
       #   - mypy             -> lint job (pre-push stage, not triggered here anyway)
+      #   - onex-validate-links -> requires uv (not available in pre-commit CI env)
       - uses: pre-commit/action@v3.0.1
         env:
-          SKIP: contract-linter,io-audit,check-ai-slop
+          SKIP: contract-linter,io-audit,check-ai-slop,onex-validate-links

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [
+        {"pattern": "^https://linear\\.app"},
+        {"pattern": "^https://github\\.com/OmniNode-ai"},
+        {"pattern": "^http://localhost"},
+        {"pattern": "^https://localhost"}
+    ],
+    "excludeFiles": [
+        ".pytest_cache/**",
+        ".venv/**",
+        "venv/**",
+        "node_modules/**",
+        "archived/**"
+    ],
+    "checkExternal": false,
+    "externalTimeout": 5000
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -470,6 +470,15 @@ repos:
         exclude: ^(archived/|archive/)
         stages: [pre-commit]
 
+      # Markdown link validation (OMN-5086) — uses onex-validate-links from omnibase_core
+      - id: onex-validate-links
+        name: Validate markdown links
+        entry: uv run onex-validate-links --verbose
+        language: system
+        types: [markdown]
+        pass_filenames: false
+        stages: [pre-commit]
+
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -329,6 +329,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "kafka-no-hardcoded-fallback",
             "validate-spdx-headers",
             "check-stub-implementations",
+            "onex-validate-links",
         }
     )
 


### PR DESCRIPTION
## Summary
- Add `onex-validate-links` pre-commit hook from omnibase_core
- Create `.markdown-link-check.json` with baseline ignore patterns
- Internal link validation runs on every commit (markdown files)

## Test plan
- [ ] Pre-commit hook runs on markdown changes
- [ ] `uv run onex-validate-links --verbose` exits 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added markdown link validation to development checks to identify broken documentation links, with configuration rules for skipping specific hosts and excluded directories.
  * Enhanced pre-commit workflow configurations to improve code quality assurance and validation processes during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->