### PR TITLE
ci: add CodeQL security scanning [OMN-5412]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# CodeQL caller workflow — delegates to onex_change_control reusable workflow.
+# OMN-5412
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly Monday 6am UTC
+
+jobs:
+  codeql:
+    uses: OmniNode-ai/onex_change_control/.github/workflows/codeql-reusable.yml@main
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+


### PR DESCRIPTION
## Summary
- Add CodeQL caller workflow that delegates to the reusable workflow in onex_change_control
- Language: Python
- Triggers: push to main, PRs to main, weekly Monday 6am UTC

## Test plan
- [ ] Verify workflow file is valid YAML
- [ ] Verify CodeQL runs on the PR itself