### PR TITLE
refactor: remove env_prefix topic prefixing from handlers [OMN-5214]

### DIFF
--- a/src/omnimemory/nodes/node_filesystem_crawler_effect/handler_filesystem_crawler.py
+++ b/src/omnimemory/nodes/node_filesystem_crawler_effect/handler_filesystem_crawler.py
@@ -50,7 +50,6 @@ Example::
             correlation_id=uuid4(),
             crawl_scope="omninode/omnimemory",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publisher,
         )
         print(f"discovered={result.discovered_count}")
@@ -353,7 +352,6 @@ class HandlerFilesystemCrawler:
         correlation_id: UUID,
         crawl_scope: str,
         trigger_source: TriggerSource,
-        env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]
         ],
@@ -373,9 +371,8 @@ class HandlerFilesystemCrawler:
             correlation_id: Threaded from the originating crawl tick command.
             crawl_scope: Scope string from the crawl tick command.
             trigger_source: What triggered this crawl run.
-            env_prefix: Deployment environment prefix (e.g. "dev").
             publish_callback: Async callback for publishing events.
-                Signature: (full_topic, message_dict) -> Coroutine[..., None].
+                Signature: (topic, message_dict) -> Coroutine[..., None].
             scope_mappings: Optional list of (path_prefix, scope_ref) pairs
                 for scope resolution. If None, DEFAULT_SCOPE_REF is used
                 for all files.
@@ -607,7 +604,7 @@ class HandlerFilesystemCrawler:
                     )
                     await _publish_event(
                         publish_callback,
-                        f"{env_prefix}.{self._config.publish_topic_discovered}",
+                        self._config.publish_topic_discovered,
                         discovered_event.model_dump(mode="json"),
                         correlation_id,
                     )
@@ -626,7 +623,7 @@ class HandlerFilesystemCrawler:
                     )
                     await _publish_event(
                         publish_callback,
-                        f"{env_prefix}.{self._config.publish_topic_indexed}",
+                        self._config.publish_topic_indexed,
                         indexed_event.model_dump(mode="json"),
                         correlation_id,
                     )
@@ -682,7 +679,7 @@ class HandlerFilesystemCrawler:
                     )
                     await _publish_event(
                         publish_callback,
-                        f"{env_prefix}.{self._config.publish_topic_changed}",
+                        self._config.publish_topic_changed,
                         changed_event.model_dump(mode="json"),
                         correlation_id,
                     )
@@ -701,7 +698,7 @@ class HandlerFilesystemCrawler:
                     )
                     await _publish_event(
                         publish_callback,
-                        f"{env_prefix}.{self._config.publish_topic_indexed}",
+                        self._config.publish_topic_indexed,
                         indexed_event.model_dump(mode="json"),
                         correlation_id,
                     )
@@ -744,7 +741,6 @@ class HandlerFilesystemCrawler:
                 emitted_at_utc=now_utc,
                 crawl_scope=crawl_scope,
                 trigger_source=trigger_source,
-                env_prefix=env_prefix,
                 publish_callback=publish_callback,
                 resolved_mappings=resolved_mappings,
             )
@@ -789,7 +785,6 @@ class HandlerFilesystemCrawler:
         emitted_at_utc: datetime,
         crawl_scope: str,
         trigger_source: TriggerSource,
-        env_prefix: str,
         publish_callback: Callable[
             [str, dict[str, object]], Coroutine[object, object, None]
         ],
@@ -816,7 +811,6 @@ class HandlerFilesystemCrawler:
             emitted_at_utc: UTC datetime when the crawl run started.
             crawl_scope: Scope string from the originating crawl tick command.
             trigger_source: What triggered the crawl run.
-            env_prefix: Environment prefix for topic construction.
             publish_callback: Async publish callback.
             resolved_mappings: Scope mappings for source_type resolution.
 
@@ -874,7 +868,7 @@ class HandlerFilesystemCrawler:
                     )
                     await _publish_event(
                         publish_callback,
-                        f"{env_prefix}.{self._config.publish_topic_removed}",
+                        self._config.publish_topic_removed,
                         removed_event.model_dump(mode="json"),
                         correlation_id,
                     )

--- a/src/omnimemory/nodes/node_intent_event_consumer_effect/handler_intent_event_consumer.py
+++ b/src/omnimemory/nodes/node_intent_event_consumer_effect/handler_intent_event_consumer.py
@@ -15,18 +15,12 @@ Architecture:
     - Staleness detection for health monitoring
 
 Topic Naming:
-    Full topic names are constructed as ``{env_prefix}.{topic_suffix}`` where:
-
-    - ``env_prefix`` is a deployment realm (e.g., ``"dev"``, ``"staging"``,
-      ``"prod"``) that isolates environments on the same cluster.
-    - ``topic_suffix`` contains the ``onex.`` namespace and event path
-      (e.g., ``onex.evt.omnimemory.intent-stored.v1``).
-
-    Resulting topic example: ``dev.onex.evt.omnimemory.intent-stored.v1``
+    Topic names use bare canonical ONEX format without environment prefixes.
+    Example: ``onex.evt.omnimemory.intent-stored.v1``
 
 Consumer Group:
     Derived from node identity per ADR:
-    ``{env_prefix}.omnimemory.intent_event_consumer_effect.consume.v1``
+    ``omnimemory.intent_event_consumer_effect.consume.v1``
 
 Contract Format:
     Uses standard ``event_bus.subscribe_topics`` contract format (OMN-1746)
@@ -56,7 +50,6 @@ Example::
         # (event_bus.subscribe is injected by the runtime layer)
         await consumer.initialize(
             subscribe_callback=event_bus.subscribe,
-            env_prefix="dev",
         )
 
         # Run until shutdown
@@ -111,14 +104,9 @@ class HandlerIntentEventConsumer:
     """Event bus consumer for intent-classified events.
 
     Consumer group is derived from node identity per ADR:
-    ``{env_prefix}.{service}.{node_name}.{purpose}.{version}``
+    ``{service}.{node_name}.{purpose}.{version}``
 
-    Example: ``dev.omnimemory.intent_event_consumer_effect.consume.v1``
-
-    The ``env_prefix`` parameter is a deployment realm (e.g., ``"dev"``,
-    ``"staging"``, ``"prod"``) that isolates environments on the same event bus
-    cluster. It is separate from the ``onex.`` namespace embedded in topic
-    suffixes.
+    Example: ``omnimemory.intent_event_consumer_effect.consume.v1``
 
     Topic configuration uses list-based fields matching the standard
     ``event_bus.subscribe_topics`` contract format (OMN-1746). The first
@@ -138,7 +126,7 @@ class HandlerIntentEventConsumer:
         await storage.initialize(connection_uri="bolt://{OMNIMEMORY_MEMGRAPH_HOST}:{OMNIMEMORY_MEMGRAPH_PORT}")
 
         consumer = HandlerIntentEventConsumer(config, storage)
-        await consumer.initialize(event_bus_subscribe, "dev")
+        await consumer.initialize(event_bus_subscribe)
     """
 
     def __init__(
@@ -174,7 +162,6 @@ class HandlerIntentEventConsumer:
 
         # Event bus publish callback (set during initialize)
         self._publish_callback: Callable[[str, dict[str, object]], None] | None = None
-        self._env_prefix: str = "dev"
 
         # Track pending tasks to prevent garbage collection (RUF006)
         self._pending_tasks: set[asyncio.Task[None]] = set()
@@ -207,19 +194,17 @@ class HandlerIntentEventConsumer:
         subscribe_callback: Callable[
             [str, Callable[[dict[str, object]], None]], Callable[[], None]
         ],
-        env_prefix: str = "dev",
         publish_callback: Callable[[str, dict[str, object]], None] | None = None,
     ) -> None:
         """Initialize event bus subscriptions for all configured subscribe_topics.
 
-        Subscribes to each topic in ``config.subscribe_topics``, constructing
-        full topic names as ``{env_prefix}.{topic_suffix}``.
+        Subscribes to each topic in ``config.subscribe_topics`` using bare
+        canonical ONEX topic names.
 
         Args:
             subscribe_callback: Function to subscribe to an event bus topic.
                 Signature: (topic, handler) -> unsubscribe_fn.
                 Injected by the runtime layer (e.g., EventBusKafka.subscribe).
-            env_prefix: Environment prefix for topic names (e.g., "dev", "staging").
             publish_callback: Optional callback for publishing events.
                 Signature: (topic, message_dict) -> None
         """
@@ -240,25 +225,23 @@ class HandlerIntentEventConsumer:
                 "consumer would initialize with no subscriptions"
             )
 
-        self._env_prefix = env_prefix
         self._publish_callback = publish_callback
 
         failed_topics: list[tuple[str, str]] = []
-        for topic_suffix in self._config.subscribe_topics:
-            full_topic = f"{env_prefix}.{topic_suffix}"
+        for topic in self._config.subscribe_topics:
             try:
-                unsubscribe = subscribe_callback(full_topic, self._handle_message_sync)
+                unsubscribe = subscribe_callback(topic, self._handle_message_sync)
             except Exception as e:
                 logger.error(
                     "Failed to subscribe to topic",
                     extra={
                         "handler": HANDLER_ID_INTENT_CONSUMER,
-                        "topic": full_topic,
+                        "topic": topic,
                         "error": str(e),
                         "error_type": type(e).__name__,
                     },
                 )
-                failed_topics.append((full_topic, str(e)))
+                failed_topics.append((topic, str(e)))
                 continue
 
             self._unsubscribe_fns.append(unsubscribe)
@@ -267,8 +250,7 @@ class HandlerIntentEventConsumer:
                 "Kafka subscription initialized",
                 extra={
                     "handler": HANDLER_ID_INTENT_CONSUMER,
-                    "topic": full_topic,
-                    "env_prefix": env_prefix,
+                    "topic": topic,
                 },
             )
 
@@ -555,8 +537,7 @@ class HandlerIntentEventConsumer:
             )
             return
 
-        publish_topic = self._config.publish_topics[0]
-        topic = f"{self._env_prefix}.{publish_topic}"
+        topic = self._config.publish_topics[0]
         try:
             self._publish_callback(topic, event.model_dump(mode="json"))
             logger.debug(
@@ -615,7 +596,7 @@ class HandlerIntentEventConsumer:
             )
             return
 
-        topic = f"{self._env_prefix}.{dlq_topic}"
+        topic = dlq_topic
         dlq_message = {
             "original_message": message,
             "failure_reason": reason,

--- a/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
@@ -100,9 +100,8 @@ performance:
 # NOTE: Using version per ModelEventTypeSubcontract from omnibase_core
 #
 # Topic Naming Convention:
-#   - These are SUFFIXES only (no env prefix like "dev.")
-#   - Runtime composes full topic: f"{topic_env_prefix}.{suffix}"
-#   - Example: dev.onex.cmd.omnimemory.intent-query-requested.v1
+#   - Topics use bare canonical ONEX names (no env prefix)
+#   - Example: onex.cmd.omnimemory.intent-query-requested.v1
 #
 # Invocation Mode: SUBSCRIPTION
 #   - This node subscribes to request topics (runtime dispatches inbound)

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/handler_kreuzberg_parse.py
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/handler_kreuzberg_parse.py
@@ -45,7 +45,7 @@ Example::
         parser_version="1.0.0",
     )
     handler = HandlerKreuzbergParse(config=config)
-    await handler.process_event(event=event, env_prefix="dev", publish_callback=cb)
+    await handler.process_event(event=event, publish_callback=cb)
 
 .. versionadded:: 0.5.0
     Initial implementation for OMN-2733.
@@ -159,7 +159,6 @@ class HandlerKreuzbergParse:
     async def process_event(
         self,
         event: ModelDocumentDiscoveredEvent | ModelDocumentChangedEvent,
-        env_prefix: str,
         publish_callback: Callable[[str, dict[str, object]], Coroutine[Any, Any, None]],
     ) -> ModelKreuzbergParseResult:
         """Process a single document discovered or changed event.
@@ -167,8 +166,6 @@ class HandlerKreuzbergParse:
         Args:
             event: The triggering document event carrying source_ref and
                 content_fingerprint.
-            env_prefix: Environment prefix used to build fully-qualified
-                topic names (e.g. "dev", "prod").
             publish_callback: Async callable that accepts (topic, payload_dict)
                 and publishes the message to the event bus.
 
@@ -180,16 +177,8 @@ class HandlerKreuzbergParse:
         content_hash = event.content_fingerprint
         config = self._config
 
-        indexed_topic = (
-            f"{env_prefix}.{config.publish_topic_indexed}"
-            if env_prefix
-            else config.publish_topic_indexed
-        )
-        failed_topic = (
-            f"{env_prefix}.{config.publish_topic_parse_failed}"
-            if env_prefix
-            else config.publish_topic_parse_failed
-        )
+        indexed_topic = config.publish_topic_indexed
+        failed_topic = config.publish_topic_parse_failed
         now = datetime.now(tz=timezone.utc)
 
         # Reject paths outside document_root before any filesystem access

--- a/tests/integration/nodes/test_kreuzberg_parse_effect.py
+++ b/tests/integration/nodes/test_kreuzberg_parse_effect.py
@@ -133,7 +133,6 @@ async def _run_handler(
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -297,13 +296,11 @@ async def test_idempotent_crawl_no_duplicate_events(tmp_path: Path) -> None:
         # First call
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
         # Second call — same event, same fingerprint
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 

--- a/tests/nodes/node_filesystem_crawler_effect/test_handler_filesystem_crawler.py
+++ b/tests/nodes/node_filesystem_crawler_effect/test_handler_filesystem_crawler.py
@@ -351,7 +351,6 @@ class TestHandlerFilesystemCrawlerNoPathPrefixes:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -377,7 +376,6 @@ class TestHandlerFilesystemCrawlerNonExistentPrefix:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -406,7 +404,6 @@ class TestHandlerFilesystemCrawlerDiscovered:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -420,7 +417,7 @@ class TestHandlerFilesystemCrawlerDiscovered:
         assert len(discovered_events) == 1
 
         topic, payload = discovered_events[0]
-        assert topic == "dev.onex.evt.omnimemory.document-discovered.v1"
+        assert topic == "onex.evt.omnimemory.document-discovered.v1"
         assert payload["event_type"] == "DocumentDiscovered"
         assert payload["content_fingerprint"] == _sha256(content)
         assert payload["source_ref"] == str(md_file.resolve())
@@ -444,7 +441,6 @@ class TestHandlerFilesystemCrawlerDiscovered:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -466,7 +462,6 @@ class TestHandlerFilesystemCrawlerDiscovered:
             correlation_id=cid,
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -487,7 +482,6 @@ class TestHandlerFilesystemCrawlerDiscovered:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -508,7 +502,6 @@ class TestHandlerFilesystemCrawlerDiscovered:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -549,7 +542,6 @@ class TestHandlerFilesystemCrawlerMtimeFastPath:
                 correlation_id=uuid4(),
                 crawl_scope="omninode/test",
                 trigger_source="scheduled",
-                env_prefix="dev",
                 publish_callback=publish,
             )
 
@@ -580,7 +572,6 @@ class TestHandlerFilesystemCrawlerMtimeFastPath:
                 correlation_id=uuid4(),
                 crawl_scope="omninode/test",
                 trigger_source="scheduled",
-                env_prefix="dev",
                 publish_callback=publish,
             )
 
@@ -613,7 +604,6 @@ class TestHandlerFilesystemCrawlerChanged:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -624,7 +614,7 @@ class TestHandlerFilesystemCrawlerChanged:
         assert len(changed_events) == 1
 
         topic, payload = changed_events[0]
-        assert topic == "dev.onex.evt.omnimemory.document-changed.v1"
+        assert topic == "onex.evt.omnimemory.document-changed.v1"
         assert payload["event_type"] == "DocumentChanged"
         assert payload["content_fingerprint"] == _sha256(new_content)
         assert payload["previous_content_fingerprint"] == old_fp
@@ -653,7 +643,6 @@ class TestHandlerFilesystemCrawlerChanged:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -686,7 +675,6 @@ class TestHandlerFilesystemCrawlerRemoved:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -696,7 +684,7 @@ class TestHandlerFilesystemCrawlerRemoved:
         assert len(removed_events) == 1
 
         topic, payload = removed_events[0]
-        assert topic == "dev.onex.evt.omnimemory.document-removed.v1"
+        assert topic == "onex.evt.omnimemory.document-removed.v1"
         assert payload["event_type"] == "DocumentRemoved"
         assert payload["source_ref"] == ghost_path
 
@@ -723,7 +711,6 @@ class TestHandlerFilesystemCrawlerRemoved:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -748,7 +735,6 @@ class TestHandlerFilesystemCrawlerFileLimits:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -771,7 +757,6 @@ class TestHandlerFilesystemCrawlerFileLimits:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -805,7 +790,6 @@ class TestHandlerFilesystemCrawlerReadErrors:
                 correlation_id=uuid4(),
                 crawl_scope="omninode/test",
                 trigger_source="scheduled",
-                env_prefix="dev",
                 publish_callback=publish,
             )
 
@@ -844,7 +828,6 @@ class TestHandlerFilesystemCrawlerSymlinkEscape:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -880,7 +863,6 @@ class TestHandlerFilesystemCrawlerPublishErrors:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=failing_publish,
         )
 
@@ -908,7 +890,6 @@ class TestHandlerFilesystemCrawlerDocTypeAssignment:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -928,7 +909,6 @@ class TestHandlerFilesystemCrawlerDocTypeAssignment:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -952,7 +932,6 @@ class TestHandlerFilesystemCrawlerSourceType:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -972,7 +951,6 @@ class TestHandlerFilesystemCrawlerSourceType:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -994,7 +972,6 @@ class TestHandlerFilesystemCrawlerPriorityHints:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1014,7 +991,6 @@ class TestHandlerFilesystemCrawlerPriorityHints:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1037,7 +1013,6 @@ class TestHandlerFilesystemCrawlerScopeMappings:
             correlation_id=uuid4(),
             crawl_scope="omninode/custom-scope",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
             scope_mappings=scope_mappings,
         )
@@ -1065,7 +1040,6 @@ class TestHandlerFilesystemCrawlerRecursive:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1087,7 +1061,6 @@ class TestHandlerFilesystemCrawlerRecursive:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1129,7 +1102,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1138,7 +1110,7 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
         indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
         assert len(indexed_events) == 1
         topic, payload = indexed_events[0]
-        assert topic == "dev.onex.evt.omnimemory.document-indexed.v1"
+        assert topic == "onex.evt.omnimemory.document-indexed.v1"
         assert payload["event_type"] == "DocumentIndexed"
         assert payload["source_ref"] == str(md_file.resolve())
         assert payload["content_fingerprint"] == _sha256(content)
@@ -1165,7 +1137,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1175,7 +1146,7 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
         indexed_events = [(t, p) for t, p in published if "document-indexed" in t]
         assert len(indexed_events) == 1
         topic, payload = indexed_events[0]
-        assert topic == "dev.onex.evt.omnimemory.document-indexed.v1"
+        assert topic == "onex.evt.omnimemory.document-indexed.v1"
         assert payload["event_type"] == "DocumentIndexed"
         assert payload["content_fingerprint"] == _sha256(new_content)
 
@@ -1199,7 +1170,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1225,7 +1195,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1251,7 +1220,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/custom-scope",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
             scope_mappings=scope_mappings,
         )
@@ -1275,7 +1243,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=cid,
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 
@@ -1321,7 +1288,6 @@ class TestHandlerFilesystemCrawlerIndexedEvent:
             correlation_id=uuid4(),
             crawl_scope="omninode/test",
             trigger_source="scheduled",
-            env_prefix="dev",
             publish_callback=publish,
         )
 

--- a/tests/nodes/node_intent_event_consumer_effect/test_handler_intent_event_consumer.py
+++ b/tests/nodes/node_intent_event_consumer_effect/test_handler_intent_event_consumer.py
@@ -139,20 +139,18 @@ class TestInitialization:
         """Consumer should report initialized after initialize() is called.
 
         Verifies that all topics in subscribe_topics are subscribed to
-        with the correct env prefix.
+        using bare canonical ONEX topic names.
         """
         config = ModelIntentEventConsumerConfig()
         storage = create_mock_storage_adapter()
         subscribe_fn, subscriptions = create_mock_subscribe()
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         assert consumer.is_initialized is True
         assert len(subscriptions) == 1
-        assert (
-            subscriptions[0][0] == "test.onex.evt.omniintelligence.intent-classified.v1"
-        )
+        assert subscriptions[0][0] == "onex.evt.omniintelligence.intent-classified.v1"
 
     @pytest.mark.asyncio
     async def test_consumer_subscribes_to_multiple_topics(self) -> None:
@@ -167,16 +165,12 @@ class TestInitialization:
         subscribe_fn, subscriptions = create_mock_subscribe()
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         assert consumer.is_initialized is True
         assert len(subscriptions) == 2
-        assert (
-            subscriptions[0][0] == "test.onex.evt.omniintelligence.intent-classified.v1"
-        )
-        assert (
-            subscriptions[1][0] == "test.onex.evt.omniintelligence.intent-classified.v2"
-        )
+        assert subscriptions[0][0] == "onex.evt.omniintelligence.intent-classified.v1"
+        assert subscriptions[1][0] == "onex.evt.omniintelligence.intent-classified.v2"
 
     @pytest.mark.asyncio
     async def test_initialize_idempotent(self) -> None:
@@ -188,11 +182,11 @@ class TestInitialization:
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
 
         # First initialization
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
         assert len(subscriptions) == 1
 
         # Second initialization should be a no-op
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
         assert len(subscriptions) == 1  # Still 1, not 2
         assert consumer.is_initialized is True
 
@@ -206,9 +200,7 @@ class TestInitialization:
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
 
         with pytest.raises(ValueError, match="subscribe_topics must not be empty"):
-            await consumer.initialize(
-                subscribe_callback=subscribe_fn, env_prefix="test"
-            )
+            await consumer.initialize(subscribe_callback=subscribe_fn)
 
         assert consumer.is_initialized is False
         assert len(subscriptions) == 0
@@ -233,15 +225,13 @@ class TestInitialization:
             return MagicMock()
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
-        await consumer.initialize(
-            subscribe_callback=subscribe_with_failure, env_prefix="test"
-        )
+        await consumer.initialize(subscribe_callback=subscribe_with_failure)
 
         # Should be initialized with 2 of 3 topics
         assert consumer.is_initialized is True
         assert len(subscriptions) == 2
-        assert subscriptions[0][0] == "test.onex.evt.topic-good.v1"
-        assert subscriptions[1][0] == "test.onex.evt.topic-good2.v1"
+        assert subscriptions[0][0] == "onex.evt.topic-good.v1"
+        assert subscriptions[1][0] == "onex.evt.topic-good2.v1"
 
     @pytest.mark.asyncio
     async def test_initialize_all_subscriptions_fail_raises(self) -> None:
@@ -260,9 +250,7 @@ class TestInitialization:
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
 
         with pytest.raises(RuntimeError, match="All topic subscriptions failed"):
-            await consumer.initialize(
-                subscribe_callback=subscribe_always_fails, env_prefix="test"
-            )
+            await consumer.initialize(subscribe_callback=subscribe_always_fails)
 
         assert consumer.is_initialized is False
 
@@ -289,7 +277,7 @@ class TestMessageProcessing:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         message = create_valid_message()
         await consumer._handle_message(message, retry_count=0)
@@ -316,7 +304,6 @@ class TestMessageProcessing:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -356,7 +343,6 @@ class TestMessageProcessing:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -406,7 +392,6 @@ class TestUUIDValidation:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -461,7 +446,7 @@ class TestRetryLogic:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         message = create_valid_message()
 
@@ -491,7 +476,7 @@ class TestRetryLogic:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Invalid message
         invalid_message: MessagePayload = {"garbage": "data"}
@@ -515,7 +500,7 @@ class TestRetryLogic:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         message = create_valid_message()
         await consumer._handle_message(message, retry_count=0)
@@ -547,7 +532,7 @@ class TestCircuitBreaker:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Process messages until circuit opens (need 3 failures)
         # Each storage failure records a circuit breaker failure
@@ -578,7 +563,6 @@ class TestCircuitBreaker:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -635,7 +619,7 @@ class TestHealthCheck:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Process a message successfully
         message = create_valid_message()
@@ -659,7 +643,7 @@ class TestHealthCheck:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Set last consume timestamp to be old
         consumer._last_consume_timestamp = datetime.now(timezone.utc) - timedelta(
@@ -682,7 +666,7 @@ class TestHealthCheck:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Never consume any messages
         health = await consumer.health_check()
@@ -699,7 +683,7 @@ class TestHealthCheck:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Manually open the circuit breaker
         consumer._circuit_breaker.state = CircuitBreakerState.OPEN
@@ -747,7 +731,6 @@ class TestEventEmission:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -786,7 +769,6 @@ class TestEventEmission:
         subscribe_fn, _ = create_mock_subscribe()
         await consumer.initialize(
             subscribe_callback=subscribe_fn,
-            env_prefix="test",
             publish_callback=mock_publish,
         )
 
@@ -824,7 +806,7 @@ class TestStopCleanup:
             return unsubscribe_mock
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
-        await consumer.initialize(subscribe_callback=mock_subscribe, env_prefix="test")
+        await consumer.initialize(subscribe_callback=mock_subscribe)
 
         assert consumer.is_initialized is True
 
@@ -854,7 +836,7 @@ class TestStopCleanup:
             return mock
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
-        await consumer.initialize(subscribe_callback=mock_subscribe, env_prefix="test")
+        await consumer.initialize(subscribe_callback=mock_subscribe)
 
         assert consumer.is_initialized is True
         assert len(unsubscribe_mocks) == 2
@@ -875,7 +857,7 @@ class TestStopCleanup:
 
         consumer = HandlerIntentEventConsumer(config=config, storage_adapter=storage)
         subscribe_fn, _ = create_mock_subscribe()
-        await consumer.initialize(subscribe_callback=subscribe_fn, env_prefix="test")
+        await consumer.initialize(subscribe_callback=subscribe_fn)
 
         # Multiple stop calls should be safe
         await consumer.stop()

--- a/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
+++ b/tests/unit/nodes/test_kreuzberg_parse_effect/test_handler_kreuzberg_parse.py
@@ -143,7 +143,6 @@ async def _run_handler(
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -181,7 +180,6 @@ async def test_too_large_file_emits_parse_failed(tmp_path: Path) -> None:
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -306,13 +304,11 @@ async def test_idempotent_second_call_no_reparse(tmp_path: Path) -> None:
         # First call
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
         # Second call — same event
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -375,7 +371,6 @@ async def test_source_file_oserror_emits_parse_failed(tmp_path: Path) -> None:
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -424,7 +419,6 @@ async def test_cache_write_oserror_inline_fallback(tmp_path: Path) -> None:
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -472,7 +466,6 @@ async def test_cache_write_oserror_too_large_emits_parse_failed(tmp_path: Path) 
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 
@@ -486,12 +479,8 @@ async def test_cache_write_oserror_too_large_emits_parse_failed(tmp_path: Path) 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_empty_env_prefix_uses_bare_topic_names(tmp_path: Path) -> None:
-    """env_prefix='' publishes to the bare topic name with no leading dot or prefix.
-
-    Validates the falsy-env_prefix branch at handler lines 184-193:
-        indexed_topic = config.publish_topic_indexed  (not f"dev.{...}")
-    """
+async def test_bare_topic_names_used(tmp_path: Path) -> None:
+    """Handler publishes to bare canonical ONEX topic names without any prefix."""
     config = _make_config(
         text_store_path=str(tmp_path),
         inline_text_max_chars=4096,
@@ -518,7 +507,6 @@ async def test_empty_env_prefix_uses_bare_topic_names(tmp_path: Path) -> None:
     ):
         await handler.process_event(
             event=event,
-            env_prefix="",
             publish_callback=_cb,
         )
 
@@ -526,14 +514,10 @@ async def test_empty_env_prefix_uses_bare_topic_names(tmp_path: Path) -> None:
     topic, payload = published[0]
 
     bare_indexed_topic = config.publish_topic_indexed
-    prefixed_indexed_topic = f"dev.{bare_indexed_topic}"
 
-    # Must publish to the bare topic — no prefix, no leading dot
+    # Must publish to the bare topic -- no prefix, no leading dot
     assert topic == bare_indexed_topic, (
         f"Expected bare topic {bare_indexed_topic!r}, got {topic!r}"
-    )
-    assert topic != prefixed_indexed_topic, (
-        f"Topic must not be prefixed with 'dev.', got {topic!r}"
     )
     assert not topic.startswith("."), f"Topic must not start with '.', got {topic!r}"
     assert payload["parse_status"] == "ok"
@@ -569,7 +553,6 @@ async def test_source_ref_path_traversal_emits_parse_failed(tmp_path: Path) -> N
     ):
         await handler.process_event(
             event=event,
-            env_prefix="dev",
             publish_callback=_cb,
         )
 

--- a/tests/unit/runtime/test_dispatch_handlers.py
+++ b/tests/unit/runtime/test_dispatch_handlers.py
@@ -216,7 +216,7 @@ class TestCreateMemoryDispatchEngine:
             intent_consumer=mock_intent_consumer,
             intent_query_handler=mock_intent_query_handler,
             publish_topics={
-                "intent_query": "dev.onex.evt.omnimemory.intent-query-response.v1",
+                "intent_query": "onex.evt.omnimemory.intent-query-response.v1",
             },
         )
         assert engine.is_frozen
@@ -432,7 +432,7 @@ class TestIntentQueryDispatchHandler:
         )
 
         publish_callback = MagicMock()
-        publish_topic = "dev.onex.evt.omnimemory.intent-query-response.v1"
+        publish_topic = "onex.evt.omnimemory.intent-query-response.v1"
 
         handler = create_intent_query_dispatch_handler(
             query_handler=mock_intent_query_handler,
@@ -511,7 +511,7 @@ class TestIntentQueryDispatchHandler:
         )
 
         async_publish_callback = AsyncMock()
-        publish_topic = "dev.onex.evt.omnimemory.intent-query-response.v1"
+        publish_topic = "onex.evt.omnimemory.intent-query-response.v1"
 
         handler = create_intent_query_dispatch_handler(
             query_handler=mock_intent_query_handler,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -747,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -755,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1420,7 +1422,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.20.1"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1455,6 +1457,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "qdrant-client" },
     { name = "redis" },
@@ -1467,9 +1470,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/ef/1c6ae6766aa0dd77c2710bbd60f5c44f34fb0050511cfe112a63f00c34cf/omnibase_infra-0.20.1.tar.gz", hash = "sha256:910b1d65a7eb389b1a56196e7ee5235c22a4977e48498c453435242cb9a5434f", size = 6514147, upload-time = "2026-03-15T21:37:48.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/ad/ef7c8b9a4b62973f249cfdc93b34637897d22f753d87155a704596b3d8bb/omnibase_infra-0.21.1.tar.gz", hash = "sha256:60f93f3d9922983738764dfb769c872e81b02b9851b5edb4b49d0a56f36c26c5", size = 6531486, upload-time = "2026-03-16T20:38:39.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/2f/ee93d47415f9ca3cd9a37eb52eee12bc6685e50f136ead667a98db992331/omnibase_infra-0.20.1-py3-none-any.whl", hash = "sha256:684a5e79aa8b0651c238248f6aa6a9486a5002f5ba0ad8f721028c642b2f14ff", size = 3797894, upload-time = "2026-03-15T21:37:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/57/cb93d89a049f12ce12acd57bd1fd64ab78beb9901993f971037419f98212/omnibase_infra-0.21.1-py3-none-any.whl", hash = "sha256:0f13f76e2c09e317a7ae0987e7041d2553bd6d99a3aa6576fb2c72b2c6c7e288", size = 3805237, upload-time = "2026-03-16T20:38:37.925Z" },
 ]
 
 [[package]]
@@ -1547,7 +1550,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "omnibase-core", specifier = "==0.28.0" },
-    { name = "omnibase-infra", specifier = "==0.20.1" },
+    { name = "omnibase-infra", specifier = "==0.21.1" },
     { name = "omnibase-spi", specifier = "==0.17.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
@@ -2158,11 +2161,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Remove `env_prefix` parameter from all 3 omnimemory event handlers (`handler_intent_event_consumer`, `handler_filesystem_crawler`, `handler_kreuzberg_parse`)
- Topic names now use bare canonical ONEX format (e.g. `onex.evt.omnimemory.intent-stored.v1`) instead of `dev.onex.evt.omnimemory.intent-stored.v1`
- Update all callers, test fixtures, and topic assertions across 9 files

## Test plan

- [x] `uv run pytest tests/ -x` passes (1338 passed, 168 skipped)
- [x] `grep -rn 'env_prefix' src/omnimemory/` returns only Pydantic SettingsConfigDict references (unrelated)
- [x] `grep -rn 'env_prefix' tests/` returns only Pydantic SettingsConfigDict test reference (unrelated)
- [x] All pre-commit hooks pass (ruff, mypy strict, pyright, contract-linter)
- [x] All topic strings in tests are bare canonical format