### PR TITLE
chore: release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.12.2 (2026-03-27)
+
+### Fixed
+- fix(types): narrow Any to object in resource/connection pool models [OMN-6680] (#209)
+- fix: handle namespaced tag format in release workflow [OMN-6712] (#208)
+
+### Changed
+- chore(deps): bump omnibase_core to 0.33.1, omnibase_infra to 0.28.0
+
 ## v0.12.1 (2026-03-26)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.12.1"
+version = "0.12.2"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.33.0",
+    "omnibase-core==0.33.1",
     "omnibase-spi>=0.19.1",
-    "omnibase-infra==0.27.1",
+    "omnibase-infra==0.28.0",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -363,6 +363,6 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.33.0",
+    "omnibase-core==0.33.1",
     "omnibase-spi>=0.19.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = "==0.33.0" },
+    { name = "omnibase-core", specifier = "==0.33.1" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
 ]
 
@@ -747,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -755,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1398,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.33.0"
+version = "0.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1412,14 +1414,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/ab/b7ab3ed2fed0c07c692c8a53a4e9f16afd3437b1fd833ca0e5c99ed46118/omnibase_core-0.33.0.tar.gz", hash = "sha256:da8ff022faa54f17458bfa2949ed3d7d8dc4bb0a02f7021e637fdbb7ed06a9ce", size = 8070141, upload-time = "2026-03-26T14:30:48.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/22/a622ae3b2634a81765345271b8e8a3f7a34d9517423e25a2dd9634a4872e/omnibase_core-0.33.1.tar.gz", hash = "sha256:d781bff756377fc789d63de06e00f5d2a6b3aba53c6c37ce5bf48071d5acc0bb", size = 8070185, upload-time = "2026-03-27T04:31:35.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/71/ed636ce3410714f9f500cda6660024d57ab663f62c3b84da99e1998e64d2/omnibase_core-0.33.0-py3-none-any.whl", hash = "sha256:11c1d16f89dca890e4bedcfcb18b6648c52e2e25d453a095987aeead8c3c1eb3", size = 5272517, upload-time = "2026-03-26T14:30:51.165Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/70/0d5145518017d36815034a547bf0649aff68eb40732001a5f55b06fafa31/omnibase_core-0.33.1-py3-none-any.whl", hash = "sha256:fbad19a34f6c8b3d95cee38c3ece42bcaf3385b9a694b56abbbc9935e7bfc832", size = 5272605, upload-time = "2026-03-27T04:31:32.884Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.27.1"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1467,9 +1469,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/7d/393ff2372842f47837783f2971ce6bb48eb9196c9f35c45f3730a6d19e63/omnibase_infra-0.27.1.tar.gz", hash = "sha256:afa1d4860daea531fae2c52e6b53eab6386d8ceb15043d70ec410ef97ee7e07d", size = 6802749, upload-time = "2026-03-26T15:05:49.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/93/03022afdbc3a1eda3de33239ca3aeee233867529d4ddbd4203ebdf9355e9/omnibase_infra-0.28.0.tar.gz", hash = "sha256:b5d640ae87600c43854430f04e2605c23bbc46f82bace3b13abf459d257eb29e", size = 6825024, upload-time = "2026-03-27T05:31:22.872Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/3f/4f971b1999f1a67da4037f4bda6251f7142c7f6f79dee67ea4b94664532e/omnibase_infra-0.27.1-py3-none-any.whl", hash = "sha256:c3fc87082bee1bbdd82691d041ba6022444c7de2c83a8d9a254c0c544cacf3ce", size = 4017568, upload-time = "2026-03-26T15:05:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ff/1bd8208bdddbb42819548fc5649786ad6d4d20b800b510b3c8bb98d8caf6/omnibase_infra-0.28.0-py3-none-any.whl", hash = "sha256:c234dabf3c1a36a6558cfe1a962554cd37d6bbaf563058e5507ed33f24b4ae0d", size = 4035099, upload-time = "2026-03-27T05:31:25.339Z" },
 ]
 
 [[package]]
@@ -1488,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1546,8 +1548,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.33.0" },
-    { name = "omnibase-infra", specifier = "==0.27.1" },
+    { name = "omnibase-core", specifier = "==0.33.1" },
+    { name = "omnibase-infra", specifier = "==0.28.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
## Summary
- Bump version from 0.12.1 to 0.12.2
- Pin deps: omnibase-core 0.33.1, omnibase-infra 0.28.0

### Changes since v0.12.1
- fix(types): narrow Any to object in resource/connection pool models [OMN-6680]
- fix: handle namespaced tag format in release workflow [OMN-6712]
- chore(deps): bump omnibase_core, omnibase_infra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.12.2

* **Bug Fixes**
  * Resolved type narrowing issue in resource and connection pool models, improving type safety and reducing potential runtime errors.
  * Fixed release workflow handling for namespaced tag formats to ensure correct version tagging and release identification.

* **Changed**
  * Updated core and infrastructure dependencies to the latest compatible versions for improved stability, performance, and overall compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->