### PR TITLE
feat(handler): add agent learning retrieval helpers [OMN-7246]

### DIFF
--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/__init__.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Agent Learning Retrieval Effect — ONEX Node.
+
+Retrieval helpers for cross-agent memory fabric. Provides query-building
+and ranking functions for layered similarity search against agent learning
+collections.
+
+.. versionadded:: 0.3.0
+    Initial implementation for OMN-7246.
+"""

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/clients/__init__.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/clients/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Agent Learning Retrieval Effect clients."""

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/handlers/__init__.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/handlers/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Agent Learning Retrieval Effect handlers."""

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/handlers/handler_agent_learning_retrieval.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/handlers/handler_agent_learning_retrieval.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Handler for agent learning retrieval.
+
+Performs layered similarity search against two Qdrant collections:
+1. agent_learnings_error — high-precision error signature matching (cosine > 0.85)
+2. agent_learnings_context — broad task context matching (cosine > 0.70)
+
+Results are ranked by combined_score = similarity * freshness_score and merged.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+
+def compute_freshness_score(created_at: datetime, now: datetime) -> float:
+    """Exponential decay: ~90% at 1 week, ~60% at 4 weeks."""
+    delta = now - created_at
+    days_old = max(0.0, delta.total_seconds() / 86400)
+    return math.exp(-0.015 * days_old)
+
+
+def build_error_query_text(error_text: str) -> str:
+    """Build the text to embed for error signature matching."""
+    return f"Error: {error_text[:2000]}"
+
+
+def build_context_query_text(
+    repo: str,
+    file_paths: tuple[str, ...],
+    task_type: str | None,
+) -> str:
+    """Build the text to embed for task context matching."""
+    parts = [f"Repository: {repo}"]
+    if file_paths:
+        parts.append(f"Files: {', '.join(file_paths[:20])}")
+    if task_type:
+        parts.append(f"Task type: {task_type}")
+    return "\n".join(parts)
+
+
+def rank_and_merge(
+    matches: list[dict[str, object]],
+    max_results: int,
+) -> list[dict[str, object]]:
+    """Rank matches by combined_score descending and limit to max_results."""
+    sorted_matches = sorted(
+        matches,
+        key=lambda m: float(m.get("combined_score", 0)),  # type: ignore[arg-type]
+        reverse=True,
+    )
+    return sorted_matches[:max_results]

--- a/tests/unit/nodes/test_handler_agent_learning_retrieval.py
+++ b/tests/unit/nodes/test_handler_agent_learning_retrieval.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Tests for agent learning retrieval handler logic."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from omnimemory.nodes.node_agent_learning_retrieval_effect.handlers.handler_agent_learning_retrieval import (
+    build_context_query_text,
+    build_error_query_text,
+    compute_freshness_score,
+    rank_and_merge,
+)
+
+
+@pytest.mark.unit
+class TestComputeFreshnessScore:
+    def test_today(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        assert compute_freshness_score(now, now) == pytest.approx(1.0)
+
+    def test_one_week(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        score = compute_freshness_score(now - timedelta(weeks=1), now)
+        assert 0.85 < score < 0.95
+
+    def test_four_weeks(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        score = compute_freshness_score(now - timedelta(weeks=4), now)
+        assert 0.60 < score < 0.72
+
+    def test_future_date_clamps_to_one(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        score = compute_freshness_score(now + timedelta(days=5), now)
+        assert score == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+class TestBuildQueryTexts:
+    def test_error_query(self) -> None:
+        text = build_error_query_text("ImportError: no module named foo")
+        assert "ImportError" in text
+        assert text.startswith("Error: ")
+
+    def test_error_query_truncates(self) -> None:
+        long_error = "x" * 5000
+        text = build_error_query_text(long_error)
+        assert len(text) <= 2007  # "Error: " prefix + 2000 chars
+
+    def test_context_query(self) -> None:
+        text = build_context_query_text(
+            repo="omnibase_infra",
+            file_paths=("src/foo.py", "tests/test_foo.py"),
+            task_type="ci_fix",
+        )
+        assert "omnibase_infra" in text
+        assert "ci_fix" in text
+        assert "src/foo.py" in text
+
+    def test_context_query_no_files(self) -> None:
+        text = build_context_query_text(
+            repo="omnimemory",
+            file_paths=(),
+            task_type="bug_fix",
+        )
+        assert "omnimemory" in text
+        assert "Files:" not in text
+
+    def test_context_query_no_task_type(self) -> None:
+        text = build_context_query_text(
+            repo="omnimemory",
+            file_paths=("a.py",),
+            task_type=None,
+        )
+        assert "Task type:" not in text
+
+
+@pytest.mark.unit
+class TestRankAndMerge:
+    def test_sorts_by_combined_score(self) -> None:
+        matches: list[dict[str, object]] = [
+            {"combined_score": 0.5, "match_type": "task_context"},
+            {"combined_score": 0.9, "match_type": "error_signature"},
+            {"combined_score": 0.7, "match_type": "task_context"},
+        ]
+        ranked = rank_and_merge(matches, max_results=3)
+        assert ranked[0]["combined_score"] == 0.9
+        assert ranked[1]["combined_score"] == 0.7
+        assert ranked[2]["combined_score"] == 0.5
+
+    def test_respects_max_results(self) -> None:
+        matches: list[dict[str, object]] = [
+            {"combined_score": float(i) / 10, "match_type": "task_context"}
+            for i in range(10)
+        ]
+        ranked = rank_and_merge(matches, max_results=3)
+        assert len(ranked) == 3
+
+    def test_empty_input(self) -> None:
+        ranked = rank_and_merge([], max_results=5)
+        assert ranked == []


### PR DESCRIPTION
## Summary

- Add `node_agent_learning_retrieval_effect` with query-building and ranking helpers for cross-agent memory fabric retrieval
- `compute_freshness_score` implements canonical formula `e^(-0.015 * days_old)` matching the design doc and omnibase_infra copy
- `build_error_query_text` / `build_context_query_text` construct embedding inputs for layered similarity search (error signature + task context)
- `rank_and_merge` sorts matches by `combined_score` descending and limits to `max_results`
- 12 unit tests covering all helpers including edge cases (future dates, empty inputs, truncation)

## Plan Reference

Task 7 of `docs/plans/2026-04-02-cross-agent-memory-fabric-phase1.md` (Sub-Phase 1B: Retrieval contract + ranking)

## Test plan

- [x] `uv run pytest tests/unit/nodes/test_handler_agent_learning_retrieval.py -v` — 12/12 pass
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] `pre-commit run --all-files` — all hooks pass
- [x] mypy strict + pyright basic pass (pre-push hooks)