### PR TITLE
feat(runtime): wire AdapterGraphMemory into PluginMemory [OMN-6578]

### DIFF
--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -118,6 +118,9 @@ DISPATCH_ALIAS_MEMORY_RETRIEVAL_REQUESTED = (
 )
 """Dispatch-compatible alias for memory-retrieval-requested command topic."""
 
+DISPATCH_ALIAS_GRAPH_MEMORY = "onex.commands.omnimemory.graph-memory-query.v1"
+"""Dispatch-compatible alias for graph memory query/mutation operations (OMN-6578)."""
+
 
 # =============================================================================
 # Bridge Handler: Intent Classified Event
@@ -501,17 +504,19 @@ def create_memory_dispatch_engine(
     | Callable[[str, dict[str, object]], None]
     | None = None,
     publish_topics: dict[str, str] | None = None,
+    graph_memory_adapter: object | None = None,
 ) -> MessageDispatchEngine:
     """Create and configure a MessageDispatchEngine for OmniMemory domain.
 
     Creates the engine, registers all omnimemory domain handlers and routes,
     and freezes it. The engine is ready for dispatch after this call.
 
-    Registers 4 handlers covering 6 routes:
+    Registers 4+ handlers covering 6+ routes:
         1. intent-classified handler (1 route: intent-classified.v1 events)
         2. intent-query handler (1 route: intent-query-requested.v1 commands)
         3. memory-retrieval handler (1 route: memory-retrieval-requested.v1 -- fail-fast)
         4. lifecycle handler (3 routes: runtime-tick, archive, expire -- fail-fast)
+        5. graph-memory handler (optional, 1 route: graph query/mutation -- OMN-6578)
 
     Args:
         intent_consumer: REQUIRED intent event consumer handler.
@@ -521,6 +526,9 @@ def create_memory_dispatch_engine(
         publish_topics: Optional mapping of handler name to publish topic.
             Keys: "intent_query". Values: full topic strings from contract
             event_bus.publish_topics.
+        graph_memory_adapter: Optional AdapterGraphMemory instance.  When
+            provided the adapter is registered as a handler for graph query
+            and mutation operations (OMN-6578).
 
     Returns:
         Frozen MessageDispatchEngine ready for dispatch.
@@ -649,6 +657,28 @@ def create_memory_dispatch_engine(
             ),
         )
     )
+
+    # --- Handler 5 (optional): graph memory adapter (OMN-6578) ---
+    if graph_memory_adapter is not None:
+        engine.register_handler(
+            handler_id="memory-graph-memory-handler",
+            handler=graph_memory_adapter,
+            category=EnumMessageCategory.COMMAND,
+            node_kind=EnumNodeKind.EFFECT,
+            message_types=None,
+        )
+        engine.register_route(
+            ModelDispatchRoute(
+                route_id="memory-graph-memory-route",
+                topic_pattern=DISPATCH_ALIAS_GRAPH_MEMORY,
+                message_category=EnumMessageCategory.COMMAND,
+                handler_id="memory-graph-memory-handler",
+                description=(
+                    "Routes graph memory queries/mutations to "
+                    "AdapterGraphMemory (OMN-6578)."
+                ),
+            )
+        )
 
     engine.freeze()
 

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -492,6 +492,70 @@ def create_memory_retrieval_dispatch_handler(  # stub-ok: references stub_handle
 
 
 # =============================================================================
+# Bridge Handler: Graph Memory Adapter (OMN-6578)
+# =============================================================================
+
+
+def _create_graph_memory_dispatch_handler(
+    *,
+    adapter: object,
+) -> Callable[
+    [ModelEventEnvelope[object], ProtocolHandlerContext],
+    Awaitable[str],
+]:
+    """Create a dispatch engine handler for graph memory operations.
+
+    Returns an async handler function compatible with MessageDispatchEngine's
+    handler signature.  The handler delegates to the ``AdapterGraphMemory``
+    instance passed as *adapter*.
+
+    Args:
+        adapter: An ``AdapterGraphMemory`` instance (typed as ``object`` to
+            avoid importing the adapter at module level).
+
+    Returns:
+        Async handler function with signature (envelope, context) -> str.
+    """
+
+    async def _handle(
+        envelope: ModelEventEnvelope[object],
+        context: ProtocolHandlerContext,
+    ) -> str:
+        """Bridge handler: envelope -> AdapterGraphMemory operation."""
+        ctx_correlation_id = getattr(context, "correlation_id", None) or uuid4()
+
+        payload = envelope.payload
+        if not isinstance(payload, dict):
+            msg = (
+                f"Unexpected payload type {type(payload).__name__} "
+                f"for graph-memory command "
+                f"(correlation_id={ctx_correlation_id})"
+            )
+            logger.warning(msg)
+            raise ValueError(msg)
+
+        logger.info(
+            "Dispatching graph-memory command via MessageDispatchEngine "
+            "(correlation_id=%s)",
+            ctx_correlation_id,
+        )
+
+        # The adapter operation is determined by the payload content.
+        # For now, this is a placeholder that logs receipt; the full
+        # operation routing will be wired by downstream tasks.
+        operation = payload.get("operation", "unknown")
+        logger.info(
+            "Graph memory command received (operation=%s, correlation_id=%s)",
+            operation,
+            ctx_correlation_id,
+        )
+
+        return ""
+
+    return _handle
+
+
+# =============================================================================
 # Dispatch Engine Factory
 # =============================================================================
 
@@ -660,9 +724,12 @@ def create_memory_dispatch_engine(
 
     # --- Handler 5 (optional): graph memory adapter (OMN-6578) ---
     if graph_memory_adapter is not None:
+        graph_memory_handler = _create_graph_memory_dispatch_handler(
+            adapter=graph_memory_adapter,
+        )
         engine.register_handler(
             handler_id="memory-graph-memory-handler",
-            handler=graph_memory_adapter,
+            handler=graph_memory_handler,
             category=EnumMessageCategory.COMMAND,
             node_kind=EnumNodeKind.EFFECT,
             message_types=None,

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -488,17 +488,17 @@ class PluginMemory:
                         connection_uri,
                         correlation_id,
                     )
+                    self._graph_memory_adapter = graph_memory_adapter
                 else:
                     logger.warning(
                         "Memgraph unreachable at %s:%d — graph memory "
-                        "adapter created but not initialized "
+                        "adapter will not be registered "
                         "(correlation_id=%s)",
                         memgraph_host,
                         memgraph_port,
                         correlation_id,
                     )
-
-                self._graph_memory_adapter = graph_memory_adapter
+                    graph_memory_adapter = None
 
             self._dispatch_engine = create_memory_dispatch_engine(
                 intent_consumer=intent_consumer,

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from omnibase_core.runtime.runtime_message_dispatch import MessageDispatchEngine
     from omnibase_infra.runtime.registry import RegistryMessageType
 
+    from omnimemory.handlers.adapters.adapter_graph_memory import AdapterGraphMemory
     from omnimemory.runtime.introspection import MemoryNodeIntrospectionProxy
 
 from omnibase_infra.runtime.models.model_handshake_result import ModelHandshakeResult
@@ -173,6 +174,7 @@ class PluginMemory:
         self._event_bus: ProtocolEventBus | None = None
         self._introspection_nodes: list[str] = []
         self._introspection_proxies: list[MemoryNodeIntrospectionProxy] = []
+        self._graph_memory_adapter: AdapterGraphMemory | None = None
 
     @property
     def message_type_registry(self) -> RegistryMessageType | None:
@@ -456,11 +458,54 @@ class PluginMemory:
                 collect_publish_topics_for_dispatch,
             )
 
+            # Graph memory adapter — connects to Memgraph (OMN-6578).
+            # ModelGraphMemoryConfig has no host/port fields; connection
+            # details are passed to initialize(connection_uri=...).
+            graph_memory_adapter = None
+            memgraph_host = os.environ.get("OMNIMEMORY_MEMGRAPH_HOST")
+            if memgraph_host:
+                from omnimemory.handlers.adapters.adapter_graph_memory import (
+                    AdapterGraphMemory,
+                )
+                from omnimemory.models.adapters.model_graph_memory_config import (
+                    ModelGraphMemoryConfig,
+                )
+
+                memgraph_port = int(os.environ.get("OMNIMEMORY_MEMGRAPH_PORT", "7687"))
+                graph_config = ModelGraphMemoryConfig()
+                graph_memory_adapter = AdapterGraphMemory(config=graph_config)
+                connection_uri = f"bolt://{memgraph_host}:{memgraph_port}"
+
+                # Probe TCP before attempting full bolt handshake to provide
+                # a clearer error message if Memgraph is unreachable.
+                reachable = await _probe_tcp_reachable(memgraph_host, memgraph_port)
+                if reachable:
+                    await graph_memory_adapter.initialize(
+                        connection_uri=connection_uri, auth=None
+                    )
+                    logger.info(
+                        "Graph memory adapter initialized (uri=%s, correlation_id=%s)",
+                        connection_uri,
+                        correlation_id,
+                    )
+                else:
+                    logger.warning(
+                        "Memgraph unreachable at %s:%d — graph memory "
+                        "adapter created but not initialized "
+                        "(correlation_id=%s)",
+                        memgraph_host,
+                        memgraph_port,
+                        correlation_id,
+                    )
+
+                self._graph_memory_adapter = graph_memory_adapter
+
             self._dispatch_engine = create_memory_dispatch_engine(
                 intent_consumer=intent_consumer,
                 intent_query_handler=intent_query_handler,
                 publish_callback=publish_callback,
                 publish_topics=publish_topics,
+                graph_memory_adapter=graph_memory_adapter,
             )
 
             # Store event_bus reference for introspection publishing.

--- a/tests/unit/runtime/test_plugin_graph_memory_wiring.py
+++ b/tests/unit/runtime/test_plugin_graph_memory_wiring.py
@@ -143,10 +143,10 @@ class TestGraphMemoryWiring:
             assert result.success
 
     @pytest.mark.asyncio
-    async def test_graph_memory_adapter_created_but_not_initialized_when_unreachable(
+    async def test_graph_memory_adapter_not_registered_when_unreachable(
         self,
     ) -> None:
-        """Adapter is created but not initialized when Memgraph is unreachable."""
+        """Adapter is not registered when Memgraph is unreachable."""
         plugin = PluginMemory()
         config = _make_config()
 
@@ -183,8 +183,16 @@ class TestGraphMemoryWiring:
             # initialize() NOT called since unreachable
             mock_adapter_instance.initialize.assert_not_called()
 
-            # Adapter still stored on plugin (created but not initialized)
-            assert plugin._graph_memory_adapter is mock_adapter_instance
+            # Adapter NOT stored — uninitialized adapter must not be registered
+            assert (
+                not hasattr(plugin, "_graph_memory_adapter")
+                or plugin._graph_memory_adapter is None
+            )
+
+            # Factory called with None for graph_memory_adapter
+            mock_factory.assert_called_once()
+            call_kwargs = mock_factory.call_args.kwargs
+            assert call_kwargs.get("graph_memory_adapter") is None
 
             assert result.success
 

--- a/tests/unit/runtime/test_plugin_graph_memory_wiring.py
+++ b/tests/unit/runtime/test_plugin_graph_memory_wiring.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Unit tests for graph memory adapter wiring in PluginMemory (OMN-6578).
+
+Validates:
+    - AdapterGraphMemory is constructed with correct config when env vars are set
+    - initialize() is called with the correct bolt:// URI
+    - Adapter is stored on the plugin instance as _graph_memory_adapter
+    - Dispatch engine registers the graph memory handler when adapter is provided
+    - Graph memory handler is NOT registered when env vars are absent
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.runtime.plugin import PluginMemory
+
+from .conftest import StubConfig, StubEventBus
+
+
+def _make_config() -> StubConfig:
+    """Create a minimal config for wire_dispatchers."""
+    return StubConfig(event_bus=StubEventBus(), correlation_id=uuid4())
+
+
+def _patch_introspection() -> patch:
+    """Patch publish_memory_introspection to avoid real Kafka calls."""
+    return patch(
+        "omnimemory.runtime.introspection.publish_memory_introspection",
+        new_callable=AsyncMock,
+        return_value=MagicMock(registered_nodes=[], proxies=[]),
+    )
+
+
+def _patch_dispatch_factory() -> patch:
+    """Patch the dispatch engine factory."""
+    return patch(
+        "omnimemory.runtime.dispatch_handlers.create_memory_dispatch_engine",
+    )
+
+
+def _patch_contract_topics() -> patch:
+    """Patch contract topic collection."""
+    return patch(
+        "omnimemory.runtime.contract_topics.collect_publish_topics_for_dispatch",
+        return_value={},
+    )
+
+
+@pytest.mark.unit
+class TestGraphMemoryWiring:
+    """Tests for AdapterGraphMemory initialization in wire_dispatchers."""
+
+    @pytest.mark.asyncio
+    async def test_graph_memory_adapter_initialized_when_env_set(self) -> None:
+        """AdapterGraphMemory is constructed and initialized when OMNIMEMORY_MEMGRAPH_HOST is set."""
+        plugin = PluginMemory()
+        config = _make_config()
+
+        mock_adapter_instance = MagicMock()
+        mock_adapter_instance.initialize = AsyncMock()
+
+        env_vars = {
+            "OMNIMEMORY_MEMGRAPH_HOST": "test-memgraph",
+            "OMNIMEMORY_MEMGRAPH_PORT": "7687",
+        }
+
+        with (
+            patch.dict("os.environ", env_vars, clear=False),
+            patch(
+                "omnimemory.runtime.plugin._probe_tcp_reachable",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "omnimemory.handlers.adapters.adapter_graph_memory.AdapterGraphMemory",
+                return_value=mock_adapter_instance,
+            ) as mock_adapter_cls,
+            patch(
+                "omnimemory.models.adapters.model_graph_memory_config.ModelGraphMemoryConfig",
+            ) as mock_config_cls,
+            _patch_dispatch_factory() as mock_factory,
+            _patch_contract_topics(),
+            _patch_introspection(),
+        ):
+            mock_factory.return_value = MagicMock(route_count=7, handler_count=5)
+
+            result = await plugin.wire_dispatchers(config)
+
+            # Adapter was constructed
+            mock_config_cls.assert_called_once()
+            mock_adapter_cls.assert_called_once()
+
+            # initialize() called with correct bolt URI
+            mock_adapter_instance.initialize.assert_called_once_with(
+                connection_uri="bolt://test-memgraph:7687", auth=None
+            )
+
+            # Adapter stored on plugin
+            assert plugin._graph_memory_adapter is mock_adapter_instance
+
+            # Factory called with graph_memory_adapter
+            mock_factory.assert_called_once()
+            call_kwargs = mock_factory.call_args[1]
+            assert call_kwargs["graph_memory_adapter"] is mock_adapter_instance
+
+            assert result.success
+
+    @pytest.mark.asyncio
+    async def test_graph_memory_adapter_not_initialized_when_env_absent(
+        self,
+    ) -> None:
+        """No graph adapter when OMNIMEMORY_MEMGRAPH_HOST is not set."""
+        plugin = PluginMemory()
+        config = _make_config()
+
+        # Ensure OMNIMEMORY_MEMGRAPH_HOST is empty/absent
+        env_patch = {"OMNIMEMORY_MEMGRAPH_HOST": ""}
+
+        with (
+            patch.dict("os.environ", env_patch, clear=False),
+            _patch_dispatch_factory() as mock_factory,
+            _patch_contract_topics(),
+            _patch_introspection(),
+        ):
+            mock_factory.return_value = MagicMock(route_count=6, handler_count=4)
+
+            result = await plugin.wire_dispatchers(config)
+
+            # Factory called WITHOUT graph_memory_adapter
+            call_kwargs = mock_factory.call_args[1]
+            assert call_kwargs["graph_memory_adapter"] is None
+
+            # Plugin has no adapter stored
+            assert plugin._graph_memory_adapter is None
+
+            assert result.success
+
+    @pytest.mark.asyncio
+    async def test_graph_memory_adapter_created_but_not_initialized_when_unreachable(
+        self,
+    ) -> None:
+        """Adapter is created but not initialized when Memgraph is unreachable."""
+        plugin = PluginMemory()
+        config = _make_config()
+
+        mock_adapter_instance = MagicMock()
+        mock_adapter_instance.initialize = AsyncMock()
+
+        env_vars = {
+            "OMNIMEMORY_MEMGRAPH_HOST": "test-memgraph",
+            "OMNIMEMORY_MEMGRAPH_PORT": "7687",
+        }
+
+        with (
+            patch.dict("os.environ", env_vars, clear=False),
+            patch(
+                "omnimemory.runtime.plugin._probe_tcp_reachable",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "omnimemory.handlers.adapters.adapter_graph_memory.AdapterGraphMemory",
+                return_value=mock_adapter_instance,
+            ),
+            patch(
+                "omnimemory.models.adapters.model_graph_memory_config.ModelGraphMemoryConfig",
+            ),
+            _patch_dispatch_factory() as mock_factory,
+            _patch_contract_topics(),
+            _patch_introspection(),
+        ):
+            mock_factory.return_value = MagicMock(route_count=7, handler_count=5)
+
+            result = await plugin.wire_dispatchers(config)
+
+            # initialize() NOT called since unreachable
+            mock_adapter_instance.initialize.assert_not_called()
+
+            # Adapter still stored on plugin (created but not initialized)
+            assert plugin._graph_memory_adapter is mock_adapter_instance
+
+            assert result.success
+
+    @pytest.mark.asyncio
+    async def test_custom_memgraph_port(self) -> None:
+        """Custom OMNIMEMORY_MEMGRAPH_PORT is used in bolt URI."""
+        plugin = PluginMemory()
+        config = _make_config()
+
+        mock_adapter_instance = MagicMock()
+        mock_adapter_instance.initialize = AsyncMock()
+
+        env_vars = {
+            "OMNIMEMORY_MEMGRAPH_HOST": "custom-host",
+            "OMNIMEMORY_MEMGRAPH_PORT": "9999",
+        }
+
+        with (
+            patch.dict("os.environ", env_vars, clear=False),
+            patch(
+                "omnimemory.runtime.plugin._probe_tcp_reachable",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "omnimemory.handlers.adapters.adapter_graph_memory.AdapterGraphMemory",
+                return_value=mock_adapter_instance,
+            ),
+            patch(
+                "omnimemory.models.adapters.model_graph_memory_config.ModelGraphMemoryConfig",
+            ),
+            _patch_dispatch_factory() as mock_factory,
+            _patch_contract_topics(),
+            _patch_introspection(),
+        ):
+            mock_factory.return_value = MagicMock(route_count=7, handler_count=5)
+
+            await plugin.wire_dispatchers(config)
+
+            mock_adapter_instance.initialize.assert_called_once_with(
+                connection_uri="bolt://custom-host:9999", auth=None
+            )


### PR DESCRIPTION
## Summary
- Wires `AdapterGraphMemory` initialization into `PluginMemory.wire_dispatchers()` with Memgraph connection from env vars
- Adds bridge handler for graph memory dispatch registration
- Guards against registering uninitialized adapter

## Tickets
- OMN-6578 (part of OMN-6575 Plan C: Integration Chains)

## Test plan
- [ ] CI passes (mypy, ruff, pytest)
- [ ] Graph memory adapter initialized with correct bolt:// URI from env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph memory operations are now available for query and mutation tasks.
  * Added automatic connectivity validation for graph memory databases; system gracefully degrades when unavailable with diagnostic logging.

* **Tests**
  * Added comprehensive test coverage for graph memory initialization and connectivity failover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->