### PR TITLE
feat: env-configurable retrieval stubs + wire similarity handler

### DIFF
--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -30,6 +30,7 @@ import contextlib
 import inspect
 import json
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 from uuid import UUID, uuid4
@@ -420,13 +421,33 @@ def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handle
         ModelHandlerMemoryRetrievalConfig,
         ModelMemoryRetrievalRequest,
     )
+    from omnimemory.nodes.node_memory_retrieval_effect.models.model_handler_qdrant_config import (
+        ModelHandlerQdrantConfig,
+    )
 
     _retrieval_handler: HandlerMemoryRetrieval | None = None
 
     async def _get_retrieval_handler() -> HandlerMemoryRetrieval:
         nonlocal _retrieval_handler
         if _retrieval_handler is None:
-            config = ModelHandlerMemoryRetrievalConfig(use_stub_handlers=True)
+            use_stubs = (
+                os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
+            )
+            qdrant_config = (
+                None
+                if use_stubs
+                else ModelHandlerQdrantConfig(
+                    qdrant_host=os.getenv("QDRANT_HOST", "localhost"),
+                    qdrant_port=int(os.getenv("QDRANT_PORT", "6333")),
+                    embedding_server_url=os.getenv(
+                        "LLM_EMBEDDING_URL", "http://localhost:8100"
+                    ),
+                )
+            )
+            config = ModelHandlerMemoryRetrievalConfig(
+                use_stub_handlers=use_stubs,
+                qdrant_config=qdrant_config,
+            )
             _retrieval_handler = HandlerMemoryRetrieval(config)
             await _retrieval_handler.initialize()
         return _retrieval_handler

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -47,6 +47,10 @@ if TYPE_CHECKING:
         ProtocolHandlerContext,
     )
 
+    from omnimemory.nodes.node_memory_retrieval_effect.models import (
+        ModelHandlerMemoryRetrievalConfig,
+    )
+
 logger = logging.getLogger(__name__)
 
 # =============================================================================
@@ -393,6 +397,47 @@ def create_lifecycle_dispatch_handler(
 # =============================================================================
 
 
+def build_retrieval_config_from_env() -> (  # stub-ok: references stub_handlers field name — fully implemented
+    ModelHandlerMemoryRetrievalConfig
+):
+    """Build retrieval config from environment variables.
+
+    Reads ``OMNIMEMORY_USE_STUB_HANDLERS`` (default ``"true"``).  When the
+    value is anything other than ``"false"`` (case-insensitive, whitespace
+    stripped), in-memory test doubles are used.  Otherwise a
+    ``ModelHandlerQdrantConfig`` is constructed from ``QDRANT_HOST``,
+    ``QDRANT_PORT``, and ``LLM_EMBEDDING_URL``.
+
+    Returns:
+        Fully-populated retrieval config ready for ``HandlerMemoryRetrieval``.
+    """
+    from omnimemory.nodes.node_memory_retrieval_effect.models import (
+        ModelHandlerMemoryRetrievalConfig,
+    )
+    from omnimemory.nodes.node_memory_retrieval_effect.models.model_handler_qdrant_config import (
+        ModelHandlerQdrantConfig,
+    )
+
+    use_stubs = (
+        os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").strip().lower() != "false"
+    )
+    qdrant_config = (
+        None
+        if use_stubs
+        else ModelHandlerQdrantConfig(
+            qdrant_host=os.getenv("QDRANT_HOST", "localhost"),
+            qdrant_port=int(os.getenv("QDRANT_PORT", "6333")),
+            embedding_server_url=os.getenv(
+                "LLM_EMBEDDING_URL", "http://localhost:8100"
+            ),
+        )
+    )
+    return ModelHandlerMemoryRetrievalConfig(
+        use_stub_handlers=use_stubs,
+        qdrant_config=qdrant_config,
+    )
+
+
 def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handlers field name — fully implemented
     *,
     correlation_id: UUID | None = None,
@@ -418,11 +463,7 @@ def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handle
         HandlerMemoryRetrieval,
     )
     from omnimemory.nodes.node_memory_retrieval_effect.models import (
-        ModelHandlerMemoryRetrievalConfig,
         ModelMemoryRetrievalRequest,
-    )
-    from omnimemory.nodes.node_memory_retrieval_effect.models.model_handler_qdrant_config import (
-        ModelHandlerQdrantConfig,
     )
 
     _retrieval_handler: HandlerMemoryRetrieval | None = None
@@ -430,24 +471,7 @@ def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handle
     async def _get_retrieval_handler() -> HandlerMemoryRetrieval:
         nonlocal _retrieval_handler
         if _retrieval_handler is None:
-            use_stubs = (
-                os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
-            )
-            qdrant_config = (
-                None
-                if use_stubs
-                else ModelHandlerQdrantConfig(
-                    qdrant_host=os.getenv("QDRANT_HOST", "localhost"),
-                    qdrant_port=int(os.getenv("QDRANT_PORT", "6333")),
-                    embedding_server_url=os.getenv(
-                        "LLM_EMBEDDING_URL", "http://localhost:8100"
-                    ),
-                )
-            )
-            config = ModelHandlerMemoryRetrievalConfig(
-                use_stub_handlers=use_stubs,
-                qdrant_config=qdrant_config,
-            )
+            config = build_retrieval_config_from_env()
             _retrieval_handler = HandlerMemoryRetrieval(config)
             await _retrieval_handler.initialize()
         return _retrieval_handler

--- a/src/omnimemory/runtime/wiring.py
+++ b/src/omnimemory/runtime/wiring.py
@@ -55,6 +55,11 @@ _HANDLER_SPECS: list[tuple[str, str, bool]] = [
         "HandlerSubscription",
         False,  # Requires ModelONEXContainer
     ),
+    (
+        "omnimemory.nodes.node_similarity_compute.handlers.handler_similarity_compute",
+        "HandlerSimilarityCompute",
+        False,  # Requires ModelONEXContainer — verify-only
+    ),
 ]
 
 

--- a/tests/unit/runtime/test_wiring.py
+++ b/tests/unit/runtime/test_wiring.py
@@ -75,4 +75,4 @@ class TestWireMemoryHandlers:
         result = await wire_memory_handlers(config=config)  # type: ignore[arg-type]
 
         # Success means all handlers passed the callable check
-        assert len(result) == 3
+        assert len(result) == 4

--- a/tests/unit/test_dispatch_retrieval_config.py
+++ b/tests/unit/test_dispatch_retrieval_config.py
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for env-var-driven retrieval config in dispatch_handlers."""
+"""Tests for env-var-driven retrieval config in dispatch_handlers.
+
+These tests exercise ``build_retrieval_config_from_env`` — the same code path
+used by the runtime dispatch handler — to verify that
+``OMNIMEMORY_USE_STUB_HANDLERS``, ``QDRANT_HOST``, ``QDRANT_PORT``, and
+``LLM_EMBEDDING_URL`` are resolved correctly.
+"""
 
 from __future__ import annotations
 
@@ -10,9 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-from omnimemory.nodes.node_memory_retrieval_effect.models.model_handler_memory_retrieval_config import (
-    ModelHandlerMemoryRetrievalConfig,
-)
+from omnimemory.runtime.dispatch_handlers import build_retrieval_config_from_env
 
 
 @pytest.mark.unit
@@ -21,24 +25,59 @@ class TestRetrievalConfigFromEnv:
 
     def test_default_is_stub(self) -> None:
         """Without env var, stubs are used."""
-        config = ModelHandlerMemoryRetrievalConfig(use_stub_handlers=True)
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove any pre-existing value so the default ("true") applies
+            os.environ.pop("OMNIMEMORY_USE_STUB_HANDLERS", None)
+            config = build_retrieval_config_from_env()
         assert config.use_stub_handlers is True
+        assert config.qdrant_config is None
 
-    def test_false_requires_qdrant_config(self) -> None:
-        """Setting use_stub_handlers=False without qdrant_config raises."""
-        with pytest.raises(
-            ValueError, match="qdrant_config is required when use_stub_handlers=False"
+    def test_env_var_false_disables_stubs(self) -> None:
+        """OMNIMEMORY_USE_STUB_HANDLERS=false wires real Qdrant config."""
+        env = {
+            "OMNIMEMORY_USE_STUB_HANDLERS": "false",
+            "QDRANT_HOST": "qdrant.example.com",
+            "QDRANT_PORT": "6334",
+            "LLM_EMBEDDING_URL": "http://embed:8100",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = build_retrieval_config_from_env()
+        assert config.use_stub_handlers is False
+        assert config.qdrant_config is not None
+        assert config.qdrant_config.qdrant_host == "qdrant.example.com"
+        assert config.qdrant_config.qdrant_port == 6334
+        assert config.qdrant_config.embedding_server_url == "http://embed:8100"
+
+    def test_env_var_true_keeps_stubs(self) -> None:
+        """OMNIMEMORY_USE_STUB_HANDLERS=true explicitly keeps stubs."""
+        with patch.dict(
+            os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "true"}, clear=True
         ):
-            ModelHandlerMemoryRetrievalConfig(use_stub_handlers=False)
+            config = build_retrieval_config_from_env()
+        assert config.use_stub_handlers is True
+        assert config.qdrant_config is None
 
-    def test_env_var_false_parsed(self) -> None:
-        """OMNIMEMORY_USE_STUB_HANDLERS=false is correctly parsed."""
-        with patch.dict(os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "false"}):
-            val = os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
-            assert val is False
+    def test_whitespace_padded_false_disables_stubs(self) -> None:
+        """Whitespace around 'false' is stripped before comparison."""
+        env = {
+            "OMNIMEMORY_USE_STUB_HANDLERS": "  false  ",
+            "QDRANT_HOST": "localhost",
+            "QDRANT_PORT": "6333",
+            "LLM_EMBEDDING_URL": "http://localhost:8100",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = build_retrieval_config_from_env()
+        assert config.use_stub_handlers is False
+        assert config.qdrant_config is not None
 
-    def test_env_var_true_parsed(self) -> None:
-        """OMNIMEMORY_USE_STUB_HANDLERS=true keeps stubs."""
-        with patch.dict(os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "true"}):
-            val = os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
-            assert val is True
+    def test_false_without_qdrant_env_uses_defaults(self) -> None:
+        """When stubs disabled but QDRANT_* unset, sensible defaults apply."""
+        with patch.dict(
+            os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "false"}, clear=True
+        ):
+            config = build_retrieval_config_from_env()
+        assert config.use_stub_handlers is False
+        assert config.qdrant_config is not None
+        assert config.qdrant_config.qdrant_host == "localhost"
+        assert config.qdrant_config.qdrant_port == 6333
+        assert config.qdrant_config.embedding_server_url == "http://localhost:8100"

--- a/tests/unit/test_dispatch_retrieval_config.py
+++ b/tests/unit/test_dispatch_retrieval_config.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for env-var-driven retrieval config in dispatch_handlers."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from omnimemory.nodes.node_memory_retrieval_effect.models.model_handler_memory_retrieval_config import (
+    ModelHandlerMemoryRetrievalConfig,
+)
+
+
+@pytest.mark.unit
+class TestRetrievalConfigFromEnv:
+    """Verify that OMNIMEMORY_USE_STUB_HANDLERS env var controls config."""
+
+    def test_default_is_stub(self) -> None:
+        """Without env var, stubs are used."""
+        config = ModelHandlerMemoryRetrievalConfig(use_stub_handlers=True)
+        assert config.use_stub_handlers is True
+
+    def test_false_requires_qdrant_config(self) -> None:
+        """Setting use_stub_handlers=False without qdrant_config raises."""
+        with pytest.raises(
+            ValueError, match="qdrant_config is required when use_stub_handlers=False"
+        ):
+            ModelHandlerMemoryRetrievalConfig(use_stub_handlers=False)
+
+    def test_env_var_false_parsed(self) -> None:
+        """OMNIMEMORY_USE_STUB_HANDLERS=false is correctly parsed."""
+        with patch.dict(os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "false"}):
+            val = os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
+            assert val is False
+
+    def test_env_var_true_parsed(self) -> None:
+        """OMNIMEMORY_USE_STUB_HANDLERS=true keeps stubs."""
+        with patch.dict(os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "true"}):
+            val = os.getenv("OMNIMEMORY_USE_STUB_HANDLERS", "true").lower() != "false"
+            assert val is True


### PR DESCRIPTION
## Summary
- **OMN-6572**: Replace hardcoded `use_stub_handlers=True` with `OMNIMEMORY_USE_STUB_HANDLERS` env var; wire `ModelHandlerQdrantConfig` from `QDRANT_HOST`/`QDRANT_PORT`/`LLM_EMBEDDING_URL`
- **OMN-6573**: Add `HandlerSimilarityCompute` to `_HANDLER_SPECS` in `wiring.py`
- **OMN-6584**: Add unit tests for env-var-driven retrieval config

## Test plan
- [x] `uv run pytest tests/unit/test_dispatch_retrieval_config.py -v` passes (4/4)
- [x] `uv run mypy src/omnimemory --strict` passes (via pre-push hook)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory retrieval backend selection is now configurable via environment variables, allowing runtime switching between stub and production backends.

* **Infrastructure**
  * Extended handler verification to include an additional memory-related handler, improving service registration coverage.

* **Tests**
  * Added and updated unit tests covering environment-driven retrieval configuration, parsing robustness, defaults, and the expanded handler registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->