### PR TITLE
fix(tests): standardize skip reason messages [OMN-6686]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,7 +193,7 @@ def contract_data(request: pytest.FixtureRequest, nodes_dir: Path) -> MappingRes
     contract_path: Path = nodes_dir / node_name / "contract.yaml"
 
     if not contract_path.exists():
-        pytest.skip(f"Contract file not yet implemented: {contract_path}")
+        pytest.skip(f"Contract file pending implementation: {contract_path}")
 
     with open(contract_path) as f:
         data = yaml.safe_load(f)

--- a/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
+++ b/tests/integration/nodes/test_memory_lifecycle_orchestrator_integration.py
@@ -89,7 +89,9 @@ class TestSkipLockedConcurrency:
         - Multiple concurrent database connections
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_skip_locked_prevents_double_processing(self) -> None:
         """Verify FOR UPDATE SKIP LOCKED prevents concurrent handlers
         from processing same memory.
@@ -114,7 +116,9 @@ class TestSkipLockedConcurrency:
             handlers reach the query point before either commits.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_skip_locked_allows_different_memory_processing(self) -> None:
         """Verify concurrent handlers can process different memories.
 
@@ -135,7 +139,9 @@ class TestSkipLockedConcurrency:
         workloads while preventing double-processing of individual entities.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_skip_locked_batch_processing_isolation(self) -> None:
         """Verify batch processing with SKIP LOCKED isolates work correctly.
 
@@ -181,7 +187,9 @@ class TestOptimisticLocking:
         - Row count validation after UPDATE
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_optimistic_lock_conflict_detected(self) -> None:
         """Verify revision mismatch is detected and handled.
 
@@ -204,7 +212,9 @@ class TestOptimisticLocking:
             When rows_affected=0, handler must recognize this as conflict.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_optimistic_lock_revision_increment(self) -> None:
         """Verify lifecycle_revision increments on each state change.
 
@@ -223,7 +233,9 @@ class TestOptimisticLocking:
         correctly across the full lifecycle state machine.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_optimistic_lock_conflict_recovery(self) -> None:
         """Verify handler gracefully recovers from optimistic lock conflict.
 
@@ -270,7 +282,9 @@ class TestArchiveAtomicity:
         - Temp file + rename pattern for atomicity
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    @pytest.mark.skip(
+        reason="Blocked: write_atomic_bytes() not yet available (OMN-1524)"
+    )
     async def test_archive_atomic_write_crash_safety(self) -> None:
         """Verify archive write is atomic (no partial files).
 
@@ -295,7 +309,9 @@ class TestArchiveAtomicity:
             On failure at any step, .tmp file is deleted.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    @pytest.mark.skip(
+        reason="Blocked: write_atomic_bytes() not yet available (OMN-1524)"
+    )
     async def test_archive_database_filesystem_consistency(self) -> None:
         """Verify database and filesystem stay consistent on archive.
 
@@ -319,7 +335,9 @@ class TestArchiveAtomicity:
             fails, delete the archive file.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: write_atomic_bytes()")
+    @pytest.mark.skip(
+        reason="Blocked: write_atomic_bytes() not yet available (OMN-1524)"
+    )
     async def test_archive_rollback_on_db_failure(self) -> None:
         """Verify archive file deleted if database update fails.
 
@@ -363,7 +381,9 @@ class TestTickIdempotency:
         - Idempotency checks in projection queries
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_tick_reprocessing_idempotent(self) -> None:
         """Verify processing same tick twice produces same result.
 
@@ -385,7 +405,9 @@ class TestTickIdempotency:
             This ensures already-emitted transitions are not re-emitted.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_emission_marker_atomicity(self) -> None:
         """Verify emission marker set atomically with event emission.
 
@@ -428,7 +450,9 @@ class TestProjectionQueryIsolation:
         - Consistent snapshot within transaction
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_projection_query_snapshot_consistency(self) -> None:
         """Verify projection query returns consistent snapshot.
 
@@ -448,7 +472,9 @@ class TestProjectionQueryIsolation:
             For stricter isolation, can use REPEATABLE READ.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_projection_query_deadline_evaluation(self) -> None:
         """Verify projection query uses injected 'now' for deadline.
 
@@ -485,7 +511,9 @@ class TestTransactionBoundaries:
         - Rollback on any failure
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_tick_processing_single_transaction(self) -> None:
         """Verify tick processing uses single transaction.
 
@@ -505,7 +533,9 @@ class TestTransactionBoundaries:
             All database operations within handler are in same transaction.
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     async def test_transaction_rollback_on_exception(self) -> None:
         """Verify transaction rolls back on unhandled exception.
 
@@ -540,7 +570,9 @@ class TestConcurrentScalePerformance:
     They validate performance characteristics, not functionality.
     """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     @pytest.mark.benchmark
     async def test_skip_locked_throughput_under_contention(self) -> None:
         """Benchmark SKIP LOCKED throughput with high contention.
@@ -562,7 +594,9 @@ class TestConcurrentScalePerformance:
             - Contention rate < 50%
         """
 
-    @pytest.mark.skip(reason="Pending OMN-1524: db.with_transaction()")
+    @pytest.mark.skip(
+        reason="Blocked: db.with_transaction() not yet available (OMN-1524)"
+    )
     @pytest.mark.benchmark
     async def test_optimistic_lock_retry_overhead(self) -> None:
         """Benchmark overhead of optimistic lock conflict resolution.

--- a/tests/test_contract_validation.py
+++ b/tests/test_contract_validation.py
@@ -44,7 +44,7 @@ class TestContractValidation:
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         # Skip if not yet implemented (scaffold phase)
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
         assert contract_path.exists(), f"Missing contract: {contract_path}"
 
     @pytest.mark.parametrize("node_name", CORE_8_NODES)
@@ -56,7 +56,7 @@ class TestContractValidation:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -82,7 +82,7 @@ class TestContractValidation:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -158,7 +158,7 @@ class TestContractRuntimeLoad:
         """
         node_path: Path = NODES_DIR / node_name / "node.py"
         if not node_path.exists():
-            pytest.skip(f"File not yet implemented: {node_path}")
+            pytest.skip(f"File pending implementation: {node_path}")
 
         # Convert node_name to class name (e.g., memory_storage_effect -> Node...)
         class_name: str = "Node" + "".join(
@@ -188,7 +188,7 @@ class TestContractRuntimeLoad:
         """
         node_path: Path = NODES_DIR / node_name / "node.py"
         if not node_path.exists():
-            pytest.skip(f"File not yet implemented: {node_path}")
+            pytest.skip(f"File pending implementation: {node_path}")
 
         class_name: str = "Node" + "".join(
             word.capitalize() for word in node_name.split("_")
@@ -275,7 +275,7 @@ class TestOrchestratorEventValidation:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -328,7 +328,7 @@ class TestOrchestratorEventValidation:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -369,7 +369,7 @@ class TestOrchestratorEventValidation:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -457,7 +457,7 @@ class TestHandlerRoutingKeyAlignment:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -546,7 +546,7 @@ class TestHandlerRoutingKeyAlignment:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)
@@ -575,7 +575,7 @@ class TestHandlerRoutingKeyAlignment:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"File not yet implemented: {contract_path}")
+            pytest.skip(f"File pending implementation: {contract_path}")
 
         with open(contract_path, encoding="utf-8") as f:
             data: MappingResultDict = yaml.safe_load(f)

--- a/tests/test_node_enforcement.py
+++ b/tests/test_node_enforcement.py
@@ -234,7 +234,7 @@ class TestContractEnforcement:
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         # Skip if not yet implemented
         if not contract_path.exists():
-            pytest.skip(f"Contract not yet implemented: {contract_path}")
+            pytest.skip(f"Contract pending implementation: {contract_path}")
         assert contract_path.exists()
 
     @pytest.mark.parametrize("node_name", CORE_8_NODES)
@@ -249,7 +249,7 @@ class TestContractEnforcement:
         """
         contract_path: Path = NODES_DIR / node_name / "contract.yaml"
         if not contract_path.exists():
-            pytest.skip(f"Contract not yet implemented: {contract_path}")
+            pytest.skip(f"Contract pending implementation: {contract_path}")
 
         result: ContractValidationResult = validate_contract(contract_path)
         assert result.valid, f"Contract {node_name} failed validation: {result.error}"
@@ -280,7 +280,7 @@ class TestContractEnforcement:
         """
         node_py_path: Path = NODES_DIR / node_name / "node.py"
         if not node_py_path.exists():
-            pytest.skip(f"node.py not present (expected): {node_py_path}")
+            pytest.skip(f"node.py not yet created: {node_py_path}")
 
         result: SuperInitValidationResult = validate_super_init_pattern(node_py_path)
         assert result.valid, (

--- a/tests/test_node_imports.py
+++ b/tests/test_node_imports.py
@@ -49,7 +49,7 @@ class TestNodeImports:
             assert module is not None
         except ImportError as e:
             # Expected during scaffold phase
-            pytest.skip(f"Node package not yet fully implemented: {e}")
+            pytest.skip(f"Node package pending implementation: {e}")
 
     def test_nodes_package_exports_core_nodes(self) -> None:
         """Verify __all__ in nodes package lists all Core 8 nodes.
@@ -129,7 +129,7 @@ class TestNodeStructure:
         """
         node_dir: Path = NODES_DIR / node_name
         if not node_dir.exists():
-            pytest.skip(f"Directory not yet created: {node_dir}")
+            pytest.skip(f"Directory pending creation: {node_dir}")
         init_path: Path = node_dir / "__init__.py"
         assert init_path.exists(), f"Missing __init__.py: {init_path}"
 
@@ -158,7 +158,7 @@ class TestNodeStructure:
 
         node_dir: Path = NODES_DIR / node_name
         if not node_dir.exists():
-            pytest.skip(f"Directory not yet created: {node_dir}")
+            pytest.skip(f"Directory pending creation: {node_dir}")
         handlers_dir: Path = node_dir / "handlers"
         assert not handlers_dir.exists(), (
             f"handlers/ should not exist in {node_name} - "


### PR DESCRIPTION
## Summary
- Standardize OMN-1524 skip messages to "Blocked: ... not yet available (OMN-1524)"
- Update "File not yet implemented" -> "File pending implementation"
- Update "Contract not yet implemented" -> "Contract pending implementation"
- Consistent messaging for runtime conditional skips

## Impact
- No behavior change - message standardization only
- 17 OMN-1524 skips remain (legitimately blocked on missing APIs)

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test skip message wording for improved clarity during development and testing phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->