### PR TITLE
feat(graph): add neo4j extra and Memgraph ingestion script [OMN-8556, OMN-8557]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ dependencies = [
     "cachetools>=6.2.4,<8.0.0",
 ]
 
+[project.optional-dependencies]
+graph = [
+    "neo4j>=5.0.0,<6.0.0",
+    # qdrant-client and httpx are already in core dependencies
+]
+
 [project.urls]
 Homepage = "https://github.com/OmniNode-ai/omnimemory"
 Repository = "https://github.com/OmniNode-ai/omnimemory"

--- a/scripts/graphify_to_memgraph.py
+++ b/scripts/graphify_to_memgraph.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Ingest graphify graph.json files into Memgraph via Bolt protocol.
+
+Graph.json schema:
+  nodes: list of {id, label, repo, source_file, node_type, ...}
+  links: list of {source, target, relation, confidence_score, ...}
+
+Usage:
+    uv run python scripts/graphify_to_memgraph.py \\
+        --graph-dir /path/to/graphify-graphs/ \\
+        --bolt-uri bolt://192.168.86.201:7687
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+
+def parse_graphify_json(
+    path: Path,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Parse a graph.json file and return (nodes, edges).
+
+    Nodes are under the 'nodes' key; edges are under the 'links' key.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    nodes: list[dict[str, Any]] = data.get("nodes", [])
+    links: list[dict[str, Any]] = data.get("links", [])
+    return nodes, links
+
+
+def build_node_cypher(node: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Return a (cypher_statement, params) pair for MERGEing a node.
+
+    Identity key is 'id' — unique per graphify output across repos.
+    """
+    cypher = (
+        "MERGE (n:Node {id: $id}) "
+        "SET n.label = $label, n.repo = $repo, n.source_file = $source_file, "
+        "n.node_type = $node_type, n.community = $community"
+    )
+    params: dict[str, Any] = {
+        "id": node["id"],
+        "label": node.get("label", ""),
+        "repo": node.get("repo", ""),
+        "source_file": node.get("source_file", ""),
+        "node_type": node.get("node_type", ""),
+        "community": node.get("community", ""),
+    }
+    return cypher, params
+
+
+def build_edge_cypher(edge: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Return a (cypher_statement, params) pair for MERGEing an edge."""
+    cypher = (
+        "MATCH (a:Node {id: $source}), (b:Node {id: $target}) "
+        "MERGE (a)-[r:RELATES {relation: $relation}]->(b) "
+        "SET r.confidence_score = $confidence_score"
+    )
+    params: dict[str, Any] = {
+        "source": edge["source"],
+        "target": edge["target"],
+        "relation": edge.get("relation", ""),
+        "confidence_score": edge.get("confidence_score", 0.0),
+    }
+    return cypher, params
+
+
+def _run_batch(session: Any, statements: list[tuple[str, dict[str, Any]]]) -> None:
+    with session.begin_transaction() as tx:
+        for cypher, params in statements:
+            tx.run(cypher, params)
+        tx.commit()
+
+
+def ingest_repo(
+    driver: Any, nodes: list[dict[str, Any]], links: list[dict[str, Any]]
+) -> dict[str, int]:
+    """Ingest a single repo's nodes and edges into Memgraph.
+
+    Returns counts of nodes and edges ingested.
+    """
+    with driver.session() as session:
+        # Ingest nodes in batches
+        node_count = 0
+        batch: list[tuple[str, dict[str, Any]]] = []
+        for node in nodes:
+            batch.append(build_node_cypher(node))
+            if len(batch) >= BATCH_SIZE:
+                _run_batch(session, batch)
+                node_count += len(batch)
+                batch = []
+        if batch:
+            _run_batch(session, batch)
+            node_count += len(batch)
+
+        # Ingest edges in batches
+        edge_count = 0
+        batch = []
+        for link in links:
+            batch.append(build_edge_cypher(link))
+            if len(batch) >= BATCH_SIZE:
+                _run_batch(session, batch)
+                edge_count += len(batch)
+                batch = []
+        if batch:
+            _run_batch(session, batch)
+            edge_count += len(batch)
+
+    return {"nodes": node_count, "edges": edge_count}
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Ingest graphify graph.json files into Memgraph"
+    )
+    parser.add_argument(
+        "--graph-dir",
+        required=True,
+        help="Directory containing per-repo graph.json files",
+    )
+    parser.add_argument(
+        "--bolt-uri",
+        default=os.environ.get("MEMGRAPH_URL", "bolt://192.168.86.201:7687"),
+        help="Memgraph Bolt URI (env: MEMGRAPH_URL)",
+    )
+    args = parser.parse_args()
+
+    graph_dir = Path(args.graph_dir)
+    if not graph_dir.is_dir():
+        logger.error("graph-dir does not exist: %s", graph_dir)
+        sys.exit(1)
+
+    graph_files = sorted(graph_dir.rglob("graph.json"))
+    if not graph_files:
+        logger.error("No graph.json files found under %s", graph_dir)
+        sys.exit(1)
+
+    try:
+        from neo4j import GraphDatabase  # type: ignore[import-untyped]
+    except ImportError:
+        logger.error("neo4j package not installed — run: uv sync --extra graph")
+        sys.exit(1)
+
+    driver = GraphDatabase.driver(args.bolt_uri, auth=None)
+    try:
+        total_nodes = 0
+        total_edges = 0
+        for graph_file in graph_files:
+            repo_name = graph_file.parent.name
+            logger.info("Ingesting %s ...", repo_name)
+            nodes, links = parse_graphify_json(graph_file)
+            counts = ingest_repo(driver, nodes, links)
+            logger.info(
+                "  %s: %d nodes, %d edges", repo_name, counts["nodes"], counts["edges"]
+            )
+            total_nodes += counts["nodes"]
+            total_edges += counts["edges"]
+        logger.info(
+            "Done. Total: %d nodes, %d edges across %d repos",
+            total_nodes,
+            total_edges,
+            len(graph_files),
+        )
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/graphify_to_memgraph.py
+++ b/scripts/graphify_to_memgraph.py
@@ -11,7 +11,12 @@ Graph.json schema:
 Usage:
     uv run python scripts/graphify_to_memgraph.py \\
         --graph-dir /path/to/graphify-graphs/ \\
-        --bolt-uri bolt://192.168.86.201:7687
+        --bolt-uri bolt://localhost:7687
+
+    # Or via env var (e.g. when Memgraph runs on a remote host):
+    MEMGRAPH_URL=bolt://192.168.86.201:7687 \\
+    uv run python scripts/graphify_to_memgraph.py \\
+        --graph-dir /path/to/graphify-graphs/
 """
 
 from __future__ import annotations
@@ -137,8 +142,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--bolt-uri",
-        default=os.environ.get("MEMGRAPH_URL", "bolt://192.168.86.201:7687"),
-        help="Memgraph Bolt URI (env: MEMGRAPH_URL)",
+        default=os.environ.get("MEMGRAPH_URL", "bolt://localhost:7687"),
+        help="Memgraph Bolt URI (env: MEMGRAPH_URL, default: bolt://localhost:7687)",
     )
     args = parser.parse_args()
 

--- a/tests/unit/test_graphify_to_memgraph.py
+++ b/tests/unit/test_graphify_to_memgraph.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for graphify_to_memgraph script.
+
+Tests parse_graphify_json, build_node_cypher, and build_edge_cypher
+without requiring a live Memgraph connection.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.graphify_to_memgraph import (
+    build_edge_cypher,
+    build_node_cypher,
+    parse_graphify_json,
+)
+
+SAMPLE_GRAPH = {
+    "nodes": [
+        {
+            "id": "omniclaude::node_delegation_orchestrator",
+            "label": "node_delegation_orchestrator",
+            "repo": "omniclaude",
+            "source_file": "src/omniclaude/nodes/node_delegation_orchestrator/__init__.py",
+            "node_type": "handler",
+            "community": "delegation",
+        },
+        {
+            "id": "omniclaude::node_quality_gate",
+            "label": "node_quality_gate",
+            "repo": "omniclaude",
+            "source_file": "src/omniclaude/nodes/node_quality_gate/__init__.py",
+            "node_type": "handler",
+            "community": "quality",
+        },
+    ],
+    "links": [
+        {
+            "source": "omniclaude::node_delegation_orchestrator",
+            "target": "omniclaude::node_quality_gate",
+            "relation": "calls",
+            "confidence_score": 0.95,
+        }
+    ],
+}
+
+
+@pytest.fixture
+def graph_json_file(tmp_path: Path) -> Path:
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text(json.dumps(SAMPLE_GRAPH))
+    return graph_file
+
+
+@pytest.mark.unit
+def test_parse_graphify_json_nodes(graph_json_file: Path) -> None:
+    nodes, links = parse_graphify_json(graph_json_file)
+    assert len(nodes) == 2
+    assert nodes[0]["id"] == "omniclaude::node_delegation_orchestrator"
+    assert nodes[1]["label"] == "node_quality_gate"
+
+
+@pytest.mark.unit
+def test_parse_graphify_json_links(graph_json_file: Path) -> None:
+    nodes, links = parse_graphify_json(graph_json_file)
+    assert len(links) == 1
+    assert links[0]["source"] == "omniclaude::node_delegation_orchestrator"
+    assert links[0]["target"] == "omniclaude::node_quality_gate"
+    assert links[0]["relation"] == "calls"
+    assert links[0]["confidence_score"] == 0.95
+
+
+@pytest.mark.unit
+def test_parse_graphify_json_empty_keys() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({}, f)
+        path = Path(f.name)
+    nodes, links = parse_graphify_json(path)
+    assert nodes == []
+    assert links == []
+
+
+@pytest.mark.unit
+def test_build_node_cypher_uses_id_as_merge_key() -> None:
+    node = SAMPLE_GRAPH["nodes"][0]
+    cypher, params = build_node_cypher(node)
+    assert "MERGE (n:Node {id: $id})" in cypher
+    assert params["id"] == "omniclaude::node_delegation_orchestrator"
+
+
+@pytest.mark.unit
+def test_build_node_cypher_sets_all_fields() -> None:
+    node = SAMPLE_GRAPH["nodes"][0]
+    cypher, params = build_node_cypher(node)
+    assert params["label"] == "node_delegation_orchestrator"
+    assert params["repo"] == "omniclaude"
+    assert (
+        params["source_file"]
+        == "src/omniclaude/nodes/node_delegation_orchestrator/__init__.py"
+    )
+    assert params["node_type"] == "handler"
+    assert params["community"] == "delegation"
+
+
+@pytest.mark.unit
+def test_build_node_cypher_missing_optional_fields() -> None:
+    node = {"id": "some::node"}
+    cypher, params = build_node_cypher(node)
+    assert params["id"] == "some::node"
+    assert params["label"] == ""
+    assert params["repo"] == ""
+    assert params["source_file"] == ""
+    assert params["node_type"] == ""
+    assert params["community"] == ""
+
+
+@pytest.mark.unit
+def test_build_node_cypher_does_not_use_label_as_merge_key() -> None:
+    node = SAMPLE_GRAPH["nodes"][0]
+    cypher, _ = build_node_cypher(node)
+    assert "MERGE (n:Node {label:" not in cypher
+    assert "MERGE (n:Node {name:" not in cypher
+
+
+@pytest.mark.unit
+def test_build_edge_cypher_structure() -> None:
+    edge = SAMPLE_GRAPH["links"][0]
+    cypher, params = build_edge_cypher(edge)
+    assert "MATCH (a:Node {id: $source})" in cypher
+    assert "MATCH" in cypher
+    assert "(b:Node {id: $target})" in cypher
+    assert "MERGE (a)-[r:RELATES" in cypher
+    assert params["source"] == "omniclaude::node_delegation_orchestrator"
+    assert params["target"] == "omniclaude::node_quality_gate"
+    assert params["relation"] == "calls"
+    assert params["confidence_score"] == 0.95
+
+
+@pytest.mark.unit
+def test_build_edge_cypher_missing_optional_fields() -> None:
+    edge = {"source": "a::node", "target": "b::node"}
+    cypher, params = build_edge_cypher(edge)
+    assert params["relation"] == ""
+    assert params["confidence_score"] == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = "==0.38.0" },
+    { name = "omnibase-core", specifier = "==0.39.0" },
     { name = "omnibase-spi", specifier = "==0.20.4" },
 ]
 
@@ -747,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -755,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1398,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.38.0"
+version = "0.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1412,14 +1414,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/f0/9c2971cc3328ca592f19da9afe3b95317de52d476f8b80f6ca03a273254f/omnibase_core-0.38.0.tar.gz", hash = "sha256:1667dd1047f937e5239a10a9443f754c0079b1fd8d58a061b73b0b900bdc6204", size = 8140989, upload-time = "2026-04-03T08:29:15.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/63/a75be3539b4046c2f9757b5da02fc5539ff0f382da84695bd1dee875b298/omnibase_core-0.39.0.tar.gz", hash = "sha256:3f57556cd65aba3af0be8e1517614f4a970b57101c9ac5e35e2b578bec5da2b9", size = 8149272, upload-time = "2026-04-06T16:36:03.186Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/dd/3061cb53bdd9725c216788652860d94bde720ae8883090ac4f18237faec4/omnibase_core-0.38.0-py3-none-any.whl", hash = "sha256:3ce216b042440e62db1959dd930f6807424de8511b0b03cf89a9868ead0c491a", size = 5365077, upload-time = "2026-04-03T08:29:18.665Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9f/c08ea924136d55fd6fe8bdd41f2cbe767eb672b4510db923ad0ff0b33f16/omnibase_core-0.39.0-py3-none-any.whl", hash = "sha256:f772e2100c655beb150a899ccd2875af69fe43d9636624c6adfb30db31a5cd36", size = 5370710, upload-time = "2026-04-06T16:36:00.702Z" },
 ]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.30.1"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1467,9 +1469,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/2b/ee1563fb12ecda7b53944d98847625331bdb85cac77b352f72396bb35479/omnibase_infra-0.30.1.tar.gz", hash = "sha256:6ef3b9cfa94d17d48ef688330ec3f3436a74994041e4cea379dfe8c148799510", size = 6919675, upload-time = "2026-03-31T07:38:55.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/a6/f54a764f9af7f45c72cdb09099d6e47d3aadbab72363d5291537bd9d33c6/omnibase_infra-0.32.0.tar.gz", hash = "sha256:7cc8e857b1f8434534b2eb38f7a8c1b9f16ec4f9cef8c17a94adf48446483009", size = 7199277, upload-time = "2026-04-03T08:55:58.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/e7/38b2c69a39d6c83a6dd2d56b2b9f6f0527f337278a1707727b0064052ea3/omnibase_infra-0.30.1-py3-none-any.whl", hash = "sha256:6484aa60e615ea5ec477fcaaa655acb85e1e2d84038dedfb317cbf23448d0fb1", size = 4109430, upload-time = "2026-03-31T07:38:57.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5a/569b0e975d3ca6c5bd137fa8a2cb809962c9bb59d5315957a1d8f66d27b4/omnibase_infra-0.32.0-py3-none-any.whl", hash = "sha256:b31c343d6163a9ad3ebfaafc4646578b8335d7c55a6914b8884341ce821d2e6e", size = 4489037, upload-time = "2026-04-03T08:55:55.783Z" },
 ]
 
 [[package]]
@@ -1517,6 +1519,11 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.optional-dependencies]
+graph = [
+    { name = "neo4j" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "detect-secrets" },
@@ -1546,8 +1553,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
-    { name = "omnibase-core", specifier = "==0.38.0" },
-    { name = "omnibase-infra", specifier = "==0.30.1" },
+    { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
+    { name = "omnibase-core", specifier = "==0.39.0" },
+    { name = "omnibase-infra", specifier = "==0.32.0" },
     { name = "omnibase-spi", specifier = "==0.20.4" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
@@ -1563,6 +1571,7 @@ requires-dist = [
     { name = "supabase", specifier = ">=2.9.0,<3.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1.0.0" },
 ]
+provides-extras = ["graph"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- **OMN-8556**: Adds `[project.optional-dependencies] graph` extra with `neo4j>=5.0.0,<6.0.0` to `pyproject.toml`. `qdrant-client` and `httpx` are already in core dependencies so only `neo4j` is new. Verified: `uv sync --extra graph` installs successfully, all three packages importable.
- **OMN-8557**: Adds `scripts/graphify_to_memgraph.py` — CLI that reads `graph.json` files (nodes from `nodes` key, edges from `links` key), generates Cypher MERGE statements keyed on `id` (not `label`/`name`), and ingests via Bolt in 500-item batches per transaction. Accepts `--graph-dir` and `--bolt-uri` (env: `MEMGRAPH_URL`).
- **OMN-8558** is execution-only (no code changes) — run after merge:
  ```bash
  uv run python scripts/graphify_to_memgraph.py \
    --graph-dir /Volumes/PRO-G40/Code/omni_home/.onex_state/graphify-graphs/ \
    --bolt-uri bolt://192.168.86.201:7687
  ```

## Test plan

- [ ] 9 unit tests pass (`test_graphify_to_memgraph.py`) — covering parse, node cypher, edge cypher, missing-field defaults, and MERGE key guard
- [ ] 867 existing unit tests pass — no regressions
- [ ] `neo4j`, `qdrant_client`, `httpx` all importable after `uv sync --extra graph`
- [ ] Run OMN-8558 ingestion after merge to populate Memgraph on .201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a command-line tool to ingest code graph data from Graphify JSON files into Memgraph databases, with automatic directory discovery and batched processing.

* **Chores**
  * Added optional neo4j dependency for graph database connectivity.
  * Expanded test coverage for graph data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->