### PR TITLE
feat: add onex.node_package entry point [OMN-5370]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ Changelog = "https://github.com/OmniNode-ai/omnimemory/blob/main/CHANGELOG.md"
 [project.entry-points."onex.domain_plugins"]
 memory = "omnimemory.runtime.plugin:PluginMemory"
 
+[project.entry-points."onex.node_package"]
+omnimemory = "omnimemory.nodes"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/omnimemory"]
 

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for onex.node_package entry point declaration."""
+
+import importlib.metadata
+
+import pytest
+
+
+@pytest.mark.unit
+def test_node_package_entry_point_declared() -> None:
+    """onex.node_package entry point must be declared and importable."""
+    eps = importlib.metadata.entry_points(group="onex.node_package")
+    names = [ep.name for ep in eps]
+    assert "omnimemory" in names, f"Expected 'omnimemory' in {names}"
+
+
+@pytest.mark.unit
+def test_node_package_entry_point_loads() -> None:
+    """Entry point value must be an importable package."""
+    eps = importlib.metadata.entry_points(group="onex.node_package")
+    ep = next(ep for ep in eps if ep.name == "omnimemory")
+    pkg = ep.load()
+    assert hasattr(pkg, "__path__"), "Entry point must resolve to a package"


### PR DESCRIPTION
## Summary

- Adds `onex.node_package` entry point to `pyproject.toml` pointing to `omnimemory.nodes`
- Enables `create_kafka_topics.py` to discover contract.yaml files from installed packages
- Adds two unit tests verifying the entry point is declared and loadable

## Test plan

- [x] `uv run pytest tests/unit/test_entry_points.py -v` passes (2/2)
- [ ] CI passes