### PR TITLE
fix(scope-mapping): replace hardcoded paths with OMNI_HOME env var [OMN-8590]

### DIFF
--- a/src/omnimemory/models/config/model_scope_mapping_config.py
+++ b/src/omnimemory/models/config/model_scope_mapping_config.py
@@ -12,8 +12,10 @@ Design doc: DESIGN_OMNIMEMORY_DOCUMENT_INGESTION_PIPELINE.md §7
 Ticket: OMN-2426
 """
 
+import os
 import types
 from collections.abc import Mapping
+from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -184,10 +186,9 @@ _DEFAULT_PRIORITY_HINTS: Mapping[EnumDetectedDocType, int] = types.MappingProxyT
 # Default scope mapping config matching design doc §7 examples
 # ---------------------------------------------------------------------------
 #
-# WARNING: LOCAL-DEV CONVENIENCE ONLY.
-# The config returned by get_default_scope_mapping_config() contains
-# machine-specific paths (/Volumes/PRO-G40/Code/..., /Users/jonah/.claude)
-# that are only valid on the primary developer's machine.
+# Paths resolve relative to the OMNI_HOME environment variable, which must
+# point to the canonical omni_home checkout (e.g. /Users/you/Code/omni_home).
+# ~/.claude is resolved via Path.home() so it works on any machine.
 # In CI and production, callers MUST supply a ModelScopeMappingConfig
 # built from environment-appropriate paths (e.g., read from config file or
 # env vars). Do NOT call get_default_scope_mapping_config() in any deployed
@@ -197,10 +198,9 @@ _DEFAULT_PRIORITY_HINTS: Mapping[EnumDetectedDocType, int] = types.MappingProxyT
 def get_default_scope_mapping_config() -> ModelScopeMappingConfig:
     """Return a local-dev convenience scope mapping config.
 
-    Constructs and returns a ``ModelScopeMappingConfig`` pre-populated with
-    machine-specific paths (``/Volumes/PRO-G40/Code/...``,
-    ``/Users/jonah/.claude``) that are only valid on the primary developer's
-    machine.
+    All paths are resolved at call time from the ``OMNI_HOME`` environment
+    variable (the canonical omni_home checkout root) and ``Path.home()``
+    (for ``~/.claude``). Raises ``KeyError`` if ``OMNI_HOME`` is not set.
 
     This function is intentionally lazy: the config is only constructed when
     explicitly called, so importing this module in CI or production code does
@@ -216,38 +216,41 @@ def get_default_scope_mapping_config() -> ModelScopeMappingConfig:
         ``ModelScopeMappingConfig`` from environment-appropriate configuration
         (e.g., environment variables or a config file).
     """
+    omni_home = Path(os.environ["OMNI_HOME"])
+    claude_dir = Path.home() / ".claude"
+
     return ModelScopeMappingConfig(
         path_mappings=(
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omniintelligence",
+                path_prefix=str(omni_home / "omniintelligence"),
                 scope_ref="omninode/omniintelligence",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omnimemory2",
+                path_prefix=str(omni_home / "omnimemory2"),
                 scope_ref="omninode/omnimemory",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omnimemory",
+                path_prefix=str(omni_home / "omnimemory"),
                 scope_ref="omninode/omnimemory",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omnibase_core",
+                path_prefix=str(omni_home / "omnibase_core"),
                 scope_ref="omninode/omnibase_core",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omni_save/design",
+                path_prefix=str(omni_home / "omni_save" / "design"),
                 scope_ref="omninode/shared/design",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code/omni_save/plans",
+                path_prefix=str(omni_home / "omni_save" / "plans"),
                 scope_ref="omninode/shared/plans",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Users/jonah/.claude",
+                path_prefix=str(claude_dir),
                 scope_ref="omninode/shared/global-standards",
             ),
             ModelPathScopeMapping(
-                path_prefix="/Volumes/PRO-G40/Code",
+                path_prefix=str(omni_home),
                 scope_ref="omninode/shared",
             ),
         ),
@@ -269,6 +272,6 @@ def get_default_scope_mapping_config() -> ModelScopeMappingConfig:
             ),
         ),
         priority_hints={
-            "/Users/jonah/.claude/CLAUDE.md": 95,
+            str(claude_dir / "CLAUDE.md"): 95,
         },
     )

--- a/tests/unit/test_scope_mapping_config.py
+++ b/tests/unit/test_scope_mapping_config.py
@@ -16,6 +16,9 @@ Ticket: OMN-2426
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -259,33 +262,40 @@ class TestResolvePriorityHint:
 class TestDefaultScopeMappingConfig:
     """Sanity-checks for the local-dev default config."""
 
+    @pytest.fixture(autouse=True)
+    def _set_omni_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNI_HOME", str(tmp_path))
+
     def test_global_claude_md_resolves_to_global_standards(self) -> None:
-        result = get_default_scope_mapping_config().resolve_scope_for_path(
-            "/Users/jonah/.claude/CLAUDE.md"
-        )
+        claude_dir = str(Path.home() / ".claude" / "CLAUDE.md")
+        result = get_default_scope_mapping_config().resolve_scope_for_path(claude_dir)
         assert result == "omninode/shared/global-standards"
 
     def test_repo_claude_md_resolves_to_repo_scope(self) -> None:
+        omni_home = Path(os.environ["OMNI_HOME"])
         result = get_default_scope_mapping_config().resolve_scope_for_path(
-            "/Volumes/PRO-G40/Code/omniintelligence/CLAUDE.md"
+            str(omni_home / "omniintelligence" / "CLAUDE.md")
         )
         assert result == "omninode/omniintelligence"
 
     def test_omnimemory2_resolves_to_omnimemory(self) -> None:
+        omni_home = Path(os.environ["OMNI_HOME"])
         result = get_default_scope_mapping_config().resolve_scope_for_path(
-            "/Volumes/PRO-G40/Code/omnimemory2/src/omnimemory/models/foo.py"
+            str(omni_home / "omnimemory2" / "src" / "omnimemory" / "models" / "foo.py")
         )
         assert result == "omninode/omnimemory"
 
     def test_design_doc_resolves_to_shared_design(self) -> None:
+        omni_home = Path(os.environ["OMNI_HOME"])
         result = get_default_scope_mapping_config().resolve_scope_for_path(
-            "/Volumes/PRO-G40/Code/omni_save/design/DESIGN_FOO.md"
+            str(omni_home / "omni_save" / "design" / "DESIGN_FOO.md")
         )
         assert result == "omninode/shared/design"
 
     def test_fallback_code_path_resolves_to_omninode_shared(self) -> None:
+        omni_home = Path(os.environ["OMNI_HOME"])
         result = get_default_scope_mapping_config().resolve_scope_for_path(
-            "/Volumes/PRO-G40/Code/some_unknown_repo/README.md"
+            str(omni_home / "some_unknown_repo" / "README.md")
         )
         assert result == "omninode/shared"
 
@@ -296,9 +306,10 @@ class TestDefaultScopeMappingConfig:
         assert result == "omninode/omnimemory"
 
     def test_global_claude_md_priority_hint(self) -> None:
+        claude_md = str(Path.home() / ".claude" / "CLAUDE.md")
         hint = get_default_scope_mapping_config().resolve_priority_hint(
             EnumDetectedDocType.CLAUDE_MD,
-            absolute_path="/Users/jonah/.claude/CLAUDE.md",
+            absolute_path=claude_md,
         )
         assert hint == 95
 

--- a/tests/unit/test_scope_mapping_config.py
+++ b/tests/unit/test_scope_mapping_config.py
@@ -350,7 +350,9 @@ class TestModelScopeMappingConfigSerialization:
         with pytest.raises(ValidationError):
             cfg.path_mappings = ()  # type: ignore[misc]
 
-    def test_default_config_round_trip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_config_round_trip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("OMNI_HOME", str(tmp_path))
         default_cfg = get_default_scope_mapping_config()
         data = default_cfg.model_dump()

--- a/tests/unit/test_scope_mapping_config.py
+++ b/tests/unit/test_scope_mapping_config.py
@@ -350,7 +350,8 @@ class TestModelScopeMappingConfigSerialization:
         with pytest.raises(ValidationError):
             cfg.path_mappings = ()  # type: ignore[misc]
 
-    def test_default_config_round_trip(self) -> None:
+    def test_default_config_round_trip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNI_HOME", str(tmp_path))
         default_cfg = get_default_scope_mapping_config()
         data = default_cfg.model_dump()
         restored = ModelScopeMappingConfig.model_validate(data)


### PR DESCRIPTION
## Summary
- Replaced 9 hardcoded `path_prefix` values (`/Volumes/PRO-G40/Code/...` and `/Users/jonah/.claude`) in `get_default_scope_mapping_config()` with `Path(os.environ["OMNI_HOME"]) / "<repo>"` and `Path.home() / ".claude"`
- Updated `TestDefaultScopeMappingConfig` tests to use `monkeypatch.setenv("OMNI_HOME", str(tmp_path))` so they run correctly on any machine
- Sub-ticket of OMN-8573

## Before / After (9 entries)

| # | Before | After |
|---|--------|-------|
| 1 | `/Volumes/PRO-G40/Code/omniintelligence` | `$OMNI_HOME/omniintelligence` |
| 2 | `/Volumes/PRO-G40/Code/omnimemory2` | `$OMNI_HOME/omnimemory2` |
| 3 | `/Volumes/PRO-G40/Code/omnimemory` | `$OMNI_HOME/omnimemory` |
| 4 | `/Volumes/PRO-G40/Code/omnibase_core` | `$OMNI_HOME/omnibase_core` |
| 5 | `/Volumes/PRO-G40/Code/omni_save/design` | `$OMNI_HOME/omni_save/design` |
| 6 | `/Volumes/PRO-G40/Code/omni_save/plans` | `$OMNI_HOME/omni_save/plans` |
| 7 | `/Users/jonah/.claude` | `Path.home() / ".claude"` |
| 8 | `/Volumes/PRO-G40/Code` | `$OMNI_HOME` (fallback) |
| 9 | `/Users/jonah/.claude/CLAUDE.md` (priority_hints key) | `Path.home() / ".claude" / "CLAUDE.md"` |

## Test plan
- [x] 35/35 unit tests pass
- [x] ruff check passes
- [x] Tests use `tmp_path` as `OMNI_HOME` — portable on all machines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration path mappings are now dynamically resolved using environment variables and home directory instead of hardcoded absolute paths. The `OMNI_HOME` environment variable is now required to be set for proper configuration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->