### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.12.1 (2026-03-26)
+
+### Fixed
+- fix(tests): standardize skip reason messages across test suite [OMN-6686] (#203)
+
+### Changed
+- chore: standardize TODO markers with ticket references [OMN-6655] (#204)
+
+### Dependencies
+- omnibase-core 0.32.0 -> 0.33.0
+- omnibase-infra 0.27.0 -> 0.27.1
+
 ## v0.12.0 (2026-03-25)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.12.0"
+version = "0.12.1"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.32.0",
+    "omnibase-core==0.33.0",
     "omnibase-spi>=0.19.1",
-    "omnibase-infra==0.27.0",
+    "omnibase-infra==0.27.1",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -363,6 +363,6 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.32.0",
+    "omnibase-core==0.33.0",
     "omnibase-spi>=0.19.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = "==0.32.0" },
+    { name = "omnibase-core", specifier = "==0.33.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
 ]
 
@@ -1400,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.32.0"
+version = "0.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1414,14 +1414,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/5f/9d5fd6b868447fea8108bb483fc4019b8f1e79b6b305d1c8cf6882daf1a7/omnibase_core-0.32.0.tar.gz", hash = "sha256:bc4e92f980731766b88fb6d6655b895a0b0ff0583a8ebac1161d5a9eb2aeb16c", size = 8051275, upload-time = "2026-03-25T23:49:20.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/ab/b7ab3ed2fed0c07c692c8a53a4e9f16afd3437b1fd833ca0e5c99ed46118/omnibase_core-0.33.0.tar.gz", hash = "sha256:da8ff022faa54f17458bfa2949ed3d7d8dc4bb0a02f7021e637fdbb7ed06a9ce", size = 8070141, upload-time = "2026-03-26T14:30:48.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/27/43433ee8bcd42b63532baef708011a06297ce252c41ecf178117a387dff4/omnibase_core-0.32.0-py3-none-any.whl", hash = "sha256:a48b86518c10b0896c266d6963220b929d299ed332eddad16bd6bdf74235e3ba", size = 5246810, upload-time = "2026-03-25T23:49:23.503Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/71/ed636ce3410714f9f500cda6660024d57ab663f62c3b84da99e1998e64d2/omnibase_core-0.33.0-py3-none-any.whl", hash = "sha256:11c1d16f89dca890e4bedcfcb18b6648c52e2e25d453a095987aeead8c3c1eb3", size = 5272517, upload-time = "2026-03-26T14:30:51.165Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.27.0"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1469,9 +1469,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/a4/dd3baa3c0473ae9a2e9860bd61f3084b882bfdcf1b49ba92f70ff4b1e8f3/omnibase_infra-0.27.0.tar.gz", hash = "sha256:76538a410e4d1b1b82466cb2a375b6ee7ff60fe0522a52e02693d2e21acf9360", size = 6808227, upload-time = "2026-03-26T00:58:26.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7d/393ff2372842f47837783f2971ce6bb48eb9196c9f35c45f3730a6d19e63/omnibase_infra-0.27.1.tar.gz", hash = "sha256:afa1d4860daea531fae2c52e6b53eab6386d8ceb15043d70ec410ef97ee7e07d", size = 6802749, upload-time = "2026-03-26T15:05:49.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/56/769f73a1690b4aedd07e767f5b82c8434b99512cf2cd28bad16b10d2812f/omnibase_infra-0.27.0-py3-none-any.whl", hash = "sha256:2823e0c1811ca578d0a2b73c6a8e62177be585b8e22071ab9e788ae74d4b5127", size = 4018010, upload-time = "2026-03-26T00:58:24.338Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3f/4f971b1999f1a67da4037f4bda6251f7142c7f6f79dee67ea4b94664532e/omnibase_infra-0.27.1-py3-none-any.whl", hash = "sha256:c3fc87082bee1bbdd82691d041ba6022444c7de2c83a8d9a254c0c544cacf3ce", size = 4017568, upload-time = "2026-03-26T15:05:51.021Z" },
 ]
 
 [[package]]
@@ -1490,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1548,8 +1548,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.32.0" },
-    { name = "omnibase-infra", specifier = "==0.27.0" },
+    { name = "omnibase-core", specifier = "==0.33.0" },
+    { name = "omnibase-infra", specifier = "==0.27.1" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
## Summary
- Patch release v0.12.1
- Skip reason standardization, TODO marker cleanup
- Dep bumps: core 0.33.0, infra 0.27.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized skip reason messages in test outcomes

* **Chores**
  * Updated TODO markers with ticket references
  * Dependency updates: omnibase-core to 0.33.0, omnibase-infra to 0.27.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->