### PR TITLE
release: omnimemory v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## v0.12.0 (2026-03-25)
+
+### Added
+- feat: env-configurable retrieval stubs + wire similarity handler (#199)
+- feat(runtime): wire AdapterGraphMemory initialization in PluginMemory [OMN-6578] (#198)
+
+### Changed
+- chore(deps): pin omnibase-core==0.32.0, omnibase-infra==0.27.0 for coordinated release
+- chore(deps): bump omnibase_core to 0.31.0 (#197)
+- chore(ci): rename test.yml -> ci.yml for cross-repo standardization [OMN-6215] (#194)
+- build(deps): bump actions/checkout from 4 to 6 in the actions group (#195)
+
+### Fixed
+- fix(deps): update stale omnibase-infra and spi version pins [OMN-6112] (#193)
+
+## v0.11.0 (2026-03-24)
+
+### Changed
+- chore(deps): bump omnibase_core to 0.30.2 (#192)
+- release: omnimemory v0.11.0 (#196)
+
+## v0.9.3 (2026-03-22)
+
+### Changed
+- ci: add check-handshake workflow [OMN-5858] (#190)
+- chore: bump omnibase-core to >=0.30.1 [OMN-5812] (#189)
+- chore(deps): bump omnibase_core to 0.30.1 (#188)
+
+## v0.9.2 (2026-03-21)
+
+### Changed
+- ci: deploy TODO enforcement hooks and workflows OMN-5694, OMN-5695 (#186)
+- chore: remove canceled TODO for OMN-1589 (pyright strictness) [OMN-5690] (#185)
+
+### Fixed
+- fix: restructure omnimemory root contract with top-level fields [OMN-5703] (#184)
+
 ## v0.9.1 (2026-03-20)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.11.0"
+version = "0.12.0"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core>=0.30.1",
+    "omnibase-core==0.32.0",
     "omnibase-spi>=0.19.1",
-    "omnibase-infra>=0.24.1",
+    "omnibase-infra==0.27.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -363,6 +363,6 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core>=0.30.2",
+    "omnibase-core==0.32.0",
     "omnibase-spi>=0.19.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = ">=0.30.2" },
+    { name = "omnibase-core", specifier = "==0.32.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
 ]
 
@@ -747,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -755,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1398,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.31.0"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1412,14 +1414,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/99/0e3d3e90d2d654cadb6054290cf5bf35efa40917c37d88e036081c9c76af/omnibase_core-0.31.0.tar.gz", hash = "sha256:6cb6a7007a5d6413cdd51f7e42c8a2a65e167bf271febaa4a802d7730209cad0", size = 8022464, upload-time = "2026-03-24T20:12:12.99Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/5f/9d5fd6b868447fea8108bb483fc4019b8f1e79b6b305d1c8cf6882daf1a7/omnibase_core-0.32.0.tar.gz", hash = "sha256:bc4e92f980731766b88fb6d6655b895a0b0ff0583a8ebac1161d5a9eb2aeb16c", size = 8051275, upload-time = "2026-03-25T23:49:20.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/ed/c3b1cbf3085d47966d00be6faea7e66163c0ba938bb4cea9e53fcdb0c92b/omnibase_core-0.31.0-py3-none-any.whl", hash = "sha256:bda1c300d0530b55f463d417de6a01f00d38316ba3e7db78a29879175979b090", size = 5216447, upload-time = "2026-03-24T20:12:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/27/43433ee8bcd42b63532baef708011a06297ce252c41ecf178117a387dff4/omnibase_core-0.32.0-py3-none-any.whl", hash = "sha256:a48b86518c10b0896c266d6963220b929d299ed332eddad16bd6bdf74235e3ba", size = 5246810, upload-time = "2026-03-25T23:49:23.503Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.24.1"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1467,9 +1469,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/e8/0de39c89f12bac7932465dfde911c5e244bc5536fee7189d493f40583498/omnibase_infra-0.24.1.tar.gz", hash = "sha256:3fe2c51be39e48e12d68c7164d95bb0476e0b7e19c0411e2a6efdc20cdefcb2c", size = 6739001, upload-time = "2026-03-23T02:18:09.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a4/dd3baa3c0473ae9a2e9860bd61f3084b882bfdcf1b49ba92f70ff4b1e8f3/omnibase_infra-0.27.0.tar.gz", hash = "sha256:76538a410e4d1b1b82466cb2a375b6ee7ff60fe0522a52e02693d2e21acf9360", size = 6808227, upload-time = "2026-03-26T00:58:26.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/40/e886d5ce21623421f78c31c4054b26d2b17d2a3250ba9cb4185329d5c654/omnibase_infra-0.24.1-py3-none-any.whl", hash = "sha256:fda83e7f699f1bbca172c8bb210b2e1b5f8b06380aadfdafc2855e1055a25439", size = 3964074, upload-time = "2026-03-23T02:18:07.891Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/56/769f73a1690b4aedd07e767f5b82c8434b99512cf2cd28bad16b10d2812f/omnibase_infra-0.27.0-py3-none-any.whl", hash = "sha256:2823e0c1811ca578d0a2b73c6a8e62177be585b8e22071ab9e788ae74d4b5127", size = 4018010, upload-time = "2026-03-26T00:58:24.338Z" },
 ]
 
 [[package]]
@@ -1488,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1546,8 +1548,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = ">=0.30.1" },
-    { name = "omnibase-infra", specifier = ">=0.24.1" },
+    { name = "omnibase-core", specifier = "==0.32.0" },
+    { name = "omnibase-infra", specifier = "==0.27.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
## Summary
- Bump version 0.11.0 -> 0.12.0 (minor)
- Pin omnibase-core==0.32.0, omnibase-infra==0.27.0 for coordinated release
- Update CHANGELOG with all changes since v0.7.0

## Coordinated Release
Run ID: `release-20260325-90ae28`
Tier: 3 (depends on omnibase_core v0.32.0, omnibase_infra v0.27.0)

## Changes since last tag (v0.7.0)
- feat: env-configurable retrieval stubs + wire similarity handler (#199)
- feat(runtime): wire AdapterGraphMemory initialization in PluginMemory (#198)
- chore(deps): bump omnibase_core to 0.31.0 (#197)
- chore(ci): rename test.yml -> ci.yml (#194)
- fix(deps): update stale omnibase-infra and spi version pins (#193)
- Multiple intermediate releases (v0.9.x, v0.11.0)

## Test plan
- [x] pre-commit passes (35/35 hooks)
- [x] uv lock resolves cleanly
- [ ] CI passes on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes - v0.12.0

* **New Features**
  * Added environment-configurable retrieval functionality
  * Introduced wire similarity handler

* **Changed**
  * Upgraded core dependencies for improved stability and compatibility
  * Enhanced runtime initialization process

* **Fixed**
  * Resolved outdated dependency version pins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->