### PR TITLE
feat: replace hardcoded MEMORY_NODES with contract-driven discovery [OMN-7154]

### DIFF
--- a/src/omnimemory/runtime/introspection.py
+++ b/src/omnimemory/runtime/introspection.py
@@ -29,11 +29,13 @@ Related:
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from uuid import NAMESPACE_DNS, UUID, uuid5
 
+import yaml
 from omnibase_core.enums import EnumNodeKind
 from omnibase_infra.enums import EnumIntrospectionReason
 from omnibase_infra.mixins.mixin_node_introspection import MixinNodeIntrospection
@@ -87,20 +89,95 @@ class _NodeDescriptor:
         return uuid5(_NAMESPACE_MEMORY, f"omnimemory.{self.name}")
 
 
-MEMORY_NODES: tuple[_NodeDescriptor, ...] = (
-    # Orchestrators
-    _NodeDescriptor("node_memory_lifecycle_orchestrator", EnumNodeKind.ORCHESTRATOR),
-    _NodeDescriptor("node_agent_coordinator_orchestrator", EnumNodeKind.ORCHESTRATOR),
-    # Compute nodes
-    _NodeDescriptor("node_similarity_compute", EnumNodeKind.COMPUTE),
-    _NodeDescriptor("node_semantic_analyzer_compute", EnumNodeKind.COMPUTE),
-    # Effect nodes
-    _NodeDescriptor("node_intent_event_consumer_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("node_intent_query_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("node_intent_storage_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("node_memory_retrieval_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("node_memory_storage_effect", EnumNodeKind.EFFECT),
-)
+def _parse_node_type(raw_type: str) -> EnumNodeKind:
+    """Convert contract.yaml ``node_type`` string to ``EnumNodeKind``.
+
+    Contract YAML uses uppercase strings with optional ``_GENERIC`` suffix::
+
+        "EFFECT_GENERIC" -> EnumNodeKind.EFFECT
+        "COMPUTE" -> EnumNodeKind.COMPUTE
+        "ORCHESTRATOR_GENERIC" -> EnumNodeKind.ORCHESTRATOR
+    """
+    normalized = raw_type.replace("_GENERIC", "").lower()
+    return EnumNodeKind(normalized)
+
+
+def _discover_nodes_from_contracts(
+    base_package: str,
+) -> tuple[_NodeDescriptor, ...]:
+    """Discover node descriptors from ``contract.yaml`` files.
+
+    Scans all ``node_*/contract.yaml`` files under *base_package* and builds
+    ``_NodeDescriptor`` instances from the ``name`` and ``node_type`` fields.
+
+    Returns:
+        Tuple of ``_NodeDescriptor`` sorted by name for deterministic ordering.
+    """
+    descriptors: list[_NodeDescriptor] = []
+    package_files = importlib.resources.files(base_package)
+
+    for item in package_files.iterdir():
+        if not item.name.startswith("node_"):
+            continue
+        contract_path = item.joinpath("contract.yaml")
+        try:
+            content = contract_path.read_text(encoding="utf-8")
+        except (FileNotFoundError, TypeError, OSError):
+            continue
+
+        try:
+            contract = yaml.safe_load(content)
+        except yaml.YAMLError:
+            logger.warning(
+                "Invalid YAML in %s/%s/contract.yaml, skipping",
+                base_package,
+                item.name,
+            )
+            continue
+
+        if not isinstance(contract, dict):
+            continue
+
+        name = contract.get("name")
+        raw_type = contract.get("node_type")
+        if not isinstance(name, str) or not isinstance(raw_type, str):
+            logger.warning(
+                "Missing name or node_type in %s/%s/contract.yaml, skipping",
+                base_package,
+                item.name,
+            )
+            continue
+
+        try:
+            node_type = _parse_node_type(raw_type)
+        except ValueError:
+            logger.warning(
+                "Unknown node_type %r in %s/%s/contract.yaml, skipping",
+                raw_type,
+                base_package,
+                item.name,
+            )
+            continue
+
+        descriptors.append(_NodeDescriptor(name, node_type))
+
+    return tuple(sorted(descriptors, key=lambda d: d.name))
+
+
+def discover_memory_nodes() -> tuple[_NodeDescriptor, ...]:
+    """Discover memory node descriptors from ``contract.yaml`` files.
+
+    Replaces the former hardcoded ``MEMORY_NODES`` tuple with dynamic
+    contract-driven discovery. Scans all ``node_*/contract.yaml`` files
+    under ``omnimemory.nodes``.
+
+    Returns:
+        Tuple of ``_NodeDescriptor`` instances sorted by name.
+    """
+    return _discover_nodes_from_contracts(base_package="omnimemory.nodes")
+
+
+MEMORY_NODES: tuple[_NodeDescriptor, ...] = discover_memory_nodes()
 
 
 # =============================================================================
@@ -422,6 +499,7 @@ __all__ = [
     "MEMORY_NODES",
     "IntrospectionResult",
     "MemoryNodeIntrospectionProxy",
+    "discover_memory_nodes",
     "publish_memory_introspection",
     "publish_memory_shutdown",
     "reset_introspection_guard",

--- a/tests/unit/runtime/test_introspection.py
+++ b/tests/unit/runtime/test_introspection.py
@@ -28,6 +28,7 @@ from omnimemory.runtime.introspection import (
     IntrospectionResult,
     MemoryNodeIntrospectionProxy,
     _NodeDescriptor,
+    discover_memory_nodes,
     publish_memory_introspection,
     publish_memory_shutdown,
     reset_introspection_guard,
@@ -85,29 +86,29 @@ class TestMemoryNodesStructure:
     """Validate the MEMORY_NODES tuple contents and invariants."""
 
     @pytest.mark.unit
-    def test_has_exactly_nine_nodes(self) -> None:
-        """MEMORY_NODES should contain exactly 9 node descriptors."""
-        assert len(MEMORY_NODES) == 9
+    def test_has_at_least_nine_nodes(self) -> None:
+        """MEMORY_NODES should contain at least the original 9 node descriptors."""
+        assert len(MEMORY_NODES) >= 9
 
     @pytest.mark.unit
-    def test_contains_two_orchestrators(self) -> None:
-        """MEMORY_NODES should contain exactly 2 orchestrator nodes."""
+    def test_contains_at_least_two_orchestrators(self) -> None:
+        """MEMORY_NODES should contain at least 2 orchestrator nodes."""
         orchestrators = [
             n for n in MEMORY_NODES if n.node_type == EnumNodeKind.ORCHESTRATOR
         ]
-        assert len(orchestrators) == 2
+        assert len(orchestrators) >= 2
 
     @pytest.mark.unit
-    def test_contains_two_compute_nodes(self) -> None:
-        """MEMORY_NODES should contain exactly 2 compute nodes."""
+    def test_contains_at_least_two_compute_nodes(self) -> None:
+        """MEMORY_NODES should contain at least 2 compute nodes."""
         compute_nodes = [n for n in MEMORY_NODES if n.node_type == EnumNodeKind.COMPUTE]
-        assert len(compute_nodes) == 2
+        assert len(compute_nodes) >= 2
 
     @pytest.mark.unit
-    def test_contains_five_effect_nodes(self) -> None:
-        """MEMORY_NODES should contain exactly 5 effect nodes."""
+    def test_contains_at_least_five_effect_nodes(self) -> None:
+        """MEMORY_NODES should contain at least 5 effect nodes."""
         effect_nodes = [n for n in MEMORY_NODES if n.node_type == EnumNodeKind.EFFECT]
-        assert len(effect_nodes) == 5
+        assert len(effect_nodes) >= 5
 
     @pytest.mark.unit
     def test_all_names_are_unique(self) -> None:
@@ -634,3 +635,91 @@ class TestIntrospectionLifecycle:
             enable_heartbeat=False,
         )
         assert len(result.registered_nodes) == len(MEMORY_NODES)
+
+
+# =============================================================================
+# Tests: Contract-driven node discovery
+# =============================================================================
+
+
+class TestDiscoverMemoryNodes:
+    """Validate contract-driven node discovery."""
+
+    @pytest.mark.unit
+    def test_discovers_all_hardcoded_nodes(self) -> None:
+        """All nodes from the former MEMORY_NODES tuple must be discoverable."""
+        discovered = discover_memory_nodes()
+        discovered_names = {d.name for d in discovered}
+        # These 9 nodes existed in the original hardcoded tuple
+        expected_names = {
+            "node_memory_lifecycle_orchestrator",
+            "node_agent_coordinator_orchestrator",
+            "node_similarity_compute",
+            "node_semantic_analyzer_compute",
+            "node_intent_event_consumer_effect",
+            "node_intent_query_effect",
+            "node_intent_storage_effect",
+            "node_memory_retrieval_effect",
+            "node_memory_storage_effect",
+        }
+        assert expected_names.issubset(discovered_names), (
+            f"Missing nodes: {expected_names - discovered_names}"
+        )
+
+    @pytest.mark.unit
+    def test_discovers_new_nodes_with_contracts(self) -> None:
+        """Nodes added after the original list should be discovered."""
+        discovered = discover_memory_nodes()
+        discovered_names = {d.name for d in discovered}
+        # These nodes have contract.yaml but were not in the original tuple
+        assert "node_filesystem_crawler_effect" in discovered_names
+        assert "node_kreuzberg_parse_effect" in discovered_names
+
+    @pytest.mark.unit
+    def test_node_types_match_contracts(self) -> None:
+        """Discovered node types must match contract.yaml node_type field."""
+        discovered = discover_memory_nodes()
+        for desc in discovered:
+            if "orchestrator" in desc.name:
+                assert desc.node_type == EnumNodeKind.ORCHESTRATOR, desc.name
+            elif "compute" in desc.name:
+                assert desc.node_type == EnumNodeKind.COMPUTE, desc.name
+            elif "effect" in desc.name:
+                assert desc.node_type == EnumNodeKind.EFFECT, desc.name
+
+    @pytest.mark.unit
+    def test_all_names_are_unique(self) -> None:
+        """All discovered node names must be unique."""
+        discovered = discover_memory_nodes()
+        names = [d.name for d in discovered]
+        assert len(names) == len(set(names))
+
+    @pytest.mark.unit
+    def test_all_node_ids_are_unique(self) -> None:
+        """All discovered node IDs must be unique."""
+        discovered = discover_memory_nodes()
+        ids = [d.node_id for d in discovered]
+        assert len(ids) == len(set(ids))
+
+    @pytest.mark.unit
+    def test_version_defaults_to_1_0_0(self) -> None:
+        """Discovered nodes should have version '1.0.0' (default)."""
+        discovered = discover_memory_nodes()
+        for desc in discovered:
+            assert desc.version == "1.0.0", f"{desc.name} has version {desc.version}"
+
+    @pytest.mark.unit
+    def test_sorted_by_name(self) -> None:
+        """Discovered nodes should be sorted by name for determinism."""
+        discovered = discover_memory_nodes()
+        names = [d.name for d in discovered]
+        assert names == sorted(names)
+
+    @pytest.mark.unit
+    def test_memory_nodes_equals_discovery(self) -> None:
+        """MEMORY_NODES module variable should equal discover_memory_nodes()."""
+        discovered = discover_memory_nodes()
+        assert len(MEMORY_NODES) == len(discovered)
+        for mod_desc, disc_desc in zip(MEMORY_NODES, discovered, strict=True):
+            assert mod_desc.name == disc_desc.name
+            assert mod_desc.node_type == disc_desc.node_type

--- a/uv.lock
+++ b/uv.lock
@@ -1490,7 +1490,7 @@ wheels = [
 
 [[package]]
 name = "omninode-memory"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Replace hardcoded `MEMORY_NODES` tuple with `discover_memory_nodes()` that scans `contract.yaml` files under `omnimemory.nodes` at import time
- Two previously unregistered nodes (`node_filesystem_crawler_effect`, `node_kreuzberg_parse_effect`) are now automatically discovered
- Update count assertions from exact to minimum to accommodate dynamic discovery

## Test plan

- [x] All 45 introspection tests pass (including 8 new discovery tests)
- [x] Full unit test suite (1012 tests) passes with no regressions
- [x] Pre-commit hooks pass (ruff, mypy, pyright, AI-slop)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contract-driven discovery of memory nodes from configuration files, replacing hardcoded node definitions with automatic detection and improved error handling.

* **Tests**
  * Updated node structure validation tests to be more flexible and added comprehensive coverage for the new discovery functionality, including determinism and consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->