### PR TITLE
feat: replace _HANDLER_SPECS with contract-driven handler discovery [OMN-7150]

### DIFF
--- a/src/omnimemory/handlers/adapters/adapter_intent_graph_contract.yaml
+++ b/src/omnimemory/handlers/adapters/adapter_intent_graph_contract.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Contract: adapter_intent_graph
+# Graph adapter for intent storage and retrieval
+
+name: adapter_intent_graph
+description: |
+  Graph adapter for intent storage and retrieval via Memgraph.
+  Standalone adapter, not part of a node directory.
+
+handler_config:
+  handler_class: "AdapterIntentGraph"
+  handler_module: "omnimemory.handlers.adapters.adapter_intent_graph"
+
+tags:
+  - memory
+  - adapter
+  - graph
+  - intent

--- a/src/omnimemory/handlers/handler_subscription_contract.yaml
+++ b/src/omnimemory/handlers/handler_subscription_contract.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Contract: handler_subscription
+# Standalone handler (not part of a node directory)
+
+name: handler_subscription
+description: |
+  Subscription management handler for omnimemory event subscriptions.
+  Standalone handler, not part of a node directory.
+
+handler_config:
+  handler_class: "HandlerSubscription"
+  handler_module: "omnimemory.handlers.handler_subscription"
+
+tags:
+  - memory
+  - subscription
+  - handler

--- a/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
+++ b/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Contract: node_navigation_history_reducer
+# Reduces navigation history events into aggregated session context
+
+name: node_navigation_history_reducer
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+node_type: REDUCER
+input_model: "ModelNavigationHistoryRequest"
+output_model: "ModelNavigationHistoryResponse"
+description: |
+  Reduces navigation history events into aggregated session context.
+  Requires pg_dsn, qdrant, and embedding parameters at runtime.
+
+handler_config:
+  handler_class: "HandlerNavigationHistoryReducer"
+  handler_module: "omnimemory.nodes.node_navigation_history_reducer.handlers.handler_navigation_history_reducer"
+
+tags:
+  - memory
+  - reducer
+  - navigation

--- a/src/omnimemory/runtime/handler_lifecycle_contract.yaml
+++ b/src/omnimemory/runtime/handler_lifecycle_contract.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# ONEX Contract: handler_memory_lifecycle
+# Runtime handler for memory lifecycle management
+
+name: handler_memory_lifecycle
+description: |
+  Runtime lifecycle handler for omnimemory component adapters.
+  Manages startup, shutdown, and health for memory subsystem components.
+
+handler_config:
+  handler_class: "HandlerMemoryLifecycle"
+  handler_module: "omnimemory.runtime.handler_lifecycle"
+
+tags:
+  - memory
+  - runtime
+  - lifecycle

--- a/src/omnimemory/runtime/wiring.py
+++ b/src/omnimemory/runtime/wiring.py
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2025 OmniNode Team
-"""Memory domain handler wiring for kernel initialization.
+"""Memory domain handler wiring via contract-driven discovery.
 
-validates, and (where possible) instantiates memory domain handlers
-during plugin initialization.
+Discovers handler classes from contract.yaml files in omnimemory node
+packages and standalone handler contracts, then verifies importability.
 
-Handlers Wired:
-    - HandlerIntentEventConsumer: Intent event consumer (class, needs deps)
-    - HandlerIntentQuery: Intent query handler (class, needs container)
-    - HandlerSubscription: Subscription management handler (class, needs container)
+Replaces the former hardcoded ``_HANDLER_SPECS`` list with contract-driven
+discovery that reads ``handler_config`` and ``handler_routing`` sections
+from YAML contracts.
 
 Note:
     OmniMemory handlers require runtime dependencies (storage adapters,
@@ -19,72 +18,144 @@ Note:
     happens when the kernel creates handler instances with injected deps.
 
 Related:
+    - OMN-7150, OMN-7151, OMN-7152: Handler wiring migration
     - OMN-2216: Phase 5 -- Runtime plugin PluginMemory
-    - omniintelligence/runtime/wiring.py (reference implementation)
+    - omnimemory/runtime/contract_topics.py (reference pattern)
 """
 
 from __future__ import annotations
 
 import asyncio
 import importlib
+import importlib.resources
 import logging
+import re
 from typing import TYPE_CHECKING
+
+import yaml
 
 if TYPE_CHECKING:
     from omnibase_infra.runtime.models import ModelDomainPluginConfig
 
 logger = logging.getLogger(__name__)
 
-# Handler import specifications: (module_path, attribute_name, is_class)
-# Classes with no-arg constructors are instantiated; everything else is
-# verified importable only.  OmniMemory handlers require runtime deps
-# (containers, adapters) so most are verify-only.
-_HANDLER_SPECS: list[tuple[str, str, bool]] = [
-    (
-        "omnimemory.nodes.node_intent_event_consumer_effect.handler_intent_event_consumer",
-        "HandlerIntentEventConsumer",
-        False,  # Requires config + storage_adapter
-    ),
-    (
-        "omnimemory.nodes.node_intent_query_effect.handlers.handler_intent_query",
-        "HandlerIntentQuery",
-        False,  # Requires ModelONEXContainer
-    ),
-    (
-        "omnimemory.handlers.handler_subscription",
-        "HandlerSubscription",
-        False,  # Requires ModelONEXContainer
-    ),
-    (
-        "omnimemory.nodes.node_similarity_compute.handlers.handler_similarity_compute",
-        "HandlerSimilarityCompute",
-        False,  # Requires ModelONEXContainer -- verify-only
-    ),
-    # Graph adapters (OMN-6579, OMN-6580)
-    (
-        "omnimemory.handlers.adapters.adapter_intent_graph",
-        "AdapterIntentGraph",
-        False,  # Requires config + initialize()
-    ),
-    # Navigation history reducer (OMN-6583)
-    (
-        "omnimemory.nodes.node_navigation_history_reducer.handlers.handler_navigation_history_reducer",
-        "HandlerNavigationHistoryReducer",
-        False,  # Requires pg_dsn, qdrant, embedding params
-    ),
-    # Semantic compute (OMN-6585)
-    (
-        "omnimemory.nodes.node_semantic_analyzer_compute.handlers.handler_semantic_compute",
-        "HandlerSemanticCompute",
-        False,  # Requires ModelONEXContainer
-    ),
-    # Lifecycle handler (OMN-6588)
-    (
-        "omnimemory.runtime.handler_lifecycle",
-        "HandlerMemoryLifecycle",
-        False,  # Requires component adapters
-    ),
+# Node packages containing handler declarations in contract.yaml.
+# Each package must have a contract.yaml with either:
+#   - handler_config: {handler_class, handler_module}
+#   - handler_routing: {handlers: [{handler_key, ...}]}
+_OMNIMEMORY_HANDLER_NODE_PACKAGES: list[str] = [
+    "omnimemory.nodes.node_intent_event_consumer_effect",
+    "omnimemory.nodes.node_intent_query_effect",
+    "omnimemory.nodes.node_similarity_compute",
+    "omnimemory.nodes.node_semantic_analyzer_compute",
+    "omnimemory.nodes.node_navigation_history_reducer",
 ]
+
+# Standalone handler contracts (not in node packages).
+# Each entry is (package, filename) for importlib.resources access.
+_OMNIMEMORY_STANDALONE_HANDLER_CONTRACTS: list[tuple[str, str]] = [
+    ("omnimemory.handlers", "handler_subscription_contract.yaml"),
+    ("omnimemory.handlers.adapters", "adapter_intent_graph_contract.yaml"),
+    ("omnimemory.runtime", "handler_lifecycle_contract.yaml"),
+]
+
+
+def _class_to_module(class_name: str) -> str:
+    """Convert CamelCase class name to snake_case module name.
+
+    Example: HandlerIntentQuery -> handler_intent_query
+    """
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", class_name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _read_handler_spec_from_contract(
+    contract: dict[str, object],
+    package: str,
+) -> tuple[str, str] | None:
+    """Extract (module_path, class_name) from a contract dict.
+
+    Supports both handler_config (flat) and handler_routing (structured)
+    patterns. Returns None if no handler declaration found.
+    """
+    # Try handler_config first (flat pattern)
+    handler_config = contract.get("handler_config")
+    if isinstance(handler_config, dict):
+        handler_class = handler_config.get("handler_class")
+        handler_module = handler_config.get("handler_module")
+        if handler_class and handler_module:
+            return (str(handler_module), str(handler_class))
+
+    # Try handler_routing (structured pattern) — extract first handler
+    handler_routing = contract.get("handler_routing")
+    if isinstance(handler_routing, dict):
+        handlers = handler_routing.get("handlers", [])
+        if handlers and isinstance(handlers, list):
+            first = handlers[0]
+            if isinstance(first, dict):
+                # handler_routing uses handler_key (class name only),
+                # sometimes with method suffix (e.g., "HandlerSimilarityCompute.cosine_distance")
+                handler_key = first.get("handler_key")
+                if handler_key and isinstance(handler_key, str):
+                    # Strip method suffix if present
+                    class_name = handler_key.split(".")[0]
+                    # Infer module from package: package.handlers.handler_<snake_name>
+                    return (
+                        f"{package}.handlers.{_class_to_module(class_name)}",
+                        class_name,
+                    )
+
+    return None
+
+
+def _discover_from_node_package(package: str) -> tuple[str, str] | None:
+    """Read handler spec from a node package's contract.yaml."""
+    try:
+        pkg_files = importlib.resources.files(package)
+        contract_file = pkg_files.joinpath("contract.yaml")
+        content = contract_file.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, TypeError):
+        logger.warning("No contract.yaml found in %s, skipping", package)
+        return None
+
+    contract: object = yaml.safe_load(content)
+    if not isinstance(contract, dict):
+        logger.warning("contract.yaml in %s is not a valid mapping, skipping", package)
+        return None
+
+    spec = _read_handler_spec_from_contract(contract, package)
+    if spec is None:
+        logger.warning(
+            "No handler_config or handler_routing in %s contract.yaml, skipping",
+            package,
+        )
+    return spec
+
+
+def _discover_from_standalone_contract(
+    package: str,
+    filename: str,
+) -> tuple[str, str] | None:
+    """Read handler spec from a standalone handler contract YAML."""
+    try:
+        pkg_files = importlib.resources.files(package)
+        contract_file = pkg_files.joinpath(filename)
+        content = contract_file.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, TypeError):
+        logger.warning(
+            "Standalone contract %s/%s not found, skipping", package, filename
+        )
+        return None
+
+    contract: object = yaml.safe_load(content)
+    if not isinstance(contract, dict):
+        logger.warning("%s/%s is not a valid mapping, skipping", package, filename)
+        return None
+
+    spec = _read_handler_spec_from_contract(contract, package)
+    if spec is None:
+        logger.warning("No handler_config in %s/%s, skipping", package, filename)
+    return spec
 
 
 async def wire_memory_handlers(
@@ -92,10 +163,9 @@ async def wire_memory_handlers(
 ) -> list[str]:
     """Wire memory domain handlers by verifying importability.
 
-    Imports and validates handler modules for the memory domain.
-    OmniMemory handlers require runtime dependencies (containers,
-    storage adapters, event buses) so they are not instantiated here --
-    only verified importable.
+    Discovers handler classes from contract.yaml files in omnimemory
+    node packages and standalone handler contracts, then verifies each
+    handler is importable and callable.
 
     Args:
         config: Plugin configuration with container and correlation_id.
@@ -109,7 +179,21 @@ async def wire_memory_handlers(
     correlation_id = config.correlation_id
     services_registered: list[str] = []
 
-    for module_path, attr_name, is_class in _HANDLER_SPECS:
+    # Collect all handler specs from contracts
+    specs: list[tuple[str, str]] = []
+
+    for package in _OMNIMEMORY_HANDLER_NODE_PACKAGES:
+        spec = _discover_from_node_package(package)
+        if spec:
+            specs.append(spec)
+
+    for package, filename in _OMNIMEMORY_STANDALONE_HANDLER_CONTRACTS:
+        spec = _discover_from_standalone_contract(package, filename)
+        if spec:
+            specs.append(spec)
+
+    # Verify importability for each discovered handler
+    for module_path, attr_name in specs:
         try:
             mod = await asyncio.to_thread(importlib.import_module, module_path)
         except ModuleNotFoundError as e:
@@ -125,20 +209,11 @@ async def wire_memory_handlers(
         if not callable(handler_attr):
             raise ImportError(f"{attr_name} in {module_path} is not callable")
 
-        if is_class:
-            # Instantiate class-based handlers (pure compute, no deps)
-            _instance = handler_attr()
-            logger.debug(
-                "Instantiated %s (correlation_id=%s)",
-                attr_name,
-                correlation_id,
-            )
-        else:
-            logger.debug(
-                "Verified %s importable (correlation_id=%s)",
-                attr_name,
-                correlation_id,
-            )
+        logger.debug(
+            "Verified %s importable (correlation_id=%s)",
+            attr_name,
+            correlation_id,
+        )
 
         services_registered.append(attr_name)
 

--- a/tests/unit/nodes/test_navigation_history_reducer_contract.py
+++ b/tests/unit/nodes/test_navigation_history_reducer_contract.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Test that node_navigation_history_reducer has a valid contract.yaml.
+
+Related:
+    - OMN-7150: Add contract.yaml for node_navigation_history_reducer
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+class TestNavigationHistoryReducerContract:
+    def test_contract_yaml_exists(self) -> None:
+        """contract.yaml must exist in the node package."""
+        package = "omnimemory.nodes.node_navigation_history_reducer"
+        pkg_files = importlib.resources.files(package)
+        contract_file = pkg_files.joinpath("contract.yaml")
+        content = contract_file.read_text(encoding="utf-8")
+        contract = yaml.safe_load(content)
+        assert isinstance(contract, dict)
+        assert contract["name"] == "node_navigation_history_reducer"
+
+    def test_contract_has_handler_config(self) -> None:
+        """contract.yaml must declare handler_config with class and module."""
+        package = "omnimemory.nodes.node_navigation_history_reducer"
+        pkg_files = importlib.resources.files(package)
+        contract_file = pkg_files.joinpath("contract.yaml")
+        content = contract_file.read_text(encoding="utf-8")
+        contract = yaml.safe_load(content)
+        handler_config = contract.get("handler_config")
+        assert handler_config is not None
+        assert handler_config["handler_class"] == "HandlerNavigationHistoryReducer"
+        assert (
+            handler_config["handler_module"]
+            == "omnimemory.nodes.node_navigation_history_reducer.handlers.handler_navigation_history_reducer"
+        )

--- a/tests/unit/runtime/test_contract_handler_completeness.py
+++ b/tests/unit/runtime/test_contract_handler_completeness.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Validate that contract-driven discovery finds all expected handlers.
+
+This test prevents silent regressions when contracts are added or removed.
+It ensures the contract-driven wiring produces the exact same handler set
+as the old hardcoded _HANDLER_SPECS list.
+
+Related:
+    - OMN-7153: Add handler completeness validation test
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnimemory.runtime.wiring import wire_memory_handlers
+
+from .conftest import StubConfig
+
+# The canonical handler set — must match what the old _HANDLER_SPECS declared.
+_EXPECTED_HANDLERS: frozenset[str] = frozenset(
+    {
+        "HandlerIntentEventConsumer",
+        "HandlerIntentQuery",
+        "HandlerSubscription",
+        "HandlerSimilarityCompute",
+        "AdapterIntentGraph",
+        "HandlerNavigationHistoryReducer",
+        "HandlerSemanticCompute",
+        "HandlerMemoryLifecycle",
+    }
+)
+
+
+@pytest.mark.unit
+class TestContractHandlerCompleteness:
+    @pytest.mark.asyncio
+    async def test_all_expected_handlers_discovered(self) -> None:
+        """Contract-driven discovery must find all expected handlers."""
+        config = StubConfig()
+        result = await wire_memory_handlers(config=config)  # type: ignore[arg-type]
+        discovered = frozenset(result)
+        assert discovered == _EXPECTED_HANDLERS, (
+            f"Handler mismatch.\n"
+            f"  Missing: {_EXPECTED_HANDLERS - discovered}\n"
+            f"  Extra: {discovered - _EXPECTED_HANDLERS}"
+        )

--- a/tests/unit/runtime/test_standalone_handler_contracts.py
+++ b/tests/unit/runtime/test_standalone_handler_contracts.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Test that standalone handlers have valid contract YAML files.
+
+Standalone handlers are those not under a ``nodes/`` directory —
+they're utility handlers, adapters, or runtime components that still
+need contract declarations for contract-driven discovery.
+
+Related:
+    - OMN-7151: Add contract YAML for standalone omnimemory handlers
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+
+import pytest
+import yaml
+
+# (package, contract_filename, expected_class, expected_module)
+_STANDALONE_HANDLER_CONTRACTS: list[tuple[str, str, str, str]] = [
+    (
+        "omnimemory.handlers",
+        "handler_subscription_contract.yaml",
+        "HandlerSubscription",
+        "omnimemory.handlers.handler_subscription",
+    ),
+    (
+        "omnimemory.handlers.adapters",
+        "adapter_intent_graph_contract.yaml",
+        "AdapterIntentGraph",
+        "omnimemory.handlers.adapters.adapter_intent_graph",
+    ),
+    (
+        "omnimemory.runtime",
+        "handler_lifecycle_contract.yaml",
+        "HandlerMemoryLifecycle",
+        "omnimemory.runtime.handler_lifecycle",
+    ),
+]
+
+
+@pytest.mark.unit
+class TestStandaloneHandlerContracts:
+    @pytest.mark.parametrize(
+        ("package", "contract_filename", "expected_class", "expected_module"),
+        _STANDALONE_HANDLER_CONTRACTS,
+        ids=["subscription", "adapter_intent_graph", "lifecycle"],
+    )
+    def test_contract_exists_and_valid(
+        self,
+        package: str,
+        contract_filename: str,
+        expected_class: str,
+        expected_module: str,
+    ) -> None:
+        """Each standalone handler must have a contract YAML with handler_config."""
+        pkg_files = importlib.resources.files(package)
+        contract_file = pkg_files.joinpath(contract_filename)
+        content = contract_file.read_text(encoding="utf-8")
+        contract = yaml.safe_load(content)
+        assert isinstance(contract, dict)
+
+        handler_config = contract.get("handler_config")
+        assert handler_config is not None, (
+            f"Missing handler_config in {contract_filename}"
+        )
+        assert handler_config["handler_class"] == expected_class
+        assert handler_config["handler_module"] == expected_module

--- a/tests/unit/runtime/test_wiring.py
+++ b/tests/unit/runtime/test_wiring.py
@@ -77,3 +77,23 @@ class TestWireMemoryHandlers:
         # Success means all handlers passed the callable check
         # 4 base (incl. similarity) + 4 integration chain handlers = 8
         assert len(result) == 8
+
+
+class TestContractDrivenDiscovery:
+    """Validate that handler discovery reads from contracts, not hardcoded list."""
+
+    @pytest.mark.asyncio
+    async def test_discovers_handlers_from_contracts(self) -> None:
+        """wire_memory_handlers returns the same 8 handlers from contracts."""
+        config = StubConfig()
+        result = await wire_memory_handlers(config=config)  # type: ignore[arg-type]
+        assert len(result) == 8
+
+    @pytest.mark.asyncio
+    async def test_no_hardcoded_handler_specs(self) -> None:
+        """_HANDLER_SPECS must not exist -- all specs come from contracts."""
+        import omnimemory.runtime.wiring as wiring_mod
+
+        assert not hasattr(wiring_mod, "_HANDLER_SPECS"), (
+            "_HANDLER_SPECS still exists -- migration incomplete"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1490,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Replace the hardcoded `_HANDLER_SPECS` list in `wiring.py` with contract-driven handler discovery that reads `handler_config` and `handler_routing` sections from `contract.yaml` files
- Add missing `contract.yaml` for `node_navigation_history_reducer` and contract YAMLs for 3 standalone handlers (`HandlerSubscription`, `AdapterIntentGraph`, `HandlerMemoryLifecycle`)
- Add completeness validation test asserting exact handler set match (all 8 handlers discovered from contracts)

Closes OMN-7150, OMN-7151, OMN-7152, OMN-7153

## Test plan

- [x] All 1012 existing unit tests pass
- [x] New tests validate contract existence and structure for all handlers
- [x] Completeness test asserts exact 8-handler set discovered from contracts
- [x] `_HANDLER_SPECS` no longer exists (verified by test)
- [x] Pre-commit hooks pass (including contract linter, ruff, mypy, pyright)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added handler contracts for improved component organization and extensibility.
  * Introduced navigation history reducer and subscription handler components.

* **Refactor**
  * Migrated handler discovery from hardcoded specifications to contract-driven configuration for greater flexibility and maintainability.

* **Tests**
  * Added comprehensive test coverage validating contract-driven handler discovery and component configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->