### PR TITLE
feat(ci): deploy CodeQL security scanning to omnimemory [OMN-5424]

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# CodeQL security and quality analysis for omnimemory.
+# Calls the reusable workflow in onex_change_control.
+# OMN-5424
+
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+jobs:
+  codeql:
+    name: CodeQL
+    uses: OmniNode-ai/onex_change_control/.github/workflows/codeql-reusable.yml@main
+    with:
+      language: python
+      query_suite: security-and-quality
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/scripts/validation/validate_naming.py
+++ b/scripts/validation/validate_naming.py
@@ -356,7 +356,9 @@ def detect_expected_prefix_from_bases(
     return None, None
 
 
-def validate_file(filepath: Path) -> list[Violation]:  # stub-ok: docstring uses ModelXxx/ServiceXxx as naming examples, not TODO markers
+def validate_file(  # stub-ok: docstring uses ModelXxx/ServiceXxx as naming examples, not TODO markers
+    filepath: Path,
+) -> list[Violation]:
     """Validate a single Python file.
 
     Validates:


### PR DESCRIPTION
## Summary

- Add `.github/workflows/security-scan.yml` calling the reusable CodeQL workflow from `onex_change_control`
- Python language, `security-and-quality` query suite
- Runs on push/PR to main and weekly Monday schedule
- Also fix pre-existing stub-ok comment placement in `scripts/validation/validate_naming.py` after ruff reformatted the multi-line return type annotation
- Part of OMN-5412 epic: Platform-wide CodeQL deployment

## Test plan

- [ ] CI passes on this PR
- [ ] CodeQL results visible in Security tab after first run
- [ ] No regressions in existing CI jobs

Closes OMN-5424