### PR TITLE
ci(omnimemory): add ruff UP007 standards compliance workflow [std-sweep-v2]

### DIFF
--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+name: Omni* Ecosystem Standards Compliance
+
+on:
+  push:
+    branches: [main, develop, "jonah/*", "jonahgabriel/*"]
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+  REPO_NAME: "omnimemory"
+
+# ci-health-ok: blocking mypy --strict already enforced in test.yml lint job
+
+jobs:
+  type-union-check:
+    name: PEP 604 Type Union Check (UP007)
+    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    runs-on: >-
+      ${{
+        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
+         (github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule'))
+        && fromJSON('["self-hosted","omnibase-ci"]')
+        || fromJSON('["ubuntu-latest"]')
+      }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check for Optional/Union usage (PEP 604)
+        run: uv run ruff check src/ --select UP007,UP006


### PR DESCRIPTION
## Summary

- Add `omni-standards-compliance.yml` with blocking `ruff check --select UP007,UP006`
- Blocking mypy already enforced in `test.yml` lint job (strict mode); `ci-health-ok` comment added
- UP007 check is fully blocking (0 violations confirmed)

Part of std-sweep-v2 initiative [OMN-5132].

## Test plan
- [ ] `type-union-check` job passes (0 UP007 violations)