### PR TITLE
fix(ci): re-trigger auto-merge after review and checks complete [OMN-7786]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,11 +4,26 @@
 # OMN-6571: Automatically enable auto-merge (squash) on every PR opened
 # by jonahgabriel. Ensures PRs do not sit idle in the merge queue waiting
 # for manual enrollment.
+#
+# OMN-7786: Re-trigger on review and check_suite events so the workflow
+# re-attempts auto-merge after CodeRabbit review finishes and branch
+# protection gates clear. Silent continue-on-error removed; "already
+# enqueued" races are tolerated but real failures surface.
 name: Auto-Merge
 
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to enable auto-merge on"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,13 +33,63 @@ jobs:
   auto-merge:
     name: Enable Auto-Merge
     runs-on: ubuntu-latest
-    if: github.actor == 'jonahgabriel'
     steps:
-      # continue-on-error: merge queue re-triggers this workflow, and
-      # gh pr merge fails with "already enqueued" — that is expected.
-      - name: Enable auto-merge (squash)
-        continue-on-error: true
-        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash
+      - name: Resolve PR and author
+        id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_FROM_PAYLOAD: ${{ github.event.pull_request.number }}
+          PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
+          CHECK_SUITE_PRS: ${{ toJson(github.event.check_suite.pull_requests) }}
+          PR_AUTHOR_FROM_PAYLOAD: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request|pull_request_review)
+              PR="$PR_FROM_PAYLOAD"
+              ACTOR="$PR_AUTHOR_FROM_PAYLOAD"
+              ;;
+            workflow_dispatch)
+              PR="$PR_FROM_DISPATCH"
+              ACTOR="$(gh pr view "$PR" --json author --jq '.author.login')"
+              ;;
+            check_suite)
+              PR="$(echo "$CHECK_SUITE_PRS" | jq -r 'if type == "array" and length > 0 then .[0].number else empty end')"
+              if [ -z "$PR" ]; then
+                echo "check_suite had no associated PRs; nothing to do"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ACTOR="$(gh pr view "$PR" --json author --jq '.author.login')"
+              ;;
+            *)
+              echo "unsupported event: $EVENT_NAME"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
+      - name: Enable auto-merge (squash)
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          # "already enqueued" / "clean" race is benign — treat as success.
+          # All other failures surface loudly (no silent continue-on-error).
+          if output=$(gh pr merge "$PR" --auto --squash 2>&1); then
+            echo "auto-merge enabled: $output"
+            exit 0
+          fi
+          if echo "$output" | grep -qiE "already|enqueued|clean|cannot be merged"; then
+            echo "auto-merge not newly enabled (expected): $output"
+            exit 0
+          fi
+          echo "auto-merge failed: $output"
+          exit 1


### PR DESCRIPTION
## Summary

- Add `pull_request_review` and `check_suite` triggers so auto-merge re-attempts after CodeRabbit review and CI completion, closing the race where the workflow fires once at PR open before branch protection gates clear.
- Resolve PR number and author per event type; gate enablement on PR author login (event.actor reflects the event trigger, not the PR author).
- Remove silent `continue-on-error`; tolerate benign "already enqueued"/"clean" races via grep while surfacing real failures.
- Add `workflow_dispatch` for manual recovery.

## Why

merge-sweep Track A has been re-enabling auto-merge by hand on every PR because the original workflow fired once at PR creation, silently failed when CodeRabbit hadn't reviewed yet, and never re-attempted.

Related: OMN-6571, OMN-5134

## Test plan

- [ ] Workflow YAML parses (verified locally)
- [ ] Next PR in this repo gets auto-merge enabled without merge-sweep intervention