### PR TITLE
fix: purge localhost fallbacks from models and runtime [OMN-7227]

### DIFF
--- a/src/omnimemory/bootstrap.py
+++ b/src/omnimemory/bootstrap.py
@@ -267,13 +267,13 @@ async def _validate_postgres_config(config: ModelPostgresConfig) -> list[str]:
     # In Pydantic v2, PostgresDsn uses hosts() which returns a list of dicts
     dsn = config.dsn
     hosts_info = dsn.hosts()
-    if hosts_info:
-        first_host = hosts_info[0]
-        host = first_host.get("host", "localhost")
-        port = first_host.get("port", 5432)
-    else:
-        host = "localhost"
-        port = 5432
+    if not hosts_info:
+        raise ValueError("PostgreSQL DSN must include a host")
+    first_host = hosts_info[0]
+    host = first_host.get("host")
+    if not host:
+        raise ValueError("PostgreSQL DSN must include a host")
+    port = first_host.get("port", 5432)
 
     logger.info(f"PostgreSQL configured: {host}:{port}")
 

--- a/src/omnimemory/bootstrap.py
+++ b/src/omnimemory/bootstrap.py
@@ -268,11 +268,15 @@ async def _validate_postgres_config(config: ModelPostgresConfig) -> list[str]:
     dsn = config.dsn
     hosts_info = dsn.hosts()
     if not hosts_info:
-        raise ValueError("PostgreSQL DSN must include a host")
+        raise BootstrapError(
+            "PostgreSQL DSN must include a host", config_block="postgres"
+        )
     first_host = hosts_info[0]
     host = first_host.get("host")
     if not host:
-        raise ValueError("PostgreSQL DSN must include a host")
+        raise BootstrapError(
+            "PostgreSQL DSN must include a host", config_block="postgres"
+        )
     port = first_host.get("port", 5432)
 
     logger.info(f"PostgreSQL configured: {host}:{port}")

--- a/src/omnimemory/handlers/adapters/__init__.py
+++ b/src/omnimemory/handlers/adapters/__init__.py
@@ -20,6 +20,7 @@ Available Adapters:
 
 Example::
 
+    import os
     from omnimemory.handlers.adapters import (
         AdapterGraphMemory,
         ModelGraphMemoryConfig,

--- a/src/omnimemory/handlers/adapters/__init__.py
+++ b/src/omnimemory/handlers/adapters/__init__.py
@@ -39,7 +39,7 @@ Example::
     # Embedding client (contract boundary for HTTP)
     embed_config = ModelEmbeddingHttpClientConfig(
         provider="local",
-        base_url="http://localhost:8100",  # set via LLM_EMBEDDING_URL env var in production
+        base_url=os.environ["LLM_EMBEDDING_URL"],
     )
     async with EmbeddingHttpClient(embed_config) as client:
         embedding = await client.get_embedding("Hello world")
@@ -50,7 +50,7 @@ Example::
     await intent_adapter.initialize(connection_uri="bolt://{OMNIMEMORY_MEMGRAPH_HOST}:{OMNIMEMORY_MEMGRAPH_PORT}")
 
     # Valkey adapter for caching
-    valkey_config = AdapterValkeyConfig(host="localhost", port=6379)
+    valkey_config = AdapterValkeyConfig(host=os.environ["VALKEY_HOST"], port=6379)
     valkey = AdapterValkey(valkey_config)
     await valkey.initialize()
     await valkey.set_key("key", "value")

--- a/src/omnimemory/handlers/adapters/adapter_valkey.py
+++ b/src/omnimemory/handlers/adapters/adapter_valkey.py
@@ -26,7 +26,7 @@ Example::
         AdapterValkeyConfig,
     )
 
-    config = AdapterValkeyConfig(host="localhost", port=6379)
+    config = AdapterValkeyConfig(host=os.environ["VALKEY_HOST"], port=6379)
     adapter = AdapterValkey(config)
     await adapter.initialize()
 
@@ -119,7 +119,7 @@ class AdapterValkeyConfig(  # omnimemory-model-exempt: adapter config
     )
 
     host: str = Field(
-        default="localhost",
+        ...,
         description="Valkey server hostname",
     )
     port: int = Field(
@@ -394,7 +394,7 @@ class AdapterValkey:
 
     Example::
 
-        config = AdapterValkeyConfig(host="localhost", port=6379)
+        config = AdapterValkeyConfig(host=os.environ["VALKEY_HOST"], port=6379)
         adapter = AdapterValkey(config)
         await adapter.initialize()
 

--- a/src/omnimemory/handlers/handler_subscription.py
+++ b/src/omnimemory/handlers/handler_subscription.py
@@ -59,8 +59,8 @@ Example::
     container = ModelONEXContainer()
     config = ModelHandlerSubscriptionConfig(
         db_dsn=os.environ["OMNIMEMORY_DB_URL"],
-        valkey_host="localhost",
-        valkey_port=6379,
+        valkey_host=os.environ["VALKEY_HOST"],
+        valkey_port=int(os.environ.get("VALKEY_PORT", "6379")),
         kafka_bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
     )
     handler = HandlerSubscription(container)
@@ -279,7 +279,7 @@ class ModelHandlerSubscriptionConfig(  # omnimemory-model-exempt: handler config
         description="PostgreSQL connection string",
     )
     valkey_host: str = Field(
-        default="localhost",
+        ...,
         description="Valkey server hostname",
     )
     valkey_port: int = Field(

--- a/src/omnimemory/models/config/model_qdrant_config.py
+++ b/src/omnimemory/models/config/model_qdrant_config.py
@@ -32,7 +32,7 @@ class ModelQdrantConfig(BaseModel):
 
     # Connection configuration
     url: HttpUrl = Field(
-        default=HttpUrl("http://localhost:6333"),
+        ...,
         description="Qdrant server URL",
     )
     api_key: SecretStr | None = Field(

--- a/src/omnimemory/nodes/node_agent_coordinator_orchestrator/__init__.py
+++ b/src/omnimemory/nodes/node_agent_coordinator_orchestrator/__init__.py
@@ -43,7 +43,7 @@ Handler Integration::
     container = ModelONEXContainer()
     config = ModelHandlerSubscriptionConfig(
         db_dsn=os.environ["OMNIMEMORY_DB_URL"],
-        valkey_host=os.getenv("VALKEY_HOST", "localhost"),
+        valkey_host=os.environ["VALKEY_HOST"],
         kafka_bootstrap_servers=os.getenv("KAFKA_BOOTSTRAP_SERVERS"),
     )
     handler = HandlerSubscription(container)

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -21,7 +21,7 @@ class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     kreuzberg_url: str = Field(
-        default="http://localhost:8090",
+        ...,
         description="Base URL of the kreuzberg Docker service",
     )
     text_store_path: str = Field(

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_qdrant_config.py
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/models/model_handler_qdrant_config.py
@@ -45,7 +45,7 @@ class ModelHandlerQdrantConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, from_attributes=True)
 
     qdrant_host: str = Field(
-        default="localhost",
+        ...,
         description="Hostname for the Qdrant server",
     )
     qdrant_port: int = Field(

--- a/src/omnimemory/nodes/node_navigation_history_reducer/handlers/handler_navigation_history_reducer.py
+++ b/src/omnimemory/nodes/node_navigation_history_reducer/handlers/handler_navigation_history_reducer.py
@@ -61,9 +61,9 @@ __all__ = ["HandlerNavigationHistoryReducer", "HandlerNavigationHistoryWriter"]
 # ---------------------------------------------------------------------------
 
 _DEFAULT_PG_DSN = os.environ.get("OMNIMEMORY_PG_DSN", "")
-_DEFAULT_QDRANT_HOST = os.environ["QDRANT_HOST"]
-_DEFAULT_QDRANT_PORT = int(os.environ["QDRANT_PORT"])
-_DEFAULT_EMBEDDING_URL = os.environ["LLM_EMBEDDING_URL"]
+_DEFAULT_QDRANT_HOST = os.environ.get("QDRANT_HOST", "")
+_DEFAULT_QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
+_DEFAULT_EMBEDDING_URL = os.environ.get("LLM_EMBEDDING_URL", "")
 _DEFAULT_EMBEDDING_MODEL = "Qwen3-Embedding-8B"
 _QDRANT_COLLECTION = "navigation_paths"
 

--- a/src/omnimemory/nodes/node_navigation_history_reducer/handlers/handler_navigation_history_reducer.py
+++ b/src/omnimemory/nodes/node_navigation_history_reducer/handlers/handler_navigation_history_reducer.py
@@ -61,11 +61,9 @@ __all__ = ["HandlerNavigationHistoryReducer", "HandlerNavigationHistoryWriter"]
 # ---------------------------------------------------------------------------
 
 _DEFAULT_PG_DSN = os.environ.get("OMNIMEMORY_PG_DSN", "")
-_DEFAULT_QDRANT_HOST = os.environ.get("QDRANT_HOST", "localhost")
-_DEFAULT_QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
-_DEFAULT_EMBEDDING_URL = os.environ.get(
-    "LLM_EMBEDDING_URL", "http://localhost:8100/v1/embeddings"
-)
+_DEFAULT_QDRANT_HOST = os.environ["QDRANT_HOST"]
+_DEFAULT_QDRANT_PORT = int(os.environ["QDRANT_PORT"])
+_DEFAULT_EMBEDDING_URL = os.environ["LLM_EMBEDDING_URL"]
 _DEFAULT_EMBEDDING_MODEL = "Qwen3-Embedding-8B"
 _QDRANT_COLLECTION = "navigation_paths"
 

--- a/src/omnimemory/runtime/dispatch_handlers.py
+++ b/src/omnimemory/runtime/dispatch_handlers.py
@@ -440,11 +440,9 @@ def build_retrieval_config_from_env() -> (  # stub-ok: references stub_handlers 
         None
         if use_stubs
         else ModelHandlerQdrantConfig(
-            qdrant_host=os.getenv("QDRANT_HOST", "localhost"),
-            qdrant_port=int(os.getenv("QDRANT_PORT", "6333")),
-            embedding_server_url=os.getenv(
-                "LLM_EMBEDDING_URL", "http://localhost:8100"
-            ),
+            qdrant_host=os.environ["QDRANT_HOST"],
+            qdrant_port=int(os.environ["QDRANT_PORT"]),
+            embedding_server_url=os.environ["LLM_EMBEDDING_URL"],
         )
     )
     return ModelHandlerMemoryRetrievalConfig(

--- a/src/omnimemory/runtime/plugin.py
+++ b/src/omnimemory/runtime/plugin.py
@@ -238,7 +238,7 @@ class PluginMemory:
         ):
             return ModelHandshakeResult.default_pass(self.plugin_id)
 
-        host = os.getenv("OMNIMEMORY_MEMGRAPH_HOST", "localhost")
+        host = os.environ["OMNIMEMORY_MEMGRAPH_HOST"]
         port = int(os.getenv("OMNIMEMORY_MEMGRAPH_PORT", "7687"))
 
         reachable = await _probe_tcp_reachable(host, port)
@@ -534,7 +534,7 @@ class PluginMemory:
                 navigation_history_handler = HandlerNavigationHistoryReducer(
                     writer=None,
                     pg_dsn=nav_pg_dsn,
-                    qdrant_host=os.environ.get("QDRANT_HOST", "localhost"),
+                    qdrant_host=os.environ["QDRANT_HOST"],
                     qdrant_port=int(os.environ.get("QDRANT_PORT", "6333")),
                     embedding_url=os.environ.get(
                         "LLM_EMBEDDING_URL",

--- a/src/omnimemory/settings.py
+++ b/src/omnimemory/settings.py
@@ -215,7 +215,7 @@ class QdrantSettings(BaseSettings):
     )
 
     url: HttpUrl = Field(
-        default="http://localhost:6333",  # type: ignore[assignment]
+        ...,  # type: ignore[assignment]
         description="Qdrant server URL",
     )
     api_key: SecretStr | None = Field(

--- a/src/omnimemory/settings.py
+++ b/src/omnimemory/settings.py
@@ -215,7 +215,7 @@ class QdrantSettings(BaseSettings):
     )
 
     url: HttpUrl = Field(
-        ...,  # type: ignore[assignment]
+        ...,
         description="Qdrant server URL",
     )
     api_key: SecretStr | None = Field(

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -346,51 +346,59 @@ class TestModelQdrantConfig:
         """Test collection_name validates as alphanumeric with underscore/hyphen."""
         # Valid names
         for name in ["my_collection", "test-collection", "collection123"]:
-            config = ModelQdrantConfig(collection_name=name)
+            config = ModelQdrantConfig(
+                url="http://qdrant.test:6333", collection_name=name
+            )
             assert config.collection_name == name
 
         # Invalid name (special characters)
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(collection_name="invalid.collection!")
+            ModelQdrantConfig(
+                url="http://qdrant.test:6333", collection_name="invalid.collection!"
+            )
 
     def test_vector_size_bounds(self) -> None:
         """Test vector_size bounds (1-65536)."""
         # Valid
-        config = ModelQdrantConfig(vector_size=384)
+        config = ModelQdrantConfig(url="http://qdrant.test:6333", vector_size=384)
         assert config.vector_size == 384
 
         # Too low
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(vector_size=0)
+            ModelQdrantConfig(url="http://qdrant.test:6333", vector_size=0)
 
         # Too high
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(vector_size=100000)
+            ModelQdrantConfig(url="http://qdrant.test:6333", vector_size=100000)
 
     def test_distance_metric_validation(self) -> None:
         """Test distance_metric validates against allowed values."""
         # Valid metrics
         for metric in ["Cosine", "Euclid", "Dot"]:
-            config = ModelQdrantConfig(distance_metric=metric)
+            config = ModelQdrantConfig(
+                url="http://qdrant.test:6333", distance_metric=metric
+            )
             assert config.distance_metric == metric
 
         # Invalid metric
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(distance_metric="Manhattan")
+            ModelQdrantConfig(
+                url="http://qdrant.test:6333", distance_metric="Manhattan"
+            )
 
     def test_score_threshold_bounds(self) -> None:
         """Test score_threshold bounds (0.0-1.0)."""
         # Valid
-        config = ModelQdrantConfig(score_threshold=0.85)
+        config = ModelQdrantConfig(url="http://qdrant.test:6333", score_threshold=0.85)
         assert config.score_threshold == 0.85
 
         # Below minimum
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(score_threshold=-0.1)
+            ModelQdrantConfig(url="http://qdrant.test:6333", score_threshold=-0.1)
 
         # Above maximum
         with pytest.raises(ValidationError):
-            ModelQdrantConfig(score_threshold=1.5)
+            ModelQdrantConfig(url="http://qdrant.test:6333", score_threshold=1.5)
 
 
 class TestModelMemoryServiceConfig:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -132,18 +132,19 @@ class TestQdrantSettings:
     def test_loads_from_env_with_defaults(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test qdrant settings load with defaults."""
+        """Test qdrant settings load with URL from env and other defaults."""
         _clear_omnimemory_env_vars(monkeypatch)
-        # Qdrant has all defaults, no required fields
+        monkeypatch.setenv("OMNIMEMORY__QDRANT__URL", "http://qdrant.test:6333")
 
         settings = QdrantSettings()
-        assert str(settings.url).rstrip("/") == "http://localhost:6333"
+        assert str(settings.url).rstrip("/") == "http://qdrant.test:6333"
         assert settings.api_key is None
         assert settings.collection_name == "omnimemory"
 
     def test_loads_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test qdrant api_key loads from environment."""
         _clear_omnimemory_env_vars(monkeypatch)
+        monkeypatch.setenv("OMNIMEMORY__QDRANT__URL", "http://qdrant.test:6333")
         monkeypatch.setenv("OMNIMEMORY__QDRANT__API_KEY", "my-api-key")
 
         settings = QdrantSettings()
@@ -153,6 +154,7 @@ class TestQdrantSettings:
     def test_to_config_converts_properly(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test to_config() produces ModelQdrantConfig."""
         _clear_omnimemory_env_vars(monkeypatch)
+        monkeypatch.setenv("OMNIMEMORY__QDRANT__URL", "http://qdrant.test:6333")
 
         settings = QdrantSettings()
         config = settings.to_config()
@@ -225,6 +227,7 @@ class TestMemoryServiceSettings:
         _clear_omnimemory_env_vars(monkeypatch)
         monkeypatch.setenv("OMNIMEMORY__FILESYSTEM__BASE_PATH", str(tmp_path))
         monkeypatch.setenv("OMNIMEMORY__QDRANT_ENABLED", "true")
+        monkeypatch.setenv("OMNIMEMORY__QDRANT__URL", "http://qdrant.test:6333")
 
         settings = MemoryServiceSettings()
         config = settings.to_config()

--- a/tests/unit/nodes/test_model_handler_qdrant_config.py
+++ b/tests/unit/nodes/test_model_handler_qdrant_config.py
@@ -19,10 +19,13 @@ from omnimemory.nodes.node_memory_retrieval_effect.models import (
 
 
 @pytest.mark.unit
-def test_defaults_with_required_url() -> None:
-    """ModelHandlerQdrantConfig has correct defaults when embedding_server_url provided."""
-    cfg = ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100")
-    assert cfg.qdrant_host == "localhost"
+def test_defaults_with_required_fields() -> None:
+    """ModelHandlerQdrantConfig has correct defaults when required fields provided."""
+    cfg = ModelHandlerQdrantConfig(
+        qdrant_host="qdrant.test",
+        embedding_server_url="http://embed.test:8100",
+    )
+    assert cfg.qdrant_host == "qdrant.test"
     assert cfg.qdrant_port == 6333
     assert cfg.collection_name == "omnimemory_documents"
     assert cfg.vector_size == 4096
@@ -63,14 +66,17 @@ def test_retrieval_config_stub_mode_default() -> None:
 @pytest.mark.unit
 def test_retrieval_config_production_mode_with_qdrant_config() -> None:
     """ModelHandlerMemoryRetrievalConfig accepts use_stub_handlers=False when qdrant_config provided."""
-    qdrant_cfg = ModelHandlerQdrantConfig(embedding_server_url="http://localhost:8100")
+    qdrant_cfg = ModelHandlerQdrantConfig(
+        qdrant_host="qdrant.test",
+        embedding_server_url="http://embed.test:8100",
+    )
     cfg = ModelHandlerMemoryRetrievalConfig(
         use_stub_handlers=False,
         qdrant_config=qdrant_cfg,
     )
     assert cfg.use_stub_handlers is False
     assert cfg.qdrant_config is not None
-    assert cfg.qdrant_config.embedding_server_url == "http://localhost:8100"
+    assert cfg.qdrant_config.embedding_server_url == "http://embed.test:8100"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_dispatch_retrieval_config.py
+++ b/tests/unit/test_dispatch_retrieval_config.py
@@ -70,14 +70,10 @@ class TestRetrievalConfigFromEnv:
         assert config.use_stub_handlers is False
         assert config.qdrant_config is not None
 
-    def test_false_without_qdrant_env_uses_defaults(self) -> None:
-        """When stubs disabled but QDRANT_* unset, sensible defaults apply."""
+    def test_false_without_qdrant_env_raises_keyerror(self) -> None:
+        """When stubs disabled but QDRANT_* unset, KeyError is raised (no fallback defaults)."""
         with patch.dict(
             os.environ, {"OMNIMEMORY_USE_STUB_HANDLERS": "false"}, clear=True
         ):
-            config = build_retrieval_config_from_env()
-        assert config.use_stub_handlers is False
-        assert config.qdrant_config is not None
-        assert config.qdrant_config.qdrant_host == "localhost"
-        assert config.qdrant_config.qdrant_port == 6333
-        assert config.qdrant_config.embedding_server_url == "http://localhost:8100"
+            with pytest.raises(KeyError):
+                build_retrieval_config_from_env()


### PR DESCRIPTION
## Summary
- Remove `localhost` default values from 6 Pydantic model Field declarations (valkey_host, kreuzberg_url, qdrant_host, qdrant url, adapter_valkey host)
- Replace `os.environ.get("VAR", "localhost")` with `os.environ["VAR"]` in 5 runtime files (plugin.py, dispatch_handlers.py, handler_navigation_history_reducer.py, node_agent_coordinator_orchestrator)
- Make PostgreSQL DSN host extraction in bootstrap.py raise on missing host instead of falling back to localhost
- Update docstring examples to use `os.environ[]` instead of hardcoded localhost

## Test plan
- [ ] Verify all required env vars are set in deployment configs: `VALKEY_HOST`, `QDRANT_HOST`, `QDRANT_PORT`, `LLM_EMBEDDING_URL`, `OMNIMEMORY_MEMGRAPH_HOST`
- [ ] Run `uv run pytest -m unit` to confirm unit tests pass (tests should provide explicit config values)
- [ ] Run `uv run ruff check src/` to confirm lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for runtime service configuration: missing host/URL env vars no longer silently fall back to localhost; failures surface immediately.

* **Breaking Changes**
  * Service hosts and URLs (Qdrant, Valkey, Kreuzberg, Memgraph, embedding service, etc.) must be explicitly provided via environment variables; implicit local defaults have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->