### PR TITLE
feat(persona): add persona enums, models, and signal types [OMN-3967][OMN-3969]

### DIFF
--- a/src/omnimemory/enums/__init__.py
+++ b/src/omnimemory/enums/__init__.py
@@ -16,15 +16,18 @@ from .enum_intelligence_operation_type import EnumIntelligenceOperationType
 from .enum_lifecycle_state import EnumLifecycleState
 from .enum_memory_operation_type import EnumMemoryOperationType
 from .enum_memory_storage_type import EnumMemoryStorageType
+from .enum_memory_type import EnumMemoryType
 from .enum_migration_status import (
     EnumFileProcessingStatus,
     EnumMigrationPriority,
     EnumMigrationStatus,
 )
+from .enum_preferred_tone import EnumPreferredTone
 from .enum_priority_level import EnumPriorityLevel
 from .enum_promotion_tier import EnumPromotionTier
 from .enum_semantic_entity_type import EnumSemanticEntityType
 from .enum_subscription_status import EnumSubscriptionStatus
+from .enum_technical_level import EnumTechnicalLevel
 from .enum_trust_level import EnumDecayFunction, EnumTrustLevel
 
 __all__ = [
@@ -40,12 +43,15 @@ __all__ = [
     "EnumLifecycleState",
     "EnumMemoryOperationType",
     "EnumMemoryStorageType",
+    "EnumMemoryType",
     "EnumMigrationPriority",
     "EnumMigrationStatus",
     "EnumOmniMemoryErrorCode",
+    "EnumPreferredTone",
     "EnumPriorityLevel",
     "EnumPromotionTier",
     "EnumSemanticEntityType",
     "EnumSubscriptionStatus",
+    "EnumTechnicalLevel",
     "EnumTrustLevel",
 ]

--- a/src/omnimemory/enums/enum_memory_type.py
+++ b/src/omnimemory/enums/enum_memory_type.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Memory type classification for persona derivation eligibility."""
+
+from enum import Enum
+
+
+class EnumMemoryType(str, Enum):
+    """Classification of memory items for persona derivation eligibility.
+
+    Phase A: Controls which persona fields each memory type contributes to.
+    Phase B (future, OMN-3980): Will also control retention duration and sharing
+    eligibility. Consent enforcement is deferred to Phase B.
+    """
+
+    FACTUAL = "factual"
+    PREFERENCE = "preference"
+    SENSITIVE = "sensitive"
+    EPHEMERAL = "ephemeral"

--- a/src/omnimemory/enums/enum_preferred_tone.py
+++ b/src/omnimemory/enums/enum_preferred_tone.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Inferred preferred interaction style for persona inference."""
+
+from enum import Enum
+
+
+class EnumPreferredTone(str, Enum):
+    """Inferred preferred interaction style.
+
+    Derived from prompt patterns and interaction history. Allowed to shift
+    faster than technical_level because tone is more situational and less
+    consequential if wrong.
+    """
+
+    EXPLANATORY = "explanatory"
+    CONCISE = "concise"
+    FORMAL = "formal"
+    CASUAL = "casual"

--- a/src/omnimemory/enums/enum_technical_level.py
+++ b/src/omnimemory/enums/enum_technical_level.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Inferred user technical capability level for persona inference."""
+
+from enum import Enum
+
+
+class EnumTechnicalLevel(str, Enum):
+    """Inferred user technical capability.
+
+    Derived from session behavior: tool usage patterns, prompt complexity,
+    error recovery rate, and vocabulary. Updated conservatively between
+    sessions (requires 3+ consistent high-confidence signals to shift).
+    """
+
+    BEGINNER = "beginner"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
+    EXPERT = "expert"

--- a/src/omnimemory/models/persona/__init__.py
+++ b/src/omnimemory/models/persona/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona models for adaptive personalization (Phase 3)."""
+
+from .model_persona_signal import ModelPersonaSignal
+from .model_user_persona_v1 import ModelUserPersonaV1
+
+__all__ = [
+    "ModelPersonaSignal",
+    "ModelUserPersonaV1",
+]

--- a/src/omnimemory/models/persona/model_persona_signal.py
+++ b/src/omnimemory/models/persona/model_persona_signal.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Single observation about user behavior for persona inference."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPersonaSignal(BaseModel):
+    """A single observation about user behavior that contributes to persona inference.
+
+    Emitted by session hooks at session end. Consumed by
+    node_persona_builder_compute to incrementally update a persona snapshot.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    signal_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this signal",
+    )
+    user_id: str = Field(..., description="User identifier")
+    session_id: str = Field(..., description="Session that produced this signal")
+    signal_type: str = Field(
+        ...,
+        description="Signal category (e.g. 'technical_level', 'vocabulary', 'tone')",
+    )
+    evidence: str = Field(
+        ...,
+        max_length=500,
+        description="What was observed in the session",
+    )
+    inferred_value: str = Field(
+        ...,
+        description="The classification value derived from the evidence",
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the inference (0.0-1.0)",
+    )
+    emitted_at: datetime = Field(..., description="When this signal was emitted")

--- a/src/omnimemory/models/persona/model_user_persona_v1.py
+++ b/src/omnimemory/models/persona/model_user_persona_v1.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deterministic persona snapshot model derived from observed behavior."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
+
+
+class ModelUserPersonaV1(BaseModel):
+    """Deterministic persona snapshot derived from memory items.
+
+    Not a configuration — this is INFERRED from observed behavior.
+    Updated incrementally between sessions. Read-only during sessions.
+
+    Consent enforcement is deferred to Phase B (OMN-3980). Phase 3 assumes
+    trusted internal deployment.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    user_id: str = Field(..., description="User or agent identifier")
+    agent_id: str | None = Field(
+        default=None,
+        description="Bound agent from Phase 2 (convenience binding, not partition key)",
+    )
+    technical_level: EnumTechnicalLevel = Field(
+        default=EnumTechnicalLevel.INTERMEDIATE,
+        description="Inferred technical capability",
+    )
+    vocabulary_complexity: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="0=simple, 1=advanced jargon (derived from prompt analysis)",
+    )
+    preferred_tone: EnumPreferredTone = Field(
+        default=EnumPreferredTone.EXPLANATORY,
+        description="Inferred interaction style preference",
+    )
+    domain_familiarity: dict[str, float] = Field(
+        default_factory=dict,
+        description="Repo/domain to proficiency score (0.0-1.0)",
+    )
+    session_count: int = Field(
+        default=0,
+        ge=0,
+        description="Total sessions observed (for confidence weighting)",
+    )
+    persona_version: int = Field(
+        default=1,
+        ge=1,
+        description="Monotonic version for append-only snapshots",
+    )
+    created_at: datetime = Field(..., description="When this snapshot was created")
+    rebuilt_from_signals: int = Field(
+        default=0,
+        ge=0,
+        description="Number of signals that contributed to this snapshot",
+    )

--- a/src/omnimemory/nodes/node_persona_builder_compute/__init__.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona Builder Compute Node — pure classification of persona signals."""
+
+from .handlers import classify_persona
+from .models import ModelPersonaClassifyRequest, ModelPersonaClassifyResult
+
+__all__ = [
+    "ModelPersonaClassifyRequest",
+    "ModelPersonaClassifyResult",
+    "classify_persona",
+]

--- a/src/omnimemory/nodes/node_persona_builder_compute/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_builder_compute/contract.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+# Persona Builder COMPUTE - ONEX Contract
+# Pure COMPUTE node that classifies persona signals into an updated PersonaProfile.
+# No I/O — takes signals and an optional existing profile, produces a new snapshot.
+
+name: "node_persona_builder_compute"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: >
+  Pure compute node that takes a batch of PersonaSignal events and an optional existing PersonaProfile,
+  then produces an updated PersonaProfile. Classification uses heuristic rules and threshold scoring (no
+  ML). Conservatism rules prevent thrashing on weak evidence. Phase 3 Adaptive Personalization (OMN-7305).
+node_type: "COMPUTE"
+input_model: "ModelPersonaClassifyRequest"
+output_model: "ModelPersonaClassifyResult"
+
+algorithm:
+  algorithm_type: "persona_classification"
+  factors:
+    technical_level:
+      weight: 1.0
+      calculation_method: "mode_with_confidence_threshold"
+      threshold: 0.7
+      min_sessions: 3
+    vocabulary_complexity:
+      weight: 1.0
+      calculation_method: "exponential_moving_average"
+      alpha: 0.2
+    preferred_tone:
+      weight: 1.0
+      calculation_method: "mode_of_recent"
+      window_size: 10
+    domain_familiarity:
+      weight: 1.0
+      calculation_method: "incremental_exposure"
+      increment: 0.1
+      cap: 1.0
+  normalization_method: "none"
+
+handler_routing:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  routing_strategy: operation_match
+  handlers:
+    - routing_key: "classify"
+      handler_key: "HandlerPersonaClassify.classify"
+      priority: 0
+      output_events: []
+  default_handler: null
+
+tags:
+  - persona
+  - compute
+  - classification
+  - personalization
+  - phase-3

--- a/src/omnimemory/nodes/node_persona_builder_compute/handlers/__init__.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/handlers/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona builder compute handlers."""
+
+from .handler_persona_classify import classify_persona
+
+__all__ = [
+    "classify_persona",
+]

--- a/src/omnimemory/nodes/node_persona_builder_compute/handlers/handler_persona_classify.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/handlers/handler_persona_classify.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona classification handler — pure compute, no I/O.
+
+Takes a batch of PersonaSignal events and an optional existing PersonaProfile,
+produces an updated PersonaProfile using conservative update rules.
+
+CONSERVATISM RULES (prevent thrashing on weak evidence):
+- technical_level: requires 3+ sessions with consistent high-confidence (>0.7)
+  signals before changing level. One anomalous session does NOT shift the level.
+- vocabulary_complexity: exponential moving average with alpha=0.2 (slow drift)
+- preferred_tone: mode of last 10 signals. Allowed to shift faster.
+- domain_familiarity: increment per-repo familiarity by 0.1 per session in that repo.
+  This is FAMILIARITY (exposure), not expertise. Capped at 1.0.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
+from omnimemory.models.persona import ModelPersonaSignal, ModelUserPersonaV1
+
+from ..models import ModelPersonaClassifyRequest, ModelPersonaClassifyResult
+
+# Confidence threshold for signals to influence technical_level
+_TECH_LEVEL_CONFIDENCE_THRESHOLD = 0.7
+
+# Minimum sessions before technical_level can shift
+_TECH_LEVEL_MIN_SESSIONS = 3
+
+# EMA alpha for vocabulary_complexity
+_VOCAB_EMA_ALPHA = 0.2
+
+# Max signals to consider for tone mode
+_TONE_WINDOW_SIZE = 10
+
+# Per-session domain familiarity increment
+_DOMAIN_INCREMENT = 0.1
+
+# Domain familiarity cap
+_DOMAIN_CAP = 1.0
+
+
+def classify_persona(
+    request: ModelPersonaClassifyRequest,
+) -> ModelPersonaClassifyResult:
+    """Incrementally update persona profile from new signals.
+
+    Pure function — no I/O, no side effects.
+    """
+    signals = request.signals
+    existing = request.existing_profile
+
+    if not signals:
+        if existing is not None:
+            return ModelPersonaClassifyResult(
+                status="success",
+                persona=existing,
+                signals_processed=0,
+            )
+        return ModelPersonaClassifyResult(
+            status="insufficient_data",
+            signals_processed=0,
+        )
+
+    # Classify technical level
+    technical_level = _classify_technical_level(signals, existing)
+
+    # Classify vocabulary complexity
+    vocabulary = _classify_vocabulary(signals, existing)
+
+    # Classify preferred tone
+    tone = _classify_tone(signals)
+
+    # Update domain familiarity
+    domains = _classify_domains(signals, existing)
+
+    # Compute session count and version
+    session_count = (existing.session_count if existing else 0) + 1
+    persona_version = (existing.persona_version if existing else 0) + 1
+    now = datetime.now(tz=timezone.utc)
+
+    persona = ModelUserPersonaV1(
+        user_id=request.user_id,
+        agent_id=existing.agent_id if existing else None,
+        technical_level=technical_level,
+        vocabulary_complexity=vocabulary,
+        preferred_tone=tone,
+        domain_familiarity=domains,
+        session_count=session_count,
+        persona_version=persona_version,
+        created_at=now,
+        rebuilt_from_signals=len(signals),
+    )
+
+    return ModelPersonaClassifyResult(
+        status="success",
+        persona=persona,
+        signals_processed=len(signals),
+    )
+
+
+def _classify_technical_level(
+    signals: list[ModelPersonaSignal],
+    existing: ModelUserPersonaV1 | None,
+) -> EnumTechnicalLevel:
+    """Classify technical level with conservative update rules.
+
+    Requires 3+ sessions with consistent high-confidence signals
+    before changing level.
+    """
+    tech_signals = [
+        s
+        for s in signals
+        if s.signal_type == "technical_level"
+        and s.confidence >= _TECH_LEVEL_CONFIDENCE_THRESHOLD
+    ]
+
+    if not tech_signals:
+        return existing.technical_level if existing else EnumTechnicalLevel.INTERMEDIATE
+
+    # Count votes for each level
+    votes: Counter[str] = Counter()
+    for s in tech_signals:
+        votes[s.inferred_value] += 1
+
+    proposed_level_str = votes.most_common(1)[0][0]
+
+    # Map string to enum
+    level_map = {member.value: member for member in EnumTechnicalLevel}
+    proposed_level = level_map.get(proposed_level_str, EnumTechnicalLevel.INTERMEDIATE)
+
+    if existing is None:
+        return proposed_level
+
+    # Conservative: only shift if we have enough sessions
+    if existing.session_count < _TECH_LEVEL_MIN_SESSIONS:
+        return proposed_level
+
+    if proposed_level != existing.technical_level:
+        # Need strong consensus (majority of high-confidence signals agree)
+        total_high_conf = len(tech_signals)
+        proposed_count = votes[proposed_level_str]
+        if proposed_count >= total_high_conf * 0.6:
+            return proposed_level
+        return existing.technical_level
+
+    return proposed_level
+
+
+def _classify_vocabulary(
+    signals: list[ModelPersonaSignal],
+    existing: ModelUserPersonaV1 | None,
+) -> float:
+    """Classify vocabulary complexity using EMA."""
+    vocab_signals = [s for s in signals if s.signal_type == "vocabulary"]
+
+    if not vocab_signals:
+        return existing.vocabulary_complexity if existing else 0.5
+
+    current = existing.vocabulary_complexity if existing else 0.5
+
+    for s in vocab_signals:
+        try:
+            new_value = float(s.inferred_value)
+            new_value = max(0.0, min(1.0, new_value))
+            current = (_VOCAB_EMA_ALPHA * new_value) + (
+                (1 - _VOCAB_EMA_ALPHA) * current
+            )
+        except ValueError:
+            continue
+
+    return round(current, 3)
+
+
+def _classify_tone(signals: list[ModelPersonaSignal]) -> EnumPreferredTone:
+    """Classify preferred tone as mode of recent signals."""
+    tone_signals = [s for s in signals if s.signal_type == "preferred_tone"]
+
+    if not tone_signals:
+        return EnumPreferredTone.EXPLANATORY
+
+    # Take most recent N signals
+    recent = sorted(tone_signals, key=lambda s: s.emitted_at, reverse=True)[
+        :_TONE_WINDOW_SIZE
+    ]
+
+    votes: Counter[str] = Counter()
+    for s in recent:
+        votes[s.inferred_value] += 1
+
+    tone_str = votes.most_common(1)[0][0]
+
+    tone_map = {member.value: member for member in EnumPreferredTone}
+    return tone_map.get(tone_str, EnumPreferredTone.EXPLANATORY)
+
+
+def _classify_domains(
+    signals: list[ModelPersonaSignal],
+    existing: ModelUserPersonaV1 | None,
+) -> dict[str, float]:
+    """Update domain familiarity from signals."""
+    domains = dict(existing.domain_familiarity) if existing else {}
+
+    domain_signals = [s for s in signals if s.signal_type == "domain_familiarity"]
+
+    for s in domain_signals:
+        domain = s.inferred_value
+        current = domains.get(domain, 0.0)
+        domains[domain] = min(current + _DOMAIN_INCREMENT, _DOMAIN_CAP)
+
+    return domains

--- a/src/omnimemory/nodes/node_persona_builder_compute/models/__init__.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/models/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona builder compute node models."""
+
+from .model_classify_request import ModelPersonaClassifyRequest
+from .model_classify_result import ModelPersonaClassifyResult
+
+__all__ = [
+    "ModelPersonaClassifyRequest",
+    "ModelPersonaClassifyResult",
+]

--- a/src/omnimemory/nodes/node_persona_builder_compute/models/model_classify_request.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/models/model_classify_request.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Request model for persona classification."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.models.persona import ModelPersonaSignal, ModelUserPersonaV1
+
+
+class ModelPersonaClassifyRequest(BaseModel):
+    """Request to classify persona signals into an updated profile."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    user_id: str = Field(..., description="User identifier for the persona")
+    signals: list[ModelPersonaSignal] = Field(
+        ...,
+        description="Batch of persona signals to classify",
+    )
+    existing_profile: ModelUserPersonaV1 | None = Field(
+        default=None,
+        description="Previous persona snapshot for incremental update",
+    )

--- a/src/omnimemory/nodes/node_persona_builder_compute/models/model_classify_result.py
+++ b/src/omnimemory/nodes/node_persona_builder_compute/models/model_classify_result.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Result model for persona classification."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.models.persona import ModelUserPersonaV1
+
+
+class ModelPersonaClassifyResult(BaseModel):
+    """Result of persona classification."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["success", "error", "insufficient_data"] = Field(
+        ...,
+        description="Classification outcome",
+    )
+    persona: ModelUserPersonaV1 | None = Field(
+        default=None,
+        description="Updated persona snapshot (None on error/insufficient_data)",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error description when status is 'error'",
+    )
+    signals_processed: int = Field(
+        default=0,
+        ge=0,
+        description="Number of signals that contributed to this classification",
+    )

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/__init__.py
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona Lifecycle Orchestrator — tick-driven fan-out and on-demand rebuild."""
+
+from .models import ModelPersonaLifecycleRequest, ModelPersonaLifecycleResponse
+
+__all__ = [
+    "ModelPersonaLifecycleRequest",
+    "ModelPersonaLifecycleResponse",
+]

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/contract.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+name: "node_persona_lifecycle_orchestrator"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: >
+  Orchestrator node that coordinates persona snapshot builds. Handles tick-driven fan-out (up to 100 users
+  per tick) and on-demand single-user builds. Phase 3 Adaptive Personalization (OMN-7305).
+node_type: "ORCHESTRATOR"
+input_model: "ModelPersonaLifecycleRequest"
+output_model: "ModelPersonaLifecycleResponse"
+
+event_bus:
+  subscribe_topics:
+    - "onex.cmd.omnimemory.runtime-tick.v1"
+    - "onex.cmd.omnimemory.build-persona.v1"
+  publish_topics:
+    - "onex.evt.omnimemory.persona-snapshot-created.v1"
+
+handler_routing:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  routing_strategy: operation_match
+  handlers:
+    - routing_key: "on_tick"
+      handler_key: "HandlerPersonaRebuild.on_tick"
+      priority: 0
+      output_events:
+        - "onex.evt.omnimemory.persona-snapshot-created.v1"
+    - routing_key: "on_demand"
+      handler_key: "HandlerPersonaRebuild.on_demand"
+      priority: 0
+      output_events:
+        - "onex.evt.omnimemory.persona-snapshot-created.v1"
+  default_handler: null
+
+tags:
+  - persona
+  - orchestrator
+  - lifecycle
+  - phase-3

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/handlers/__init__.py
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/handlers/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona lifecycle orchestrator handlers."""

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/__init__.py
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona lifecycle orchestrator models."""
+
+from .model_persona_lifecycle_request import ModelPersonaLifecycleRequest
+from .model_persona_lifecycle_response import ModelPersonaLifecycleResponse
+
+__all__ = [
+    "ModelPersonaLifecycleRequest",
+    "ModelPersonaLifecycleResponse",
+]

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/model_persona_lifecycle_request.py
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/model_persona_lifecycle_request.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Request model for persona lifecycle orchestration."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPersonaLifecycleRequest(BaseModel):
+    """Request for persona lifecycle operations (tick or on-demand)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: Literal["on_tick", "on_demand"] = Field(
+        ...,
+        description="Tick-driven fan-out or single-user on-demand rebuild",
+    )
+    user_id: str | None = Field(
+        default=None,
+        description="User ID for on-demand rebuild (required when operation='on_demand')",
+    )

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/model_persona_lifecycle_response.py
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/models/model_persona_lifecycle_response.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Response model for persona lifecycle orchestration."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPersonaLifecycleResponse(BaseModel):
+    """Response from persona lifecycle orchestration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["success", "error"] = Field(
+        ...,
+        description="Orchestration outcome",
+    )
+    users_processed: int = Field(
+        default=0,
+        ge=0,
+        description="Number of users whose personas were rebuilt",
+    )
+    personas_created: int = Field(
+        default=0,
+        ge=0,
+        description="Number of new persona snapshots stored",
+    )
+    users_skipped: int = Field(
+        default=0,
+        ge=0,
+        description="Users skipped due to insufficient data",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error description when status is 'error'",
+    )

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/__init__.py
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona Retrieval Effect Node — read latest persona snapshot from Postgres."""
+
+from .models import ModelPersonaRetrievalRequest, ModelPersonaRetrievalResponse
+
+__all__ = [
+    "ModelPersonaRetrievalRequest",
+    "ModelPersonaRetrievalResponse",
+]

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/contract.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+name: "node_persona_retrieval_effect"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: >
+  Read-only EFFECT node that retrieves the latest PersonaSnapshot for a user_id/agent_id from Postgres.
+  No event bus (read-only). Phase 3 Adaptive Personalization (OMN-7305).
+node_type: "EFFECT"
+input_model: "ModelPersonaRetrievalRequest"
+output_model: "ModelPersonaRetrievalResponse"
+
+io_operations:
+  - operation_type: "database_read"
+    atomic: false
+    timeout_seconds: 5
+    validation_enabled: true
+
+tags:
+  - persona
+  - effect
+  - retrieval
+  - postgres
+  - phase-3

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/models/__init__.py
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/models/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona retrieval effect models."""
+
+from .model_persona_retrieval_request import ModelPersonaRetrievalRequest
+from .model_persona_retrieval_response import ModelPersonaRetrievalResponse
+
+__all__ = [
+    "ModelPersonaRetrievalRequest",
+    "ModelPersonaRetrievalResponse",
+]

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/models/model_persona_retrieval_request.py
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/models/model_persona_retrieval_request.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Request model for persona retrieval."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPersonaRetrievalRequest(BaseModel):
+    """Request to retrieve the latest persona snapshot for a user."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    user_id: str = Field(..., description="User identifier to retrieve persona for")
+    agent_id: str | None = Field(
+        default=None,
+        description="Optional agent binding filter",
+    )

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/models/model_persona_retrieval_response.py
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/models/model_persona_retrieval_response.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Response model for persona retrieval."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.models.persona import ModelUserPersonaV1
+
+
+class ModelPersonaRetrievalResponse(BaseModel):
+    """Response from persona retrieval."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["found", "not_found", "error"] = Field(
+        ...,
+        description="Retrieval outcome",
+    )
+    persona: ModelUserPersonaV1 | None = Field(
+        default=None,
+        description="Latest persona snapshot (None if not_found or error)",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error description when status is 'error'",
+    )

--- a/src/omnimemory/nodes/node_persona_storage_effect/__init__.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona Storage Effect Node — append-only persona snapshot persistence."""
+
+from .adapters import AdapterPostgresPersona
+from .models import ModelPersonaStorageRequest, ModelPersonaStorageResponse
+
+__all__ = [
+    "AdapterPostgresPersona",
+    "ModelPersonaStorageRequest",
+    "ModelPersonaStorageResponse",
+]

--- a/src/omnimemory/nodes/node_persona_storage_effect/adapters/__init__.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/adapters/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona storage adapters."""
+
+from .adapter_postgres_persona import AdapterPostgresPersona
+
+__all__ = [
+    "AdapterPostgresPersona",
+]

--- a/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
@@ -107,17 +107,24 @@ class AdapterPostgresPersona:
         if isinstance(domain_familiarity, str):
             domain_familiarity = json.loads(domain_familiarity)
 
+        # Row values come as object from the protocol; cast to expected types
+        session_count_val: int = int(str(row["session_count"]))
+        persona_version_val: int = int(str(row["persona_version"]))
+        rebuilt_from_signals_val: int = int(str(row["rebuilt_from_signals"]))
+        vocab_val: float = float(str(row["vocabulary_complexity"]))
+        created_at_val = row["created_at"]
+
         return ModelUserPersonaV1(
             user_id=str(row["user_id"]),
             agent_id=str(row["agent_id"]) if row.get("agent_id") else None,
             technical_level=str(row["technical_level"]),
-            vocabulary_complexity=float(row["vocabulary_complexity"]),  # type: ignore[arg-type]
+            vocabulary_complexity=vocab_val,
             preferred_tone=str(row["preferred_tone"]),
-            domain_familiarity=domain_familiarity,  # type: ignore[arg-type]
-            session_count=int(row["session_count"]),  # type: ignore[arg-type]
-            persona_version=int(row["persona_version"]),  # type: ignore[arg-type]
-            rebuilt_from_signals=int(row["rebuilt_from_signals"]),  # type: ignore[arg-type]
-            created_at=row["created_at"],  # type: ignore[arg-type]
+            domain_familiarity=domain_familiarity,
+            session_count=session_count_val,
+            persona_version=persona_version_val,
+            rebuilt_from_signals=rebuilt_from_signals_val,
+            created_at=created_at_val,
         )
 
     async def get_users_needing_rebuild(

--- a/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, cast
 from uuid import UUID
 
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
 from omnimemory.models.persona import ModelUserPersonaV1
 
 logger = logging.getLogger(__name__)
@@ -112,15 +113,15 @@ class AdapterPostgresPersona:
         persona_version_val: int = int(str(row["persona_version"]))
         rebuilt_from_signals_val: int = int(str(row["rebuilt_from_signals"]))
         vocab_val: float = float(str(row["vocabulary_complexity"]))
-        created_at_val = row["created_at"]
+        created_at_val = cast("datetime", row["created_at"])
 
         return ModelUserPersonaV1(
             user_id=str(row["user_id"]),
             agent_id=str(row["agent_id"]) if row.get("agent_id") else None,
-            technical_level=str(row["technical_level"]),
+            technical_level=EnumTechnicalLevel(str(row["technical_level"])),
             vocabulary_complexity=vocab_val,
-            preferred_tone=str(row["preferred_tone"]),
-            domain_familiarity=domain_familiarity,
+            preferred_tone=EnumPreferredTone(str(row["preferred_tone"])),
+            domain_familiarity=cast("dict[str, float]", domain_familiarity),
             session_count=session_count_val,
             persona_version=persona_version_val,
             rebuilt_from_signals=rebuilt_from_signals_val,

--- a/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/adapters/adapter_postgres_persona.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""PostgreSQL adapter for persona snapshot storage.
+
+Shared by both persona_storage_effect and persona_retrieval_effect nodes.
+Append-only: no updates or deletes. Duplicate (user_id, persona_version)
+inserts are caught and logged as INFO.
+
+Consent enforcement is deferred to Phase B (OMN-3980).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+from omnimemory.models.persona import ModelUserPersonaV1
+
+logger = logging.getLogger(__name__)
+
+
+class ProtocolAsyncConnection(Protocol):
+    """Minimal async DB connection protocol."""
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None: ...
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]: ...
+    async def execute(self, query: str, *args: object) -> str: ...
+
+
+class AdapterPostgresPersona:
+    """PostgreSQL adapter for persona snapshot CRUD.
+
+    Methods:
+        store: Insert a new persona snapshot (append-only, idempotent)
+        get_latest: Retrieve the latest snapshot for a user
+        get_users_needing_rebuild: Find users with stale personas
+    """
+
+    def __init__(self, conn: ProtocolAsyncConnection) -> None:
+        self._conn = conn
+
+    async def store(
+        self,
+        persona: ModelUserPersonaV1,
+        trigger_reason: str,
+        correlation_id: UUID,
+    ) -> bool:
+        """Store a persona snapshot. Returns True on new insert, False on duplicate.
+
+        Catches UniqueViolationError (23505) from asyncpg for idempotent
+        duplicate handling. Event should only be emitted when this returns True.
+        """
+        try:
+            await self._conn.execute(
+                """
+                INSERT INTO user_persona_snapshots (
+                    user_id, agent_id, technical_level, vocabulary_complexity,
+                    preferred_tone, domain_familiarity, session_count,
+                    persona_version, rebuilt_from_signals, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                """,
+                persona.user_id,
+                persona.agent_id,
+                persona.technical_level.value,
+                persona.vocabulary_complexity,
+                persona.preferred_tone.value,
+                json.dumps(persona.domain_familiarity),
+                persona.session_count,
+                persona.persona_version,
+                persona.rebuilt_from_signals,
+                persona.created_at,
+            )
+            return True
+        except Exception as e:
+            # asyncpg.UniqueViolationError has pgcode "23505"
+            if hasattr(e, "sqlstate") and e.sqlstate == "23505":
+                logger.info(
+                    "Persona snapshot already exists for user=%s version=%d, skipping",
+                    persona.user_id,
+                    persona.persona_version,
+                )
+                return False
+            raise
+
+    async def get_latest(self, user_id: str) -> ModelUserPersonaV1 | None:
+        """Retrieve the latest persona snapshot for a user."""
+        row = await self._conn.fetchrow(
+            """
+            SELECT user_id, agent_id, technical_level, vocabulary_complexity,
+                   preferred_tone, domain_familiarity, session_count,
+                   persona_version, rebuilt_from_signals, created_at
+            FROM user_persona_snapshots
+            WHERE user_id = $1
+            ORDER BY persona_version DESC
+            LIMIT 1
+            """,
+            user_id,
+        )
+        if row is None:
+            return None
+
+        domain_familiarity = row["domain_familiarity"]
+        if isinstance(domain_familiarity, str):
+            domain_familiarity = json.loads(domain_familiarity)
+
+        return ModelUserPersonaV1(
+            user_id=str(row["user_id"]),
+            agent_id=str(row["agent_id"]) if row.get("agent_id") else None,
+            technical_level=str(row["technical_level"]),
+            vocabulary_complexity=float(row["vocabulary_complexity"]),  # type: ignore[arg-type]
+            preferred_tone=str(row["preferred_tone"]),
+            domain_familiarity=domain_familiarity,  # type: ignore[arg-type]
+            session_count=int(row["session_count"]),  # type: ignore[arg-type]
+            persona_version=int(row["persona_version"]),  # type: ignore[arg-type]
+            rebuilt_from_signals=int(row["rebuilt_from_signals"]),  # type: ignore[arg-type]
+            created_at=row["created_at"],  # type: ignore[arg-type]
+        )
+
+    async def get_users_needing_rebuild(
+        self,
+        since: datetime | None = None,
+    ) -> list[str]:
+        """Return up to 100 user_ids with memory items newer than their latest persona.
+
+        If since is None, returns all users with at least one persona snapshot.
+        """
+        if since is not None:
+            rows = await self._conn.fetch(
+                """
+                SELECT DISTINCT user_id
+                FROM user_persona_snapshots
+                WHERE created_at < $1
+                ORDER BY user_id
+                LIMIT 100
+                """,
+                since,
+            )
+        else:
+            rows = await self._conn.fetch(
+                """
+                SELECT DISTINCT user_id
+                FROM user_persona_snapshots
+                ORDER BY user_id
+                LIMIT 100
+                """,
+            )
+        return [str(row["user_id"]) for row in rows]

--- a/src/omnimemory/nodes/node_persona_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_storage_effect/contract.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+
+name: "node_persona_storage_effect"
+contract_version: {major: 0, minor: 1, patch: 0}
+node_version: {major: 0, minor: 1, patch: 0}
+description: >
+  EFFECT node that writes PersonaSnapshot to Postgres (append-only). Emits persona-snapshot-created event
+  on successful new insert. Idempotent: duplicate (user_id, persona_version) is caught and logged. Phase
+  3 Adaptive Personalization (OMN-7305).
+node_type: "EFFECT"
+input_model: "ModelPersonaStorageRequest"
+output_model: "ModelPersonaStorageResponse"
+
+io_operations:
+  - operation_type: "database_write"
+    atomic: true
+    timeout_seconds: 10
+    validation_enabled: true
+
+event_bus:
+  publish_topics:
+    - "onex.evt.omnimemory.persona-snapshot-created.v1"
+
+tags:
+  - persona
+  - effect
+  - storage
+  - postgres
+  - phase-3

--- a/src/omnimemory/nodes/node_persona_storage_effect/models/__init__.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/models/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Persona storage effect models."""
+
+from .model_persona_storage_request import ModelPersonaStorageRequest
+from .model_persona_storage_response import ModelPersonaStorageResponse
+
+__all__ = [
+    "ModelPersonaStorageRequest",
+    "ModelPersonaStorageResponse",
+]

--- a/src/omnimemory/nodes/node_persona_storage_effect/models/model_persona_storage_request.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/models/model_persona_storage_request.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Request model for persona storage operations."""
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnimemory.models.persona import ModelUserPersonaV1
+
+
+class ModelPersonaStorageRequest(BaseModel):
+    """Request to store a persona snapshot."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: Literal["store"] = Field(
+        default="store",
+        description="Storage operation (currently only 'store')",
+    )
+    persona: ModelUserPersonaV1 = Field(
+        ...,
+        description="Persona snapshot to persist",
+    )
+    trigger_reason: Literal["tick", "on_demand"] = Field(
+        ...,
+        description="What triggered this storage operation",
+    )
+    correlation_id: UUID = Field(
+        ...,
+        description="Correlation ID for tracing",
+    )

--- a/src/omnimemory/nodes/node_persona_storage_effect/models/model_persona_storage_response.py
+++ b/src/omnimemory/nodes/node_persona_storage_effect/models/model_persona_storage_response.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Response model for persona storage operations."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelPersonaStorageResponse(BaseModel):
+    """Response from persona storage operation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: Literal["success", "duplicate", "error"] = Field(
+        ...,
+        description="Operation outcome",
+    )
+    is_new_insert: bool = Field(
+        default=False,
+        description="True if a new row was inserted (vs duplicate skip)",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error description when status is 'error'",
+    )

--- a/tests/unit/nodes/test_persona_builder.py
+++ b/tests/unit/nodes/test_persona_builder.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for persona builder compute node classification logic."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
+from omnimemory.models.persona import ModelPersonaSignal, ModelUserPersonaV1
+from omnimemory.nodes.node_persona_builder_compute import (
+    ModelPersonaClassifyRequest,
+    classify_persona,
+)
+
+
+def _signal(
+    signal_type: str,
+    inferred_value: str,
+    confidence: float = 0.85,
+    user_id: str = "test-user",
+    session_id: str = "sess-001",
+) -> ModelPersonaSignal:
+    """Helper to create a persona signal."""
+    return ModelPersonaSignal(
+        user_id=user_id,
+        session_id=session_id,
+        signal_type=signal_type,
+        evidence=f"Test evidence for {signal_type}={inferred_value}",
+        inferred_value=inferred_value,
+        confidence=confidence,
+        emitted_at=datetime.now(tz=timezone.utc),
+    )
+
+
+def _existing_profile(
+    technical_level: EnumTechnicalLevel = EnumTechnicalLevel.INTERMEDIATE,
+    session_count: int = 5,
+    persona_version: int = 1,
+) -> ModelUserPersonaV1:
+    """Helper to create an existing persona."""
+    return ModelUserPersonaV1(
+        user_id="test-user",
+        technical_level=technical_level,
+        session_count=session_count,
+        persona_version=persona_version,
+        created_at=datetime.now(tz=timezone.utc),
+    )
+
+
+@pytest.mark.unit
+class TestClassifyPersona:
+    def test_beginner_from_signals(self) -> None:
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("technical_level", "beginner", confidence=0.85),
+                _signal("preferred_tone", "explanatory", confidence=0.78),
+            ],
+        )
+        result = classify_persona(request)
+        assert result.status == "success"
+        assert result.persona is not None
+        assert result.persona.technical_level == EnumTechnicalLevel.BEGINNER
+        assert result.persona.preferred_tone == EnumPreferredTone.EXPLANATORY
+
+    def test_expert_from_signals(self) -> None:
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("technical_level", "expert", confidence=0.92),
+                _signal("preferred_tone", "concise", confidence=0.88),
+            ],
+        )
+        result = classify_persona(request)
+        assert result.status == "success"
+        assert result.persona is not None
+        assert result.persona.technical_level == EnumTechnicalLevel.EXPERT
+        assert result.persona.preferred_tone == EnumPreferredTone.CONCISE
+
+    def test_insufficient_data_no_signals(self) -> None:
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[],
+        )
+        result = classify_persona(request)
+        assert result.status == "insufficient_data"
+        assert result.persona is None
+
+    def test_no_signals_with_existing_returns_existing(self) -> None:
+        existing = _existing_profile()
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[],
+            existing_profile=existing,
+        )
+        result = classify_persona(request)
+        assert result.status == "success"
+        assert result.persona == existing
+
+    def test_vocabulary_ema_slow_drift(self) -> None:
+        existing = _existing_profile()
+        assert existing.vocabulary_complexity == 0.5
+
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[_signal("vocabulary", "0.9", confidence=0.8)],
+            existing_profile=existing,
+        )
+        result = classify_persona(request)
+        assert result.status == "success"
+        assert result.persona is not None
+        # EMA: 0.2 * 0.9 + 0.8 * 0.5 = 0.58
+        assert abs(result.persona.vocabulary_complexity - 0.58) < 0.01
+
+    def test_domain_familiarity_increments(self) -> None:
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("domain_familiarity", "omnimemory"),
+                _signal("domain_familiarity", "omnimemory"),
+                _signal("domain_familiarity", "omniclaude"),
+            ],
+        )
+        result = classify_persona(request)
+        assert result.status == "success"
+        assert result.persona is not None
+        assert result.persona.domain_familiarity["omnimemory"] == pytest.approx(0.2)
+        assert result.persona.domain_familiarity["omniclaude"] == pytest.approx(0.1)
+
+    def test_domain_familiarity_caps_at_one(self) -> None:
+        # Create profile with domain already at 0.95
+        existing_with_domain = ModelUserPersonaV1(
+            user_id="test-user",
+            domain_familiarity={"omnimemory": 0.95},
+            session_count=5,
+            persona_version=1,
+            created_at=datetime.now(tz=timezone.utc),
+        )
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[_signal("domain_familiarity", "omnimemory")],
+            existing_profile=existing_with_domain,
+        )
+        result = classify_persona(request)
+        assert result.persona is not None
+        assert result.persona.domain_familiarity["omnimemory"] == 1.0
+
+    def test_technical_level_conservative_with_existing(self) -> None:
+        """Technical level should not shift on low-confidence signals."""
+        existing = _existing_profile(
+            technical_level=EnumTechnicalLevel.INTERMEDIATE,
+            session_count=5,
+        )
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("technical_level", "expert", confidence=0.5),  # Below threshold
+            ],
+            existing_profile=existing,
+        )
+        result = classify_persona(request)
+        assert result.persona is not None
+        # Low confidence signal should not shift level
+        assert result.persona.technical_level == EnumTechnicalLevel.INTERMEDIATE
+
+    def test_tone_mode_selection(self) -> None:
+        """Tone should be the mode of recent signals."""
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("preferred_tone", "concise"),
+                _signal("preferred_tone", "concise"),
+                _signal("preferred_tone", "explanatory"),
+            ],
+        )
+        result = classify_persona(request)
+        assert result.persona is not None
+        assert result.persona.preferred_tone == EnumPreferredTone.CONCISE
+
+    def test_session_count_increments(self) -> None:
+        existing = _existing_profile(session_count=5)
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[_signal("technical_level", "intermediate")],
+            existing_profile=existing,
+        )
+        result = classify_persona(request)
+        assert result.persona is not None
+        assert result.persona.session_count == 6
+
+    def test_persona_version_increments(self) -> None:
+        existing = _existing_profile(persona_version=3)
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[_signal("technical_level", "intermediate")],
+            existing_profile=existing,
+        )
+        result = classify_persona(request)
+        assert result.persona is not None
+        assert result.persona.persona_version == 4
+
+    def test_signals_processed_count(self) -> None:
+        request = ModelPersonaClassifyRequest(
+            user_id="test-user",
+            signals=[
+                _signal("technical_level", "beginner"),
+                _signal("vocabulary", "0.3"),
+                _signal("preferred_tone", "explanatory"),
+            ],
+        )
+        result = classify_persona(request)
+        assert result.signals_processed == 3

--- a/tests/unit/nodes/test_persona_storage_retrieval.py
+++ b/tests/unit/nodes/test_persona_storage_retrieval.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for persona storage/retrieval effect nodes and adapter."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
+from omnimemory.models.persona import ModelUserPersonaV1
+from omnimemory.nodes.node_persona_retrieval_effect import (
+    ModelPersonaRetrievalRequest,
+    ModelPersonaRetrievalResponse,
+)
+from omnimemory.nodes.node_persona_storage_effect import (
+    AdapterPostgresPersona,
+    ModelPersonaStorageRequest,
+    ModelPersonaStorageResponse,
+)
+
+
+def _make_persona(
+    user_id: str = "test-user",
+    version: int = 1,
+) -> ModelUserPersonaV1:
+    return ModelUserPersonaV1(
+        user_id=user_id,
+        technical_level=EnumTechnicalLevel.INTERMEDIATE,
+        vocabulary_complexity=0.5,
+        preferred_tone=EnumPreferredTone.EXPLANATORY,
+        domain_familiarity={"omnimemory": 0.3},
+        session_count=5,
+        persona_version=version,
+        created_at=datetime.now(tz=timezone.utc),
+        rebuilt_from_signals=10,
+    )
+
+
+@pytest.mark.unit
+class TestAdapterPostgresPersonaStore:
+    @pytest.mark.asyncio
+    async def test_store_returns_true_on_new_insert(self) -> None:
+        conn = AsyncMock()
+        conn.execute = AsyncMock(return_value="INSERT 0 1")
+        adapter = AdapterPostgresPersona(conn)
+        persona = _make_persona()
+        result = await adapter.store(persona, "tick", uuid4())
+        assert result is True
+        conn.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_store_returns_false_on_duplicate(self) -> None:
+        conn = AsyncMock()
+        # Simulate asyncpg UniqueViolationError (sqlstate 23505)
+        exc = Exception("duplicate key")
+        exc.sqlstate = "23505"  # type: ignore[attr-defined]
+        conn.execute = AsyncMock(side_effect=exc)
+        adapter = AdapterPostgresPersona(conn)
+        persona = _make_persona()
+        result = await adapter.store(persona, "tick", uuid4())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_store_raises_on_other_error(self) -> None:
+        conn = AsyncMock()
+        conn.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+        adapter = AdapterPostgresPersona(conn)
+        persona = _make_persona()
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await adapter.store(persona, "tick", uuid4())
+
+
+@pytest.mark.unit
+class TestAdapterPostgresPersonaRetrieve:
+    @pytest.mark.asyncio
+    async def test_get_latest_returns_none_when_no_rows(self) -> None:
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value=None)
+        adapter = AdapterPostgresPersona(conn)
+        result = await adapter.get_latest("nonexistent-user")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_latest_returns_persona(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "user_id": "test-user",
+                "agent_id": None,
+                "technical_level": "expert",
+                "vocabulary_complexity": 0.8,
+                "preferred_tone": "concise",
+                "domain_familiarity": '{"omnimemory": 0.5}',
+                "session_count": 10,
+                "persona_version": 3,
+                "rebuilt_from_signals": 25,
+                "created_at": now,
+            }
+        )
+        adapter = AdapterPostgresPersona(conn)
+        result = await adapter.get_latest("test-user")
+        assert result is not None
+        assert result.technical_level == EnumTechnicalLevel.EXPERT
+        assert result.persona_version == 3
+
+    @pytest.mark.asyncio
+    async def test_get_users_needing_rebuild_limits_to_100(self) -> None:
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(
+            return_value=[{"user_id": f"user-{i}"} for i in range(100)]
+        )
+        adapter = AdapterPostgresPersona(conn)
+        result = await adapter.get_users_needing_rebuild(since=None)
+        assert len(result) == 100
+
+
+@pytest.mark.unit
+class TestPersonaStorageModels:
+    def test_storage_request_creation(self) -> None:
+        persona = _make_persona()
+        request = ModelPersonaStorageRequest(
+            persona=persona,
+            trigger_reason="tick",
+            correlation_id=uuid4(),
+        )
+        assert request.operation == "store"
+        assert request.persona == persona
+
+    def test_storage_response_success(self) -> None:
+        response = ModelPersonaStorageResponse(
+            status="success",
+            is_new_insert=True,
+        )
+        assert response.is_new_insert is True
+
+    def test_storage_response_duplicate(self) -> None:
+        response = ModelPersonaStorageResponse(
+            status="duplicate",
+            is_new_insert=False,
+        )
+        assert response.is_new_insert is False
+
+
+@pytest.mark.unit
+class TestPersonaRetrievalModels:
+    def test_retrieval_request_creation(self) -> None:
+        request = ModelPersonaRetrievalRequest(user_id="test-user")
+        assert request.user_id == "test-user"
+        assert request.agent_id is None
+
+    def test_retrieval_response_found(self) -> None:
+        persona = _make_persona()
+        response = ModelPersonaRetrievalResponse(
+            status="found",
+            persona=persona,
+        )
+        assert response.persona is not None
+
+    def test_retrieval_response_not_found(self) -> None:
+        response = ModelPersonaRetrievalResponse(status="not_found")
+        assert response.persona is None

--- a/tests/unit/test_model_user_persona_v1.py
+++ b/tests/unit/test_model_user_persona_v1.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ModelUserPersonaV1 and ModelPersonaSignal."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnimemory.enums import EnumPreferredTone, EnumTechnicalLevel
+from omnimemory.models.persona import ModelPersonaSignal, ModelUserPersonaV1
+
+
+@pytest.mark.unit
+class TestModelUserPersonaV1:
+    def test_create_with_defaults(self) -> None:
+        persona = ModelUserPersonaV1(
+            user_id="test-user",
+            created_at=datetime.now(tz=timezone.utc),
+        )
+        assert persona.technical_level == EnumTechnicalLevel.INTERMEDIATE
+        assert persona.vocabulary_complexity == 0.5
+        assert persona.preferred_tone == EnumPreferredTone.EXPLANATORY
+        assert persona.domain_familiarity == {}
+        assert persona.session_count == 0
+        assert persona.persona_version == 1
+        assert persona.rebuilt_from_signals == 0
+        assert persona.agent_id is None
+
+    def test_create_with_all_fields(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        persona = ModelUserPersonaV1(
+            user_id="test-user",
+            agent_id="caia-001",
+            technical_level=EnumTechnicalLevel.EXPERT,
+            vocabulary_complexity=0.9,
+            preferred_tone=EnumPreferredTone.CONCISE,
+            domain_familiarity={"omnimemory": 0.8, "omniclaude": 0.6},
+            session_count=25,
+            persona_version=3,
+            created_at=now,
+            rebuilt_from_signals=42,
+        )
+        assert persona.technical_level == EnumTechnicalLevel.EXPERT
+        assert persona.vocabulary_complexity == 0.9
+        assert persona.domain_familiarity["omnimemory"] == 0.8
+        assert persona.session_count == 25
+
+    def test_frozen_immutability(self) -> None:
+        persona = ModelUserPersonaV1(
+            user_id="test-user",
+            created_at=datetime.now(tz=timezone.utc),
+        )
+        with pytest.raises(ValidationError):
+            persona.technical_level = EnumTechnicalLevel.EXPERT  # type: ignore[misc]
+
+    def test_persona_version_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelUserPersonaV1(
+                user_id="test-user",
+                persona_version=0,
+                created_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_vocabulary_complexity_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelUserPersonaV1(
+                user_id="test-user",
+                vocabulary_complexity=1.5,
+                created_at=datetime.now(tz=timezone.utc),
+            )
+        with pytest.raises(ValidationError):
+            ModelUserPersonaV1(
+                user_id="test-user",
+                vocabulary_complexity=-0.1,
+                created_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelUserPersonaV1(
+                user_id="test-user",
+                created_at=datetime.now(tz=timezone.utc),
+                unknown_field="bad",  # type: ignore[call-arg]
+            )
+
+    def test_serialization_round_trip(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        persona = ModelUserPersonaV1(
+            user_id="test-user",
+            agent_id="caia-001",
+            technical_level=EnumTechnicalLevel.ADVANCED,
+            vocabulary_complexity=0.7,
+            preferred_tone=EnumPreferredTone.FORMAL,
+            domain_familiarity={"omnibase_core": 0.5},
+            session_count=10,
+            persona_version=2,
+            created_at=now,
+            rebuilt_from_signals=15,
+        )
+        data = persona.model_dump()
+        restored = ModelUserPersonaV1.model_validate(data)
+        assert restored == persona
+
+
+@pytest.mark.unit
+class TestModelPersonaSignal:
+    def test_create_signal(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        signal = ModelPersonaSignal(
+            user_id="test-user",
+            session_id="sess-001",
+            signal_type="technical_level",
+            evidence="Used terms: contract.yaml, handler pattern",
+            inferred_value="expert",
+            confidence=0.92,
+            emitted_at=now,
+        )
+        assert signal.user_id == "test-user"
+        assert signal.signal_type == "technical_level"
+        assert signal.confidence == 0.92
+        assert signal.signal_id is not None
+
+    def test_frozen_immutability(self) -> None:
+        signal = ModelPersonaSignal(
+            user_id="test-user",
+            session_id="sess-001",
+            signal_type="tone",
+            evidence="Short imperative prompts",
+            inferred_value="concise",
+            confidence=0.8,
+            emitted_at=datetime.now(tz=timezone.utc),
+        )
+        with pytest.raises(ValidationError):
+            signal.confidence = 0.5  # type: ignore[misc]
+
+    def test_confidence_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPersonaSignal(
+                user_id="test-user",
+                session_id="sess-001",
+                signal_type="tone",
+                evidence="test",
+                inferred_value="concise",
+                confidence=1.5,
+                emitted_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_evidence_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelPersonaSignal(
+                user_id="test-user",
+                session_id="sess-001",
+                signal_type="tone",
+                evidence="x" * 501,
+                inferred_value="concise",
+                confidence=0.5,
+                emitted_at=datetime.now(tz=timezone.utc),
+            )
+
+    def test_custom_signal_id(self) -> None:
+        custom_id = uuid4()
+        signal = ModelPersonaSignal(
+            signal_id=custom_id,
+            user_id="test-user",
+            session_id="sess-001",
+            signal_type="vocabulary",
+            evidence="High jargon density",
+            inferred_value="0.85",
+            confidence=0.7,
+            emitted_at=datetime.now(tz=timezone.utc),
+        )
+        assert signal.signal_id == custom_id
+
+    def test_serialization_round_trip(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        signal = ModelPersonaSignal(
+            user_id="test-user",
+            session_id="sess-001",
+            signal_type="technical_level",
+            evidence="Asked 'what does frozen=True mean?'",
+            inferred_value="beginner",
+            confidence=0.85,
+            emitted_at=now,
+        )
+        data = signal.model_dump()
+        restored = ModelPersonaSignal.model_validate(data)
+        assert restored == signal

--- a/tests/unit/test_persona_enums.py
+++ b/tests/unit/test_persona_enums.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for persona classification enums."""
+
+import pytest
+
+from omnimemory.enums import EnumMemoryType, EnumPreferredTone, EnumTechnicalLevel
+
+
+@pytest.mark.unit
+class TestEnumMemoryType:
+    def test_member_count(self) -> None:
+        assert len(EnumMemoryType) == 4
+
+    def test_string_values(self) -> None:
+        assert EnumMemoryType.FACTUAL == "factual"
+        assert EnumMemoryType.PREFERENCE == "preference"
+        assert EnumMemoryType.SENSITIVE == "sensitive"
+        assert EnumMemoryType.EPHEMERAL == "ephemeral"
+
+    def test_str_subclass(self) -> None:
+        assert isinstance(EnumMemoryType.FACTUAL, str)
+
+
+@pytest.mark.unit
+class TestEnumTechnicalLevel:
+    def test_member_count(self) -> None:
+        assert len(EnumTechnicalLevel) == 4
+
+    def test_string_values(self) -> None:
+        assert EnumTechnicalLevel.BEGINNER == "beginner"
+        assert EnumTechnicalLevel.INTERMEDIATE == "intermediate"
+        assert EnumTechnicalLevel.ADVANCED == "advanced"
+        assert EnumTechnicalLevel.EXPERT == "expert"
+
+    def test_str_subclass(self) -> None:
+        assert isinstance(EnumTechnicalLevel.BEGINNER, str)
+
+    def test_ordering_is_progressive(self) -> None:
+        levels = list(EnumTechnicalLevel)
+        assert levels == [
+            EnumTechnicalLevel.BEGINNER,
+            EnumTechnicalLevel.INTERMEDIATE,
+            EnumTechnicalLevel.ADVANCED,
+            EnumTechnicalLevel.EXPERT,
+        ]
+
+
+@pytest.mark.unit
+class TestEnumPreferredTone:
+    def test_member_count(self) -> None:
+        assert len(EnumPreferredTone) == 4
+
+    def test_string_values(self) -> None:
+        assert EnumPreferredTone.EXPLANATORY == "explanatory"
+        assert EnumPreferredTone.CONCISE == "concise"
+        assert EnumPreferredTone.FORMAL == "formal"
+        assert EnumPreferredTone.CASUAL == "casual"
+
+    def test_str_subclass(self) -> None:
+        assert isinstance(EnumPreferredTone.EXPLANATORY, str)


### PR DESCRIPTION
## Summary
- Adds EnumMemoryType, EnumTechnicalLevel, EnumPreferredTone persona classification enums
- Adds ModelUserPersonaV1 (frozen persona snapshot) and ModelPersonaSignal (behavioral observation)
- 23 unit tests covering validation, immutability, serialization round-trips

## Context
Wave 1 (Sub-Phase 3A) of Phase 3: Adaptive Personalization (OMN-7305).

## Test plan
- [x] `uv run pytest tests/unit/test_persona_enums.py tests/unit/test_model_user_persona_v1.py -v` — 23/23 pass
- [x] Pre-commit hooks pass (ruff format, ruff check, mypy strict, pyright)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Persona classification system that analyzes user behavior patterns to infer technical expertise level, communication style preferences, and vocabulary complexity.
  * Persistent persona snapshots with database storage and retrieval for tracking user profiles over time.
  * Automated persona lifecycle management supporting scheduled and on-demand profile updates.
  * Memory categorization system for organizing observed user behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->