### PR TITLE
ci(auto-merge): add --repo flag to gh pr merge workflow (OMN-8509)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -78,12 +78,13 @@ jobs:
         if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR: ${{ steps.resolve.outputs.pr }}
         run: |
           set -euo pipefail
           # "already enqueued" / "clean" race is benign — treat as success.
           # All other failures surface loudly (no silent continue-on-error).
-          if output=$(gh pr merge "$PR" --auto --squash 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Fixes the Enable Auto-Merge workflow which calls `gh pr merge` without `--repo`, causing failures with "not a git repository" when running in a job without `actions/checkout`.

## Change

- Add `GH_REPO: ${{ github.repository }}` to the `env:` block
- Change `gh pr merge "$PR" --auto --squash` → `gh pr merge "$PR" --repo "$GH_REPO" --auto --squash`

## References

- Sweep parent: OMN-8509
- Audit report: `docs/briefs/audit-automerge-systemic.md`
- Reference fix: `onex_change_control@534285a` (PR #157, OMN-8431)

## Bootstrap Note

This PR itself cannot be auto-merged via the new workflow (the workflow isn't active until after this merges). First merge of this fix must be manual or via admin bypass to bootstrap the fleet.