### PR TITLE
chore: remove canceled TODO for OMN-1589 [OMN-5690]

### DIFF
--- a/src/omnimemory/nodes/node_intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/node_intent_query_effect/handlers/handler_intent_query.py
@@ -695,7 +695,6 @@ class HandlerIntentQuery:
         execution_time_ms = (time.monotonic() - start) * 1000
 
         # Handler is initialized if we reached here (checked in execute())
-        # TODO(OMN-1589): query_type="health_check" not in Literal - need to update omnibase_core model
         return ModelIntentQueryResponseEvent(
             query_id=request.query_id,
             query_type="health_check",  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Summary

- Remove canceled TODO for OMN-1589 (pyright strictness)

Closes OMN-5690 (omnimemory portion)