### PR TITLE
chore: standardize TODO markers with ticket references [OMN-6655]

### DIFF
--- a/src/omnimemory/models/events/model_intent_classified_event.py
+++ b/src/omnimemory/models/events/model_intent_classified_event.py
@@ -85,7 +85,7 @@ class ModelIntentClassifiedEvent(BaseModel):
     Note: Uses ``extra="ignore"`` to allow forward compatibility — if
     omniintelligence adds new fields, this consumer won't reject them.
 
-    TODO(OMN-future): Consider migrating to omnibase_core.models.events
+    TODO(OMN-6655): Consider migrating to omnibase_core.models.events
     once cross-repo event schemas are standardized. This is logically
     an omniintelligence-owned event; omnimemory is a consumer.
     """

--- a/src/omnimemory/utils/pii_detector.py
+++ b/src/omnimemory/utils/pii_detector.py
@@ -89,9 +89,9 @@ class PIIDetector:
         """Initialize regex patterns for different PII types using configuration.
 
         Note: The following PIIType values do NOT have patterns implemented:
-        - PIIType.URL: TODO - Add URL validation patterns
-        - PIIType.PERSON_NAME: TODO - Add dictionary-based name matching
-        - PIIType.ADDRESS: TODO - Add address pattern detection
+        - PIIType.URL: TODO(OMN-5762) - Add URL validation patterns
+        - PIIType.PERSON_NAME: TODO(OMN-5762) - Add dictionary-based name matching
+        - PIIType.ADDRESS: TODO(OMN-5762) - Add address pattern detection
 
         These types are defined in PIIType for future extensibility but will
         not match any content until patterns are added.
@@ -203,7 +203,7 @@ class PIIDetector:
     ) -> set[str]:
         """Load common first and last names for person name detection.
 
-        TODO: This name database is loaded but not actively used for detection.
+        TODO(OMN-5762): This name database is loaded but not actively used for detection.
         To enable PERSON_NAME detection:
         1. Add PIIType.PERSON_NAME patterns to _initialize_patterns()
         2. Or implement context-aware NLP-based name detection

--- a/tests/test_node_imports.py
+++ b/tests/test_node_imports.py
@@ -99,7 +99,7 @@ class TestNodeStructure:
         "node_semantic_analyzer_compute",
         # EFFECT node with MOCK handlers: Temporary mock implementations for
         # development/testing. Will be removed when omnibase_infra is integrated.
-        # TODO: Remove from exclusion list when migrating to real handlers.
+        # TODO(OMN-6655): Remove from exclusion list when migrating to real handlers.
         "node_memory_retrieval_effect",
         # ORCHESTRATOR node with domain-specific lifecycle handlers:
         # - handler_memory_tick: TTL evaluation and event emission

--- a/tests/test_validation_scripts.py
+++ b/tests/test_validation_scripts.py
@@ -1332,7 +1332,9 @@ old_function = new_function  # alias
         finally:
             cleanup_temp_file(path)
 
-    def test_detects_todo_remove_deprecated(self) -> None:
+    def test_detects_todo_remove_deprecated(  # TODO_FORMAT_EXEMPT: test fixture
+        self,
+    ) -> None:
         """Test detection of TODO to remove deprecated code."""
         code = """
 # TODO: remove deprecated function in next version
@@ -2084,7 +2086,9 @@ class TestValidateNoBackwardCompatAdditional:
         violations = validate_no_backward_compat(path)
         assert violations == []
 
-    def test_delete_deprecated_todo(self) -> None:
+    def test_delete_deprecated_todo(  # TODO_FORMAT_EXEMPT: test fixture
+        self,
+    ) -> None:
         """Test detection of TODO: delete deprecated."""
         code = """
 # TODO: delete deprecated code


### PR DESCRIPTION
## Summary
- Add ticket references to 5 bare TODO markers across omnimemory
- Replace `TODO(OMN-future)` placeholder with `TODO(OMN-6655)` in model_intent_classified_event.py
- Link bare PII detector TODOs to existing OMN-5762 ticket
- Add `TODO_FORMAT_EXEMPT` to test fixtures that intentionally contain TODO markers
- Part of epic OMN-6655: Tech Debt TODO/FIXME/HACK marker cleanup

## Test plan
- [ ] Pre-commit hooks pass (no-untracked-todos)
- [ ] All existing tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal TODO documentation references for better tracking and organization.

* **Tests**
  * Applied formatting updates to test method definitions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->