### PR TITLE
ci: deploy TODO enforcement hooks and workflows [OMN-5694][OMN-5695]

### DIFF
--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -1,0 +1,158 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# stale-todo-gate.yml
+#
+# CI gate: check that TODO/FIXME/HACK comments in changed Python files
+# do not reference Linear tickets in terminal states (Done/Canceled).
+#
+# Copy this file to .github/workflows/stale-todo-gate.yml in each repo.
+#
+# Requires: LINEAR_API_KEY as an org/repo secret.
+# Graceful degradation: if LINEAR_API_KEY is unset, the check is skipped
+# (exit 0) with a visible warning.
+#
+# Implements OMN-5688.
+
+name: Stale TODO Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  stale-todo-gate:
+    name: Stale TODO Gate
+    runs-on: >-
+      ${{
+        vars.USE_SELF_HOSTED_RUNNERS == 'true'
+        && 'self-hosted, omnibase-ci'
+        || 'ubuntu-latest'
+      }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for stale TODOs in changed files
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # --- Graceful degradation ---
+          if [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "::warning::LINEAR_API_KEY not set -- stale-TODO gate skipped"
+            exit 0
+          fi
+
+          # --- Collect changed .py files ---
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD -- '*.py' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No Python files changed -- nothing to check."
+            exit 0
+          fi
+
+          # --- Extract unique OMN-XXXX ticket IDs from TODO comments ---
+          TICKET_IDS=""
+          while IFS= read -r file; do
+            [ -f "$file" ] || continue
+            # Match TODO(OMN-1234), FIXME(OMN-1234), HACK(OMN-1234) in comments
+            IDS=$(grep -oE '#.*\b(TODO|FIXME|HACK)\(OMN-[0-9]+\)' "$file" 2>/dev/null \
+              | grep -oE 'OMN-[0-9]+' || true)
+            if [ -n "$IDS" ]; then
+              TICKET_IDS="$TICKET_IDS"$'\n'"$IDS"
+            fi
+          done <<< "$CHANGED_FILES"
+
+          UNIQUE_IDS=$(echo "$TICKET_IDS" | sort -u | grep -v '^$' || true)
+          if [ -z "$UNIQUE_IDS" ]; then
+            echo "No TODO ticket references found in changed files -- clean."
+            exit 0
+          fi
+
+          echo "Found ticket references: $(echo "$UNIQUE_IDS" | tr '\n' ' ')"
+
+          # --- Query Linear for ticket states ---
+          # Build a filter query to batch-check all ticket IDs
+          STALE_TICKETS=""
+          STALE_COUNT=0
+
+          while IFS= read -r TICKET_ID; do
+            [ -z "$TICKET_ID" ] && continue
+
+            # Validate format
+            if ! echo "$TICKET_ID" | grep -qE '^OMN-[0-9]+$'; then
+              continue
+            fi
+
+            RESPONSE=$(curl -s --max-time 15 -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"{ issue(id: \\\"$TICKET_ID\\\") { identifier title state { name type } } }\"}" \
+              2>&1)
+
+            STATE_TYPE=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          issue = data.get('data', {}).get('issue')
+          if issue:
+              print(issue.get('state', {}).get('type', ''))
+          else:
+              print('NOT_FOUND')
+          " 2>/dev/null || echo "UNKNOWN")
+
+            STATE_NAME=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          issue = data.get('data', {}).get('issue')
+          if issue:
+              print(issue.get('state', {}).get('name', ''))
+          else:
+              print('')
+          " 2>/dev/null || echo "")
+
+            TITLE=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          issue = data.get('data', {}).get('issue')
+          if issue:
+              print(issue.get('title', ''))
+          else:
+              print('')
+          " 2>/dev/null || echo "")
+
+            # Terminal states: COMPLETED or CANCELED (using Linear's state type field)
+            if echo "$STATE_TYPE" | grep -qiE '^(completed|canceled|cancelled)$'; then
+              STALE_COUNT=$((STALE_COUNT + 1))
+              STALE_TICKETS="${STALE_TICKETS}  - ${TICKET_ID} (${STATE_NAME}): ${TITLE}"$'\n'
+
+              # Find which files reference this ticket
+              while IFS= read -r file; do
+                [ -f "$file" ] || continue
+                LOCATIONS=$(grep -n "TODO.*${TICKET_ID}\|FIXME.*${TICKET_ID}\|HACK.*${TICKET_ID}" "$file" 2>/dev/null || true)
+                if [ -n "$LOCATIONS" ]; then
+                  while IFS= read -r loc; do
+                    STALE_TICKETS="${STALE_TICKETS}    ${file}:${loc}"$'\n'
+                  done <<< "$LOCATIONS"
+                fi
+              done <<< "$CHANGED_FILES"
+            fi
+          done <<< "$UNIQUE_IDS"
+
+          if [ "$STALE_COUNT" -gt 0 ]; then
+            echo ""
+            echo "::error::Found ${STALE_COUNT} stale TODO(s) referencing closed/canceled tickets:"
+            echo ""
+            echo "$STALE_TICKETS"
+            echo ""
+            echo "These TODOs reference tickets that are already Done or Canceled."
+            echo "Either remove the TODO or create a new ticket for the remaining work."
+            exit 1
+          fi
+
+          echo "All ${UNIQUE_IDS_COUNT:-$(echo "$UNIQUE_IDS" | wc -l | tr -d ' ')} TODO ticket references are active -- clean."

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -1,0 +1,197 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# todo-audit-on-merge.yml
+#
+# Post-merge workflow: when a PR merges, check for residual TODOs
+# referencing the branch's ticket. If found, auto-create a follow-up
+# Linear ticket to track the cleanup.
+#
+# Copy this file to .github/workflows/todo-audit-on-merge.yml in each repo.
+#
+# Requires: LINEAR_API_KEY as an org/repo secret.
+# Graceful degradation: if LINEAR_API_KEY is unset, the audit is skipped.
+#
+# Branch name conventions (reuses linear-close-on-merge.yml extraction):
+#   jonahgabriel/omn-XXXX-description
+#   jonah/omn-XXXX-description
+#   epic/OMN-XXXX/OMN-YYYY/run-id
+#   OMN-XXXX-description
+#
+# Implements OMN-5689.
+
+name: TODO Audit on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  todo-audit:
+    name: TODO Audit
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract ticket ID from branch name
+        id: extract
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        shell: bash
+        run: |
+          echo "Branch: $BRANCH"
+
+          TICKET_ID=""
+
+          # Epic branch: epic/OMN-XXXX/OMN-YYYY/...
+          if printf '%s' "$BRANCH" | grep -qiE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)"; then
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)" | grep -ioE "OMN-[0-9]+" | tail -1)
+          fi
+
+          # Standard: */omn-XXXX-* or omn-XXXX-*
+          if [[ -z "$TICKET_ID" ]]; then
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "(OMN|omn)-[0-9]+" | head -1 | tr '[:lower:]' '[:upper:]')
+          fi
+
+          if [[ -z "$TICKET_ID" ]]; then
+            echo "No OMN-XXXX ticket ID found in branch '$BRANCH' -- skipping audit."
+            echo "ticket_id=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Extracted ticket ID: $TICKET_ID"
+            echo "ticket_id=$TICKET_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for residual TODOs and create follow-up ticket
+        if: steps.extract.outputs.ticket_id != ''
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          TICKET_ID: ${{ steps.extract.outputs.ticket_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${LINEAR_API_KEY:-}" ]; then
+            echo "::warning::LINEAR_API_KEY not set -- TODO audit skipped"
+            exit 0
+          fi
+
+          echo "Scanning for residual TODOs referencing $TICKET_ID..."
+
+          # Find residual TODOs/FIXMEs/HACKs referencing this ticket
+          RESIDUALS=$(grep -rn "TODO.*${TICKET_ID}\|FIXME.*${TICKET_ID}\|HACK.*${TICKET_ID}" \
+            --include="*.py" . 2>/dev/null || true)
+
+          if [ -z "$RESIDUALS" ]; then
+            echo "No residual TODOs found for $TICKET_ID -- clean merge."
+            exit 0
+          fi
+
+          RESIDUAL_COUNT=$(echo "$RESIDUALS" | wc -l | tr -d ' ')
+          echo "Found $RESIDUAL_COUNT residual TODO(s) for $TICKET_ID:"
+          echo "$RESIDUALS"
+
+          # --- Dedup check: search for existing follow-up ticket ---
+          FOLLOWUP_TITLE="chore: clean up residual TODOs for ${TICKET_ID}"
+
+          SEARCH_RESPONSE=$(curl -s --max-time 15 -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ issueSearch(query: \\\"${FOLLOWUP_TITLE}\\\", first: 5) { nodes { id identifier title description } } }\"}" \
+            2>&1)
+
+          EXISTING=$(echo "$SEARCH_RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          nodes = data.get('data', {}).get('issueSearch', {}).get('nodes', [])
+          # Check for exact title match or metadata match
+          for n in nodes:
+              if n.get('title', '') == '${FOLLOWUP_TITLE}':
+                  print(n['identifier'])
+                  sys.exit(0)
+              desc = n.get('description', '') or ''
+              if '<!-- source: ${TICKET_ID} -->' in desc:
+                  print(n['identifier'])
+                  sys.exit(0)
+          print('')
+          " 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING" ]; then
+            echo "Follow-up ticket already exists: $EXISTING -- skipping creation."
+            exit 0
+          fi
+
+          # --- Get team ID from the source ticket ---
+          TEAM_RESPONSE=$(curl -s --max-time 15 -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ issue(id: \\\"$TICKET_ID\\\") { team { id } } }\"}" \
+            2>&1)
+
+          TEAM_ID=$(echo "$TEAM_RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          issue = data.get('data', {}).get('issue')
+          if issue:
+              print(issue.get('team', {}).get('id', ''))
+          else:
+              print('')
+          " 2>/dev/null || echo "")
+
+          if [ -z "$TEAM_ID" ]; then
+            echo "Could not determine team ID from $TICKET_ID -- skipping follow-up creation."
+            exit 0
+          fi
+
+          # Validate TEAM_ID
+          if ! echo "$TEAM_ID" | grep -qE '^[0-9a-f-]+$'; then
+            echo "Invalid team ID format -- skipping."
+            exit 0
+          fi
+
+          # --- Build description ---
+          # Escape residuals for JSON
+          ESCAPED_RESIDUALS=$(echo "$RESIDUALS" | python3 -c "
+          import json, sys
+          print(json.dumps(sys.stdin.read()))
+          " 2>/dev/null | sed 's/^"//;s/"$//')
+
+          DESCRIPTION="<!-- source: ${TICKET_ID} -->\n\nResidual TODOs found after merging PR #${PR_NUMBER} in \`${REPO}\`.\n\nSource ticket: ${TICKET_ID}\n\n## Locations\n\n\`\`\`\n${ESCAPED_RESIDUALS}\n\`\`\`\n\nPlease remove or re-tag these TODOs with a new ticket number."
+
+          # --- Create follow-up ticket (priority 4 = Low) ---
+          CREATE_RESPONSE=$(curl -s --max-time 15 -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { issueCreate(input: { title: \\\"${FOLLOWUP_TITLE}\\\", description: \\\"${DESCRIPTION}\\\", teamId: \\\"${TEAM_ID}\\\", priority: 4 }) { success issue { id identifier url } } }\"}" \
+            2>&1)
+
+          CREATED_ID=$(echo "$CREATE_RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          issue = data.get('data', {}).get('issueCreate', {}).get('issue')
+          if issue:
+              print(issue.get('identifier', ''))
+          else:
+              print('')
+          " 2>/dev/null || echo "")
+
+          if [ -n "$CREATED_ID" ]; then
+            CREATED_URL=$(echo "$CREATE_RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          print(data.get('data', {}).get('issueCreate', {}).get('issue', {}).get('url', ''))
+          " 2>/dev/null || echo "")
+            echo "Created follow-up ticket: $CREATED_ID ($CREATED_URL)"
+            echo "::notice::Created follow-up ticket $CREATED_ID for $RESIDUAL_COUNT residual TODO(s)"
+          else
+            echo "::warning::Failed to create follow-up ticket for residual TODOs"
+            # Non-fatal
+            exit 0
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,12 +78,14 @@
 repos:
   # No hardcoded ONEX topic strings — sourced from onex_change_control (OMN-5259)
   - repo: https://github.com/OmniNode-ai/onex_change_control
-    rev: 39a09ffb2432b8b7d3f47b334b869b55c9cb4fc6  # pragma: allowlist secret
+    rev: 8d7e85bc00e7f1b1306d1cb40949be1ab6e7e91a  # pragma: allowlist secret
     hooks:
       - id: no-hardcoded-topics
         # Pre-existing violations — pending migration to canonical topic constants
         exclude: >-
           ^src/omnimemory/nodes/(node_filesystem_crawler_effect|node_intent_event_consumer_effect|node_kreuzberg_parse_effect)/models/
+        stages: [pre-commit]
+      - id: no-untracked-todos
         stages: [pre-commit]
 
   # Stub implementation detection — sourced from omnibase_core (OMN-4472)

--- a/scripts/validation/validate_http_imports.py
+++ b/scripts/validation/validate_http_imports.py
@@ -105,7 +105,7 @@ ALLOWED_PATHS = [
     # Adapter layer - the only allowed exit hatch
     "handlers/adapters/",
     # Legacy clients directory - allowed during migration
-    # TODO: Remove this allowance after migration to adapters is complete
+    # TODO(OMN-5694): Remove this allowance after migration to adapters is complete
     "nodes/node_memory_retrieval_effect/clients/",
     # Kreuzberg effect client - HTTP transport boundary for document extraction (OMN-2733)
     "nodes/node_kreuzberg_parse_effect/clients/",

--- a/scripts/validation/validate_naming.py
+++ b/scripts/validation/validate_naming.py
@@ -356,7 +356,7 @@ def detect_expected_prefix_from_bases(
     return None, None
 
 
-def validate_file(  # stub-ok: docstring uses ModelXxx/ServiceXxx as naming examples, not TODO markers
+def validate_file(  # stub-ok: docstring uses ModelXxx/ServiceXxx as naming examples  # TODO_FORMAT_EXEMPT: function doc references marker names
     filepath: Path,
 ) -> list[Violation]:
     """Validate a single Python file.

--- a/scripts/validation/validate_no_backward_compatibility.py
+++ b/scripts/validation/validate_no_backward_compatibility.py
@@ -69,7 +69,7 @@ PATTERNS = [
         "Legacy comment found - migrate to new patterns",
     ),
     (
-        # TODO to remove deprecated code
+        # Marker to remove deprecated code  # TODO_FORMAT_EXEMPT: describes detection pattern for cleanup markers
         re.compile(r"#\s*TODO:\s*(remove|delete).*\bdeprecated\b", re.IGNORECASE),
         "TODO to remove deprecated code - do it now",
     ),

--- a/scripts/validation/validate_secrets.py
+++ b/scripts/validation/validate_secrets.py
@@ -211,8 +211,8 @@ SKIP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "Explicit placeholder: 'REPLACE_ME' (exact match)",
     ),
     (
-        # Matches: "TODO_ADD_REAL_KEY", "TODO-replace-secret"
-        # Requires TODO followed by separator, not just containing TODO
+        # Matches: "TODO_ADD_REAL_KEY", "TODO-replace-secret"  # TODO_FORMAT_EXEMPT: describes regex pattern for placeholder detection
+        # Requires a placeholder marker followed by separator, not just containing it  # TODO_FORMAT_EXEMPT: describes regex pattern
         re.compile(r'["\']TODO[-_][A-Z_-]+["\']', re.IGNORECASE),
         "Explicit placeholder: 'TODO_...' or 'TODO-...'",
     ),
@@ -306,7 +306,7 @@ def _check_line_level_skip_patterns(
     return False, None
 
 
-def _check_skip_patterns(  # stub-ok: docstring uses 'xxxx' as example secret string, not a FIXME marker
+def _check_skip_patterns(  # stub-ok: docstring uses 'xxxx' as example secret string, not a marker  # TODO_FORMAT_EXEMPT: function doc references marker names
     line: str,
     patterns: list[tuple[re.Pattern[str], str]],
     filepath: Path,

--- a/src/omnimemory/models/utils/model_pii_type.py
+++ b/src/omnimemory/models/utils/model_pii_type.py
@@ -41,5 +41,9 @@ class PIIType(str, Enum):
     URL = "url"  # TODO(OMN-5762): Implement URL detection patterns
     API_KEY = "api_key"
     PASSWORD_HASH = "password_hash"  # noqa: S105  # Not a password - PII type enum value
-    PERSON_NAME = "person_name"  # TODO(OMN-5762): Implement dictionary-based + NLP name detection
-    ADDRESS = "address"  # TODO(OMN-5762): Implement address detection with geocoding/NLP
+    PERSON_NAME = (
+        "person_name"  # TODO(OMN-5762): Implement dictionary-based + NLP name detection
+    )
+    ADDRESS = (
+        "address"  # TODO(OMN-5762): Implement address detection with geocoding/NLP
+    )

--- a/src/omnimemory/models/utils/model_pii_type.py
+++ b/src/omnimemory/models/utils/model_pii_type.py
@@ -38,8 +38,8 @@ class PIIType(str, Enum):
     SSN = "ssn"
     CREDIT_CARD = "credit_card"
     IP_ADDRESS = "ip_address"
-    URL = "url"  # TODO: Implement URL detection patterns
+    URL = "url"  # TODO(OMN-5762): Implement URL detection patterns
     API_KEY = "api_key"
     PASSWORD_HASH = "password_hash"  # noqa: S105  # Not a password - PII type enum value
-    PERSON_NAME = "person_name"  # TODO: Implement dictionary-based + NLP name detection
-    ADDRESS = "address"  # TODO: Implement address detection with geocoding/NLP
+    PERSON_NAME = "person_name"  # TODO(OMN-5762): Implement dictionary-based + NLP name detection
+    ADDRESS = "address"  # TODO(OMN-5762): Implement address detection with geocoding/NLP

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -331,6 +331,7 @@ class TestPrecommitHooksCoveredByAlignments:
             "check-stub-implementations",
             "onex-validate-links",
             "no-hardcoded-topics",
+            "no-untracked-todos",
         }
     )
 


### PR DESCRIPTION
## Summary
- Deploy `no-untracked-todos` pre-commit hook from onex_change_control
- Add `stale-todo-gate.yml` CI workflow (checks TODO ticket status on PRs)
- Add `todo-audit-on-merge.yml` post-merge workflow (creates follow-up tickets for residual TODOs)
- Update onex_change_control rev to include the new hook

## Context
Part of the TODO Enforcement System epic (OMN-5685). Wave 2 deployment of enforcement tooling created in Wave 1 (PR OmniNode-ai/onex_change_control#84).

## Test plan
- [ ] CI passes
- [ ] `stale-todo-gate` workflow runs on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated workflows to gate pull requests for TODOs referencing issue IDs and to audit/create follow-up tasks on merge.

* **Chores**
  * Updated pre-commit configuration and validation scripts to surface and ignore intended TODO markers and improve developer checks.
  * Adjusted inline annotations and formatting for clearer tracking.

* **Tests**
  * Updated unit test expectations to account for the new pre-commit hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->