### PR TITLE
fix: handle namespaced tag format in release workflow [OMN-6712]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ name: Release
 
 on:
   push:
-    tags: ['v[0-9]*.[0-9]*.[0-9]*']
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'omnimemory/v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:
@@ -42,6 +44,8 @@ jobs:
           else
             TAG="${GITHUB_REF_NAME}"
           fi
+          # Strip optional namespace prefix (e.g. omnimemory/v0.12.0 → v0.12.0)
+          TAG="${TAG#omnimemory/}"
           TAG="${TAG#v}"
           PKG_VERSION=$(python3 -c "
           import tomllib, sys
@@ -86,10 +90,13 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            RAW_TAG="${{ inputs.tag }}"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            RAW_TAG="${GITHUB_REF_NAME}"
           fi
+          # Strip optional namespace prefix (e.g. omnimemory/v0.12.0 → v0.12.0)
+          RAW_TAG="${RAW_TAG#omnimemory/}"
+          echo "tag=${RAW_TAG}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -100,7 +107,7 @@ jobs:
             dist/*.tar.gz
             dist/SHA256SUMS.txt
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, 'rc') }}
+          prerelease: ${{ contains(steps.tag.outputs.tag, 'rc') }}
 
   # ---------------------------------------------------------------------------
   # Post-release: trigger Dockerfile.runtime pin cascade (OMN-5137)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,14 +94,17 @@ jobs:
           else
             RAW_TAG="${GITHUB_REF_NAME}"
           fi
-          # Strip optional namespace prefix (e.g. omnimemory/v0.12.0 → v0.12.0)
-          RAW_TAG="${RAW_TAG#omnimemory/}"
-          echo "tag=${RAW_TAG}" >> $GITHUB_OUTPUT
+          # Preserve original tag for release creation (softprops/action-gh-release
+          # requires the tag to already exist in git)
+          echo "raw_tag=${RAW_TAG}" >> $GITHUB_OUTPUT
+          # Strip optional namespace prefix for version logic (e.g. omnimemory/v0.12.0 → v0.12.0)
+          NORMALIZED="${RAW_TAG#omnimemory/}"
+          echo "tag=${NORMALIZED}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ steps.tag.outputs.raw_tag }}
           files: |
             dist/*.whl
             dist/*.tar.gz


### PR DESCRIPTION
## Summary

- Release workflow now accepts both `vX.Y.Z` and `omnimemory/vX.Y.Z` tag formats
- Strips namespace prefix before version validation and tag extraction
- Fixes prerelease detection to use extracted tag instead of raw ref_name

Closes OMN-6712

## Test plan

- [ ] CI passes
- [ ] Manual workflow_dispatch with bare `v0.12.0` tag still works
- [ ] Push of `omnimemory/v0.12.0` tag triggers release correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to support namespaced tag formats, improving release handling and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->