### PR TITLE
fix(ci): auto-tag workflow matches chore: release PR titles [OMN-6909]

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -6,7 +6,12 @@ on:
 
 jobs:
   auto-tag:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: >-
+      github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'release') ||
+       startsWith(github.event.pull_request.title, 'release:') ||
+       startsWith(github.event.pull_request.title, 'chore: release') ||
+       startsWith(github.event.pull_request.title, 'chore(release)'))
     uses: OmniNode-ai/omnibase_core/.github/workflows/auto-tag-reusable.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Auto-tag workflow only matched PRs with a `release` label. It missed `release:`, `chore: release`, and `chore(release)` title patterns, causing release cascade stalls.
- Adds `startsWith` checks for all three title patterns.

## Test plan
- [x] Verify the `if` condition syntax is valid YAML and valid GitHub Actions expressions
- [ ] Merge a PR with title `chore: release ...` and confirm auto-tag fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to support additional trigger patterns. The auto-tag workflow now activates when pull requests have a release label or use specific title prefixes, increasing flexibility in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->