### PR TITLE
chore(ci): rename test.yml -> ci.yml for cross-repo standardization [OMN-6215]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-name: Test Suite
+name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -50,3 +50,29 @@ jobs:
 
       - name: Check for Optional/Union usage (PEP 604)
         run: uv run ruff check src/ --select UP007,UP006
+
+  ci-naming-convention:
+    name: CI Naming Convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Verify CI workflow naming convention
+        run: |
+          if [ ! -f .github/workflows/ci.yml ]; then
+            echo "::error::Missing .github/workflows/ci.yml"
+            exit 1
+          fi
+          CI_NAME=$(grep -m1 "^name:" .github/workflows/ci.yml | sed "s/name: *//")
+          if [ "$CI_NAME" != "CI" ]; then
+            echo "::error::ci.yml has name '$CI_NAME' — must be 'CI'"
+            exit 1
+          fi
+          for legacy in test.yml ci.yaml; do
+            if [ -f ".github/workflows/$legacy" ]; then
+              echo "::error::Legacy workflow .github/workflows/$legacy exists"
+              exit 1
+            fi
+          done
+          echo "CI naming convention: PASS"

--- a/scripts/validate_ci_precommit_alignment.py
+++ b/scripts/validate_ci_precommit_alignment.py
@@ -4,7 +4,7 @@
 
 """Validate alignment between CI workflow jobs and pre-commit hooks.
 
-This script ensures that the CI workflow (.github/workflows/test.yml) and
+This script ensures that the CI workflow (.github/workflows/ci.yml) and
 pre-commit configuration (.pre-commit-config.yaml) stay synchronized.
 
 It checks:
@@ -117,7 +117,7 @@ def main() -> int:
     verbose = "--verbose" in sys.argv or "-v" in sys.argv
 
     precommit_path = Path(".pre-commit-config.yaml")
-    ci_path = Path(".github/workflows/test.yml")
+    ci_path = Path(".github/workflows/ci.yml")
     required_checks_path = Path(".github/required-checks.yaml")
 
     precommit_content = load_file(precommit_path)

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -58,7 +58,7 @@ def precommit_content() -> str:
 @pytest.fixture
 def ci_content() -> str:
     """Load the actual .github/workflows/ci.yml content from the repo."""
-    path = _REPO_ROOT / ".github" / "workflows" / "test.yml"
+    path = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
     content = path.read_text(encoding="utf-8")
     return content
 
@@ -74,7 +74,7 @@ def precommit_data() -> dict:
 @pytest.fixture
 def ci_data() -> dict:
     """Parse the actual .github/workflows/ci.yml as a YAML dict."""
-    path = _REPO_ROOT / ".github" / "workflows" / "test.yml"
+    path = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
     content = path.read_text(encoding="utf-8")
     return yaml.safe_load(content)
 
@@ -355,7 +355,7 @@ class TestPrecommitHooksCoveredByAlignments:
 
 @pytest.mark.unit
 class TestAlignmentsMatchCiWorkflow:
-    """Every CI job name in EXPECTED_ALIGNMENTS must exist in test.yml."""
+    """Every CI job name in EXPECTED_ALIGNMENTS must exist in ci.yml."""
 
     def test_all_expected_ci_jobs_exist(self, ci_content: str) -> None:
         actual_ci_jobs = extract_ci_job_ids(ci_content)

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -57,7 +57,7 @@ def precommit_content() -> str:
 
 @pytest.fixture
 def ci_content() -> str:
-    """Load the actual .github/workflows/test.yml content from the repo."""
+    """Load the actual .github/workflows/ci.yml content from the repo."""
     path = _REPO_ROOT / ".github" / "workflows" / "test.yml"
     content = path.read_text(encoding="utf-8")
     return content
@@ -73,7 +73,7 @@ def precommit_data() -> dict:
 
 @pytest.fixture
 def ci_data() -> dict:
-    """Parse the actual .github/workflows/test.yml as a YAML dict."""
+    """Parse the actual .github/workflows/ci.yml as a YAML dict."""
     path = _REPO_ROOT / ".github" / "workflows" / "test.yml"
     content = path.read_text(encoding="utf-8")
     return yaml.safe_load(content)
@@ -363,7 +363,7 @@ class TestAlignmentsMatchCiWorkflow:
         missing = expected_ci_jobs - actual_ci_jobs
         assert not missing, (
             f"EXPECTED_ALIGNMENTS references CI jobs not found in "
-            f".github/workflows/test.yml: {missing}"
+            f".github/workflows/ci.yml: {missing}"
         )
 
     def test_all_ci_descriptions_found_in_workflow(self, ci_content: str) -> None:
@@ -373,7 +373,7 @@ class TestAlignmentsMatchCiWorkflow:
                 missing.append((hook_id, ci_desc))
         assert not missing, (
             f"EXPECTED_ALIGNMENTS references CI descriptions not found in "
-            f".github/workflows/test.yml: {missing}"
+            f".github/workflows/ci.yml: {missing}"
         )
 
 
@@ -483,7 +483,7 @@ class TestEachAlignmentEntry:
         actual_ci_jobs = extract_ci_job_ids(ci_content)
         assert ci_job in actual_ci_jobs, (
             f"CI job '{ci_job}' listed in EXPECTED_ALIGNMENTS but not found in "
-            f".github/workflows/test.yml. Available jobs: {sorted(actual_ci_jobs)}"
+            f".github/workflows/ci.yml. Available jobs: {sorted(actual_ci_jobs)}"
         )
 
     @pytest.mark.parametrize(
@@ -497,7 +497,7 @@ class TestEachAlignmentEntry:
         hook_id, _ci_job, ci_desc = alignment
         assert check_ci_contains(ci_content, ci_desc), (
             f"CI description '{ci_desc}' (for hook '{hook_id}') not found anywhere "
-            f"in .github/workflows/test.yml"
+            f"in .github/workflows/ci.yml"
         )
 
 


### PR DESCRIPTION
## Summary
- Rename `.github/workflows/test.yml` to `ci.yml` with `name: CI`
- Standardize triggers to canonical block (main only, no develop)
- Add CI naming convention check to `omni-standards-compliance.yml`

Part of epic OMN-6211: CI Workflow Standardization.

## Test plan
- [ ] CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CI workflow to "CI" and limited its runs to the main branch.
  * Added automated validation to enforce workflow naming and disallow legacy workflow files.
* **Tests**
  * Updated test suite to align with the renamed CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->