### PR TITLE
feat(node): add agent learning retrieval effect node [OMN-7245]

### DIFF
--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# Agent Learning Retrieval EFFECT - ONEX Contract
+# EFFECT node for retrieving agent learning records from Qdrant vector collections.
+
+# === REQUIRED ROOT FIELDS ===
+name: "node_agent_learning_retrieval_effect"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: "Retrieves agent learning records from Qdrant vector collections. Supports error signature
+  matching (high precision, cosine > 0.85) and task context matching (broad recall, cosine > 0.70) with
+  freshness decay ranking."
+node_type: "EFFECT"
+input_model: "ModelAgentLearningRetrievalRequest"
+output_model: "ModelAgentLearningRetrievalResponse"
+
+# === IO OPERATIONS (Required for EFFECT nodes) ===
+io_operations:
+  - operation_type: "vector_query"
+    atomic: false
+    timeout_seconds: 10
+    validation_enabled: true
+
+# === TRANSACTION MANAGEMENT ===
+transaction_management:
+  enabled: false
+
+# === NODE CONFIGURATION ===
+tool_specification:
+  tool_name: "agent_learning_retrieval_effect"
+  main_tool_class: "NodeAgentLearningRetrievalEffect"
+
+# === SERVICE CONFIGURATION ===
+service_configuration:
+  is_persistent_service: false
+  requires_external_dependencies: true
+
+# === INPUT/OUTPUT STATE ===
+input_state:
+  object_type: "object"
+  required: ["repo"]
+  optional: ["match_type", "error_text", "file_paths", "task_type", "max_results", "min_similarity_error",
+    "min_similarity_context"]
+
+output_state:
+  object_type: "object"
+  required: ["query_ms"]
+  optional: ["matches", "error_matches_count", "context_matches_count"]
+
+# === ACTIONS ===
+actions:
+  - name: "retrieve"
+    description: "Retrieve relevant agent learnings by error signature or task context"
+    inputs: ["repo", "match_type", "error_text", "file_paths", "task_type", "max_results"]
+    outputs: ["matches", "query_ms", "error_matches_count", "context_matches_count"]
+
+  - name: "health_check"
+    description: "Check node health status"
+    inputs: []
+    outputs: ["status"]
+
+# === DEPENDENCIES ===
+dependencies:
+  - name: qdrant
+    dependency_type: service
+    description: Qdrant vector store for learning record similarity search
+    required: true
+
+  - name: ProtocolEmbeddingClient
+    dependency_type: protocol
+    description: Embedding client for vectorizing query text
+
+# === PERFORMANCE ===
+performance:
+  max_response_time_ms: 100
+
+# === EVENT TYPE CONFIGURATION ===
+event_type:
+  version: {major: 1, minor: 0, patch: 0}
+  primary_events: ["learning_retrieved"]
+  event_categories: ["memory", "effect", "retrieval", "learning"]
+  publish_events: true
+  subscribe_events: true
+  invocation_mode: "subscription"
+  event_routing: "memory"
+
+# === INFRASTRUCTURE ===
+infrastructure:
+  retrieval_backends:
+    - qdrant
+
+# === VALIDATION RULES ===
+validation_rules:
+  strict_typing_enabled: true
+  input_validation_enabled: true
+  output_validation_enabled: true
+  performance_validation_enabled: true
+  constraint_definitions:
+    match_type: "Literal['error_signature', 'task_context', 'auto'] - retrieval strategy"
+    repo: "string (1-128) - repository to scope search to"
+    error_text: "string (max 4000) - error message for signature matching"
+    max_results: "int (1-20) - maximum results to return"
+
+# === HANDLER ROUTING ===
+handler_routing:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  routing_strategy: default
+  handlers:
+    - routing_key: "retrieve"
+      handler_key: "HandlerAgentLearningRetrieval"
+      priority: 0
+      output_events: []
+  default_handler: "HandlerAgentLearningRetrieval"
+
+# === EVENT BUS SUBCONTRACT ===
+event_bus:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  event_bus_enabled: true
+
+  subscribe_topics:
+    - "onex.cmd.omnimemory.agent-learning-retrieval-requested.v1"
+
+  publish_topics:
+    - "onex.evt.omnimemory.agent-learning-retrieval-response.v1"
+
+  subscribe_topic_metadata:
+    "onex.cmd.omnimemory.agent-learning-retrieval-requested.v1":
+      schema_ref: "omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_request.ModelAgentLearningRetrievalRequest"
+      description: "Agent learning retrieval request with match type, error text, repo, and context parameters."
+
+  publish_topic_metadata:
+    "onex.evt.omnimemory.agent-learning-retrieval-response.v1":
+      schema_ref: "omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_response.ModelAgentLearningRetrievalResponse"
+      description: "Agent learning retrieval response with ranked matches, similarity scores, and freshness
+        decay."
+
+# === TAGS ===
+tags:
+  - memory
+  - retrieval
+  - effect
+  - learning
+  - agent
+  - qdrant
+  - vector

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/__init__.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/__init__.py
@@ -2,23 +2,21 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2025 OmniNode Team
-"""Agent Learning Retrieval Effect — ONEX Node.
+"""Models for agent learning retrieval node."""
 
-Retrieval helpers for cross-agent memory fabric. Provides query-building
-and ranking functions for layered similarity search against agent learning
-collections.
-
-.. versionadded:: 0.3.0
-    Initial implementation for OMN-7246.
-"""
-
-from omnimemory.nodes.node_agent_learning_retrieval_effect.models import (
+from omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_request import (
+    EnumRetrievalMatchType,
     ModelAgentLearningRetrievalRequest,
+)
+from omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_response import (
+    EnumRetrievalTaskType,
     ModelAgentLearningRetrievalResponse,
     ModelRetrievedLearning,
 )
 
 __all__ = [
+    "EnumRetrievalMatchType",
+    "EnumRetrievalTaskType",
     "ModelAgentLearningRetrievalRequest",
     "ModelAgentLearningRetrievalResponse",
     "ModelRetrievedLearning",

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/model_request.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/model_request.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Request model for agent learning retrieval."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EnumRetrievalMatchType(StrEnum):
+    """How to match against the learning store."""
+
+    ERROR_SIGNATURE = "error_signature"
+    TASK_CONTEXT = "task_context"
+    AUTO = "auto"
+
+
+class ModelAgentLearningRetrievalRequest(BaseModel):
+    """Request to retrieve relevant agent learnings."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    match_type: EnumRetrievalMatchType = Field(
+        default=EnumRetrievalMatchType.AUTO,
+        description="Match strategy",
+    )
+    error_text: str | None = Field(
+        default=None,
+        max_length=4000,
+        description="Error message for error_signature matching",
+    )
+    repo: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="Repository to scope search to",
+    )
+    file_paths: tuple[str, ...] = Field(
+        default=(),
+        description="File paths for context matching",
+    )
+    task_type: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Optional task type filter",
+    )
+    max_results: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum results to return",
+    )
+    min_similarity_error: float = Field(
+        default=0.85,
+        ge=0.0,
+        le=1.0,
+        description="Minimum cosine similarity for error signature matches",
+    )
+    min_similarity_context: float = Field(
+        default=0.70,
+        ge=0.0,
+        le=1.0,
+        description="Minimum cosine similarity for task context matches",
+    )

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/model_response.py
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/models/model_response.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Response model for agent learning retrieval."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_request import (  # noqa: TC001
+    EnumRetrievalMatchType,
+)
+
+
+class EnumRetrievalTaskType(StrEnum):
+    """Task type classification for retrieved learnings.
+
+    Mirrors EnumLearningTaskType in omnibase_infra. Both enums MUST remain
+    identical — see Canonical Freshness Formula note in the design doc for
+    the cross-repo sync contract.
+    """
+
+    CI_FIX = "ci_fix"
+    MIGRATION = "migration"
+    FEATURE = "feature"
+    REFACTOR = "refactor"
+    BUG_FIX = "bug_fix"
+    TEST = "test"
+    DOCS = "docs"
+    DEPENDENCY = "dependency"
+    UNKNOWN = "unknown"
+
+
+class ModelRetrievedLearning(BaseModel):
+    """A single retrieved learning with match metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    learning_id: UUID = Field(..., description="Primary key of the learning record")
+    match_type: EnumRetrievalMatchType = Field(
+        ..., description="How this match was found"
+    )
+    similarity: float = Field(..., ge=0.0, le=1.0, description="Cosine similarity")
+    freshness_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Freshness decay factor"
+    )
+    combined_score: float = Field(
+        ..., ge=0.0, le=1.0, description="Final ranking score"
+    )
+    repo: str = Field(..., description="Repository name")
+    resolution_summary: str = Field(..., description="What the agent did")
+    error_signatures: tuple[str, ...] = Field(
+        default=(), description="Failed tool summaries encountered"
+    )
+    file_paths_touched: tuple[str, ...] = Field(
+        default=(), description="Files modified"
+    )
+    ticket_id: str | None = Field(default=None, description="Associated ticket")
+    task_type: EnumRetrievalTaskType = Field(..., description="Task classification")
+    age_days: int = Field(..., ge=0, description="Days since learning was created")
+    created_at: datetime = Field(..., description="When the learning was created")
+
+
+class ModelAgentLearningRetrievalResponse(BaseModel):
+    """Response from agent learning retrieval."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    matches: tuple[ModelRetrievedLearning, ...] = Field(
+        default=(),
+        description="Matched learnings sorted by combined_score descending",
+    )
+    query_ms: int = Field(..., ge=0, description="Total query time in milliseconds")
+    error_matches_count: int = Field(
+        default=0, ge=0, description="Matches from error collection"
+    )
+    context_matches_count: int = Field(
+        default=0, ge=0, description="Matches from context collection"
+    )

--- a/tests/unit/nodes/test_node_agent_learning_retrieval_models.py
+++ b/tests/unit/nodes/test_node_agent_learning_retrieval_models.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Tests for agent learning retrieval node models."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_request import (
+    EnumRetrievalMatchType,
+    ModelAgentLearningRetrievalRequest,
+)
+from omnimemory.nodes.node_agent_learning_retrieval_effect.models.model_response import (
+    EnumRetrievalTaskType,
+    ModelAgentLearningRetrievalResponse,
+    ModelRetrievedLearning,
+)
+
+
+@pytest.mark.unit
+class TestRetrievalRequest:
+    def test_error_query(self) -> None:
+        req = ModelAgentLearningRetrievalRequest(
+            match_type=EnumRetrievalMatchType.ERROR_SIGNATURE,
+            error_text="ImportError: foo",
+            repo="omnibase_core",
+        )
+        assert req.min_similarity_error == 0.85
+
+    def test_auto_query(self) -> None:
+        req = ModelAgentLearningRetrievalRequest(
+            repo="omnidash",
+            error_text="TypeError: undefined",
+            file_paths=("src/app/page.tsx",),
+        )
+        assert req.match_type == EnumRetrievalMatchType.AUTO
+
+    def test_frozen(self) -> None:
+        req = ModelAgentLearningRetrievalRequest(repo="test")
+        with pytest.raises(Exception):
+            req.repo = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestRetrievalResponse:
+    def test_empty_response(self) -> None:
+        resp = ModelAgentLearningRetrievalResponse(query_ms=12)
+        assert resp.matches == ()
+
+    def test_with_matches(self) -> None:
+        match = ModelRetrievedLearning(
+            learning_id=uuid4(),
+            match_type=EnumRetrievalMatchType.ERROR_SIGNATURE,
+            similarity=0.92,
+            freshness_score=0.95,
+            combined_score=0.87,
+            repo="omnibase_infra",
+            resolution_summary="Fixed by adding missing import.",
+            task_type=EnumRetrievalTaskType.CI_FIX,
+            age_days=2,
+            created_at=datetime.now(tz=timezone.utc),
+        )
+        resp = ModelAgentLearningRetrievalResponse(
+            matches=(match,),
+            query_ms=45,
+            error_matches_count=1,
+        )
+        assert len(resp.matches) == 1
+        assert resp.matches[0].similarity == 0.92


### PR DESCRIPTION
## Summary

- Add `node_agent_learning_retrieval_effect` EFFECT node with ONEX-compliant contract, request/response models, and unit tests
- Request model supports error signature matching (cosine > 0.85), task context matching (cosine > 0.70), and auto mode
- Response model uses typed enums (`EnumRetrievalMatchType`, `EnumRetrievalTaskType`) with freshness-decay combined scoring
- Part of Cross-Agent Memory Fabric Phase 1B (Task 6) — enables future agents to retrieve solutions from prior successful sessions

## Test plan

- [x] `uv run pytest tests/unit/nodes/test_node_agent_learning_retrieval_models.py -v` — 5/5 pass
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] Contract linter passes
- [x] All pre-commit hooks pass (30+ hooks including yamlfmt, SPDX, AI-slop, contract linter)
- [x] mypy strict + pyright basic pass (push hooks)