### PR TITLE
refactor: remove event_bus_enabled from contracts and discovery [OMN-7658]

### DIFF
--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
@@ -123,7 +123,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   subscribe_topics:
     - "onex.cmd.omnimemory.agent-learning-retrieval-requested.v1"

--- a/src/omnimemory/nodes/node_filesystem_crawler_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_filesystem_crawler_effect/contract.yaml
@@ -83,7 +83,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to (receives crawl tick commands)
   subscribe_topics:

--- a/src/omnimemory/nodes/node_intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_event_consumer_effect/contract.yaml
@@ -107,7 +107,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to (receives events from)
   subscribe_topics:

--- a/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
@@ -197,7 +197,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to (receives events from)
   subscribe_topics:

--- a/src/omnimemory/nodes/node_intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_storage_effect/contract.yaml
@@ -183,7 +183,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # This node does not subscribe to topics (orchestrator-invoked)
   subscribe_topics: []

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
@@ -81,7 +81,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to
   subscribe_topics:

--- a/src/omnimemory/nodes/node_memory_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_lifecycle_orchestrator/contract.yaml
@@ -193,7 +193,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to (receives events from)
   subscribe_topics:

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
@@ -201,7 +201,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # Topics this node subscribes to (receives events from)
   subscribe_topics:

--- a/src/omnimemory/nodes/node_memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_storage_effect/contract.yaml
@@ -199,7 +199,6 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
-  event_bus_enabled: true
 
   # This node does not subscribe to topics (orchestrator-invoked)
   subscribe_topics: []

--- a/src/omnimemory/runtime/contract_topics.py
+++ b/src/omnimemory/runtime/contract_topics.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 # Node packages that declare event_bus topics
 # ============================================================================
-# All omnimemory nodes with ``event_bus.event_bus_enabled: true`` in their
+# All omnimemory nodes with ``event_bus.subscribe_topics`` in their
 # contract.yaml. Both effect nodes and orchestrator nodes are included since
 # the memory_lifecycle_orchestrator also subscribes to Kafka topics.
 
@@ -291,7 +291,7 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
         field: Topic field name (``"subscribe_topics"`` or ``"publish_topics"``).
 
     Returns:
-        List of topic strings (empty if event bus is disabled or field absent).
+        List of topic strings (empty if field absent).
     """
     package_files = importlib.resources.files(package)
     contract_file = package_files.joinpath("contract.yaml")
@@ -313,9 +313,6 @@ def _read_event_bus_topics(package: str, field: str) -> list[str]:
             package,
             type(event_bus).__name__,
         )
-        return []
-
-    if not event_bus.get("event_bus_enabled", False):
         return []
 
     topics_raw: object = event_bus.get(field, [])


### PR DESCRIPTION
## Summary
- Remove `event_bus_enabled` from all 9 `contract.yaml` files
- Remove `event_bus_enabled` gate from `contract_topics._read_event_bus_topics()`
- Update comments referencing the flag

## Context
Part of cross-repo OMN-7658. The `event_bus_enabled` flag is redundant — presence of `subscribe_topics` is sufficient for wiring eligibility.

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined event bus configuration across multiple core system nodes by removing explicit enablement flags.
  * Refactored topic discovery logic to no longer require explicit enablement settings, allowing event bus functionality to activate through default behavior while preserving all topic routing, subscriptions, and metadata configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->