### PR TITLE
chore(deps): bump omnibase-core to 0.28.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1420,7 +1420,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.20.1"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1455,6 +1455,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pyyaml" },
     { name = "qdrant-client" },
     { name = "redis" },
@@ -1467,9 +1468,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/ef/1c6ae6766aa0dd77c2710bbd60f5c44f34fb0050511cfe112a63f00c34cf/omnibase_infra-0.20.1.tar.gz", hash = "sha256:910b1d65a7eb389b1a56196e7ee5235c22a4977e48498c453435242cb9a5434f", size = 6514147, upload-time = "2026-03-15T21:37:48.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/ad/ef7c8b9a4b62973f249cfdc93b34637897d22f753d87155a704596b3d8bb/omnibase_infra-0.21.1.tar.gz", hash = "sha256:60f93f3d9922983738764dfb769c872e81b02b9851b5edb4b49d0a56f36c26c5", size = 6531486, upload-time = "2026-03-16T20:38:39.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/2f/ee93d47415f9ca3cd9a37eb52eee12bc6685e50f136ead667a98db992331/omnibase_infra-0.20.1-py3-none-any.whl", hash = "sha256:684a5e79aa8b0651c238248f6aa6a9486a5002f5ba0ad8f721028c642b2f14ff", size = 3797894, upload-time = "2026-03-15T21:37:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/57/cb93d89a049f12ce12acd57bd1fd64ab78beb9901993f971037419f98212/omnibase_infra-0.21.1-py3-none-any.whl", hash = "sha256:0f13f76e2c09e317a7ae0987e7041d2553bd6d99a3aa6576fb2c72b2c6c7e288", size = 3805237, upload-time = "2026-03-16T20:38:37.925Z" },
 ]
 
 [[package]]
@@ -1547,7 +1548,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "omnibase-core", specifier = "==0.28.0" },
-    { name = "omnibase-infra", specifier = "==0.20.1" },
+    { name = "omnibase-infra", specifier = "==0.21.1" },
     { name = "omnibase-spi", specifier = "==0.17.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
@@ -2158,11 +2159,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_core` (v0.28.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_core`
- No source code changes -- lockfile only

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_core/actions/runs/23144285409

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version