### PR TITLE
fix: pre-commit sweep — broken CHANGELOG link [OMN-7408]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.15.0 (2026-04-03)
 
 ### Features
-- feat(persona): add persona enums, models, and signal types [OMN-3967][OMN-3969] (#231)
+- feat(persona): add persona enums, models, and signal types OMN-3967, OMN-3969 (#231)
 - feat(node): add agent learning retrieval effect node with contract and models [OMN-7245] (#230)
 - feat(handler): add agent learning retrieval query-building and ranking helpers [OMN-7246] (#229)
 - feat: replace hardcoded MEMORY_NODES with contract-driven discovery [OMN-7154] (#226)


### PR DESCRIPTION
## Summary
- Fix broken markdown reference-style link `[OMN-3967][OMN-3969]` in CHANGELOG.md
- Convert to plain text ticket references `OMN-3967, OMN-3969` (no link definition existed for OMN-3969)

## Test plan
- [x] `pre-commit run onex-validate-links --all-files` passes
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entry formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->