### PR TITLE
chore: standardize Python tooling to canonical baseline [OMN-5077]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,7 +158,7 @@ repos:
       - id: mypy-type-check
         name: mypy (type checking - strict)
         # SYNCHRONIZED WITH CI: Identical to .github/workflows/test.yml lint job
-        entry: poetry run mypy --show-error-codes --no-error-summary src/omnimemory
+        entry: uv run mypy --show-error-codes --no-error-summary src/omnimemory
         language: system
         types: [python]
         pass_filenames: false
@@ -347,7 +347,7 @@ repos:
       - id: contract-linter
         name: ONEX Contract Linter
         description: Validates node contract YAML files. Requires Poetry (poetry install).
-        entry: poetry run python -m omnimemory.tools.contract_linter
+        entry: uv run python -m omnimemory.tools.contract_linter
         language: system
         pass_filenames: true
         # SYNC: CI uses `find src/omnimemory -name contract.yaml` with graceful
@@ -367,7 +367,7 @@ repos:
       - id: io-audit
         name: I/O Audit (ONEX node purity)
         description: Audits node purity for forbidden I/O. Requires Poetry (poetry install).
-        entry: poetry run python -m omnimemory.audit
+        entry: uv run python -m omnimemory.audit
         language: system
         pass_filenames: false
         types: [python]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - OmniMemory
 
-> **Python**: 3.12+ | **Framework**: ONEX 4.0 | **Package Manager**: uv | **Shared Standards**: See **`~/.claude/CLAUDE.md`** for shared development standards (Python, Git, testing, architecture principles) and infrastructure configuration (PostgreSQL, Kafka/Redpanda, Docker networking, environment variables).
+> **Python**: 3.12+ | **Framework**: ONEX 4.0 | **Package Manager**: uv (hatchling backend) | **Shared Standards**: See **`~/.claude/CLAUDE.md`** for shared development standards (Python, Git, testing, architecture principles) and infrastructure configuration (PostgreSQL, Kafka/Redpanda, Docker networking, environment variables).
 
 ---
 
@@ -49,7 +49,7 @@ OmniMemory explicitly does **NOT**:
 
 ```bash
 # Setup
-uv sync
+uv sync --group dev
 pre-commit install
 pre-commit install --hook-type pre-push
 
@@ -61,10 +61,10 @@ uv run ruff check --fix src/ tests/
 uv run mypy src/omnimemory
 
 # Testing
-uv run pytest                    # All tests
-uv run pytest -m unit            # Unit tests only
-uv run pytest -m integration     # Integration tests
-uv run pytest --cov              # With coverage report
+uv run pytest                        # All tests
+uv run pytest -m unit                # Unit tests only
+uv run pytest -m integration         # Integration tests
+uv run pytest --cov                  # With coverage report
 
 # Pre-commit validation
 pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ ignore = [
     "N806",      # Variable in function should be lowercase
     "PTH123",    # Use Path.open() instead of open()
     "TID252",    # Prefer absolute imports over relative from parent
-    "T201",      # print() found (use logging instead)
+    # T201 (print) is NOT ignored — enforced per standardization plan
     "S311",      # Random not suitable for crypto (acceptable for non-crypto)
     "RUF022",    # __all__ is not sorted
     "RUF012",    # Mutable class attrs should be ClassVar
@@ -269,6 +269,11 @@ known-first-party = ["omnimemory"]
 "src/omnimemory/audit/*" = [
     "N802",  # AST visitor methods use CamelCase (visit_Import, visit_Call, etc.)
 ]
+# CLI entry points — intentional print() for user-facing output
+"src/omnimemory/audit/__main__.py" = ["T201"]
+"src/omnimemory/tools/contract_linter.py" = ["T201"]
+# Performance benchmark test — uses print() for results output
+"tests/test_performance.py" = ["T201"]
 # Test-only rules - acceptable in test files
 "tests/**/*" = [
     "SLF001",  # Private member accessed (tests need to verify internals)
@@ -329,9 +334,15 @@ warn_untyped_fields = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+pythonpath = ["src", "."]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short --strict-markers"
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "-ra",
+    "--tb=short",
+]
 # Filter deprecation warnings from third-party libraries we can't fix
 filterwarnings = [
     # Google protobuf PyType_Spec metaclass warning - upstream issue, can't fix


### PR DESCRIPTION
## Summary

- Remove `T201` from global ruff ignore list (enforce no-print rule); add per-file-ignores for CLI entry points (`audit/__main__.py`, `contract_linter.py`) and benchmark tests (`test_performance.py`)
- Convert `addopts` to list format, add `--strict-config`, add `pythonpath`
- Replace `poetry run` with `uv run` in pre-commit hooks
- Fix stale Poetry reference in CLAUDE.md (repo uses hatchling/uv)

Part of cross-repo Python standardization epic OMN-5067, Wave 2.

## Test plan

- [ ] CI passes (ruff check, mypy strict, pytest)
- [ ] Pre-commit hooks work with uv run
- [ ] No regressions in test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/pre-commit hooks now run via the uv runner instead of the previous runner.
* **Documentation**
  * Clarified package manager as uv (hatchling backend) and updated setup command to use uv sync --group dev.
* **Tests**
  * Strengthened pytest configuration: stricter marker/config checks, compact option format, added pythonpath entries, and targeted per-file allowances for specific checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->