### PR TITLE
feat(ci): add repository_dispatch trigger for plugin pin cascade [OMN-5137]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,3 +101,47 @@ jobs:
             dist/SHA256SUMS.txt
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') }}
+
+  # ---------------------------------------------------------------------------
+  # Post-release: trigger Dockerfile.runtime pin cascade (OMN-5137)
+  # ---------------------------------------------------------------------------
+  # When omnimemory is released, notify omnibase_infra so its
+  # plugin-pin-cascade workflow can bump Dockerfile.runtime pins automatically.
+  #
+  # REQUIREMENT: CROSS_REPO_PAT secret must be a GitHub PAT with `repo` scope
+  # on OmniNode-ai/omnibase_infra (same pattern as omnibase_infra's
+  # trigger-runtime-rebuild job).
+  notify-plugin-pin-cascade:
+    name: Notify Plugin Pin Cascade
+    needs: release
+    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CROSS_REPO_PAT is configured
+        id: token_check
+        env:
+          CROSS_REPO_PAT: ${{ secrets.CROSS_REPO_PAT }}
+        run: |
+          if [ -z "$CROSS_REPO_PAT" ]; then
+            echo "::warning::CROSS_REPO_PAT secret is not set. Skipping cross-repo dispatch." \
+              "Set a PAT with 'repo' scope on OmniNode-ai/omnibase_infra" \
+              "as the CROSS_REPO_PAT repository secret to enable plugin pin cascade."
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch plugin-release to omnibase_infra
+        if: steps.token_check.outputs.has_token == 'true'
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.CROSS_REPO_PAT }}
+          repository: OmniNode-ai/omnibase_infra
+          event-type: plugin-release
+          client-payload: >-
+            {
+              "package": "omninode-memory",
+              "version": "${{ needs.release.outputs.version }}",
+              "source_repo": "${{ github.repository }}",
+              "source_sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

- Add `notify-plugin-pin-cascade` job to `release.yml` that dispatches a `plugin-release` event to `OmniNode-ai/omnibase_infra` after successful non-RC releases
- Triggers the `plugin-pin-cascade.yml` workflow (OMN-5110) to automatically bump `Dockerfile.runtime` pins
- Gracefully skips when `CROSS_REPO_PAT` secret is not configured
- Uses `peter-evans/repository-dispatch@v4` with `package=omninode-memory`

Part of cross-repo OMN-5137 (omniclaude, omniintelligence, omnimemory).

## Test plan

- [ ] CI passes
- [ ] Manual test: `workflow_dispatch` on `plugin-pin-cascade.yml` in omnibase_infra with `package=omninode-memory` and a test version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated plugin release notifications now alert dependent systems and repositories when new versions are available

* **Chores**
  * Enhanced release automation with improved version tracking and output management for better cross-system coordination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->