### PR TITLE
chore: release omnimemory v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.13.0 (2026-03-28)
+
+### Added
+- ci: add CodeQL security scanning workflow [OMN-5412] (#214)
+- feat(ci): add auto-merge-on-open workflow [OMN-6571] (#213)
+- feat(runtime): wire AdapterGraphMemory into PluginMemory [OMN-6578] (#211)
+
+### Changed
+- chore(deps): bump omnibase-core to 0.34.0
+
+### Dependencies
+- omnibase-core 0.33.1 -> 0.34.0
+
 ## v0.12.2 (2026-03-27)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.12.2"
+version = "0.13.0"
 description = "OmniNode document ingestion and semantic retrieval"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -59,7 +59,7 @@ dependencies = [
     "pyyaml>=6.0.2,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.33.1",
+    "omnibase-core==0.34.0",
     "omnibase-spi>=0.19.1",
     "omnibase-infra==0.28.0",
 
@@ -363,6 +363,6 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.33.1",
+    "omnibase-core==0.34.0",
     "omnibase-spi>=0.19.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = "==0.33.1" },
+    { name = "omnibase-core", specifier = "==0.34.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
 ]
 
@@ -1400,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.33.1"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1414,9 +1414,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/22/a622ae3b2634a81765345271b8e8a3f7a34d9517423e25a2dd9634a4872e/omnibase_core-0.33.1.tar.gz", hash = "sha256:d781bff756377fc789d63de06e00f5d2a6b3aba53c6c37ce5bf48071d5acc0bb", size = 8070185, upload-time = "2026-03-27T04:31:35.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/6a11a3f9c626fd462cb76f82918b7b5a65111ca8427c6b9867abaf77eb48/omnibase_core-0.34.0.tar.gz", hash = "sha256:1e363e6d6db1b237b02d447478c96a18906485a6941398b563c8643a63ddb731", size = 8072369, upload-time = "2026-03-28T19:32:11.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/70/0d5145518017d36815034a547bf0649aff68eb40732001a5f55b06fafa31/omnibase_core-0.33.1-py3-none-any.whl", hash = "sha256:fbad19a34f6c8b3d95cee38c3ece42bcaf3385b9a694b56abbbc9935e7bfc832", size = 5272605, upload-time = "2026-03-27T04:31:32.884Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cb/56600b5e438417148a787eb82995dfec37b23380c78aeef64baa6ea38237/omnibase_core-0.34.0-py3-none-any.whl", hash = "sha256:99bacd85b40d49d1f875b199fc6775e79708b92a7891b9186a09dea1cabe1dc2", size = 5274122, upload-time = "2026-03-28T19:32:08.709Z" },
 ]
 
 [[package]]
@@ -1490,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.12.2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1548,7 +1548,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.33.1" },
+    { name = "omnibase-core", specifier = "==0.34.0" },
     { name = "omnibase-infra", specifier = "==0.28.0" },
     { name = "omnibase-spi", specifier = ">=0.19.1" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },


### PR DESCRIPTION
## Coordinated release 2026-03-28

### Changes
- Version bump: 0.12.2 → 0.13.0
- Pin omnibase-core==0.34.0
- CHANGELOG updated

### Since v0.12.2
- feat: CodeQL, auto-merge workflow, AdapterGraphMemory wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CodeQL security scanning integration for enhanced code security analysis
  * Auto-merge-on-open CI workflow for streamlined pull request handling
  * Runtime improvements for memory management

* **Dependencies**
  * Updated omnibase-core to version 0.34.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->