### PR TITLE
chore: wire no-hardcoded-topics pre-commit hook [OMN-5259]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,16 @@
 #   pre-commit run --all-files --hook-stage pre-push  # Run pre-push hooks
 
 repos:
+  # No hardcoded ONEX topic strings — sourced from onex_change_control (OMN-5259)
+  - repo: https://github.com/OmniNode-ai/onex_change_control
+    rev: 39a09ffb2432b8b7d3f47b334b869b55c9cb4fc6  # pragma: allowlist secret
+    hooks:
+      - id: no-hardcoded-topics
+        # Pre-existing violations — pending migration to canonical topic constants
+        exclude: >-
+          ^src/omnimemory/nodes/(node_filesystem_crawler_effect|node_intent_event_consumer_effect|node_kreuzberg_parse_effect)/models/
+        stages: [pre-commit]
+
   # Stub implementation detection — sourced from omnibase_core (OMN-4472)
   - repo: https://github.com/OmniNode-ai/omnibase_core
     rev: 30a06f85bb5849902d33c8d0bdb90fc6cba0c346  # pragma: allowlist secret

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -330,6 +330,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "validate-spdx-headers",
             "check-stub-implementations",
             "onex-validate-links",
+            "no-hardcoded-topics",
         }
     )
 


### PR DESCRIPTION
## Summary
- Wire `no-hardcoded-topics` hook from onex_change_control into omnimemory
- Pre-existing violations excluded via regex (pending migration to canonical constants)
- Part of OMN-5259: org-wide hook rollout

## Test Plan
- `pre-commit run no-hardcoded-topics --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow validation with a new pre-commit check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->