### PR TITLE
chore(deps): bump omnibase-infra to 0.27.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1419,7 +1419,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.24.1"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1467,9 +1467,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/e8/0de39c89f12bac7932465dfde911c5e244bc5536fee7189d493f40583498/omnibase_infra-0.24.1.tar.gz", hash = "sha256:3fe2c51be39e48e12d68c7164d95bb0476e0b7e19c0411e2a6efdc20cdefcb2c", size = 6739001, upload-time = "2026-03-23T02:18:09.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/58/8d1fdf301a5792daeaff52656a12c00ac590d6f4940a31d281bd6d6cc1a6/omnibase_infra-0.26.0.tar.gz", hash = "sha256:a9b675fcd90cda461f4e01e2082794c6fc64c463fed6b7d974656259248d86c5", size = 6798320, upload-time = "2026-03-25T04:34:27.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/40/e886d5ce21623421f78c31c4054b26d2b17d2a3250ba9cb4185329d5c654/omnibase_infra-0.24.1-py3-none-any.whl", hash = "sha256:fda83e7f699f1bbca172c8bb210b2e1b5f8b06380aadfdafc2855e1055a25439", size = 3964074, upload-time = "2026-03-23T02:18:07.891Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7e/eb40d2ca116ff41bf14bf4a858af323ada4c36a18630733ee131e3adcf5f/omnibase_infra-0.26.0-py3-none-any.whl", hash = "sha256:6a4f0994f7f96d47f6d7b11cce0de94ae2907d55caca1d5d3f133cf25607171e", size = 4016662, upload-time = "2026-03-25T04:34:30.005Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_infra` (v0.27.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_infra`
- Updates `pyproject.toml` exact pins (`==X.Y.Z`) to match resolved version

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_infra/actions/runs/23572095803

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version