### PR TITLE
fix(graph): replace required --graph-dir with dynamic default [OMN-8569]

### DIFF
--- a/scripts/graphify_to_memgraph.py
+++ b/scripts/graphify_to_memgraph.py
@@ -13,10 +13,12 @@ Usage:
         --graph-dir /path/to/graphify-graphs/ \\
         --bolt-uri bolt://localhost:7687
 
+    # --graph-dir defaults to $OMNI_HOME/.onex_state/graphify-graphs/ (or
+    # path relative to this script's repo root if OMNI_HOME is not set).
+
     # Or via env var (e.g. when Memgraph runs on a remote host):
-    MEMGRAPH_URL=bolt://192.168.86.201:7687 \\
-    uv run python scripts/graphify_to_memgraph.py \\
-        --graph-dir /path/to/graphify-graphs/
+    MEMGRAPH_URL=bolt://192.168.1.201:7687 \\
+    uv run python scripts/graphify_to_memgraph.py
 """
 
 from __future__ import annotations
@@ -32,6 +34,16 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 500
+
+# scripts/ is one level below the repo root (omnimemory/)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _default_graph_dir() -> Path:
+    omni_home = os.environ.get("OMNI_HOME")
+    if omni_home:
+        return Path(omni_home) / ".onex_state" / "graphify-graphs"
+    return _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"
 
 
 def parse_graphify_json(
@@ -137,8 +149,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--graph-dir",
-        required=True,
-        help="Directory containing per-repo graph.json files",
+        default=None,
+        help=(
+            "Directory containing per-repo graph.json files. "
+            "Defaults to $OMNI_HOME/.onex_state/graphify-graphs/ "
+            "or <repo-root>/../.onex_state/graphify-graphs/ if OMNI_HOME is unset."
+        ),
     )
     parser.add_argument(
         "--bolt-uri",
@@ -147,7 +163,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    graph_dir = Path(args.graph_dir)
+    graph_dir = Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
     if not graph_dir.is_dir():
         logger.error("graph-dir does not exist: %s", graph_dir)
         sys.exit(1)

--- a/tests/unit/test_graphify_to_memgraph.py
+++ b/tests/unit/test_graphify_to_memgraph.py
@@ -160,7 +160,9 @@ def test_default_graph_dir_uses_omni_home(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.unit
-def test_default_graph_dir_falls_back_to_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_graph_dir_falls_back_to_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("OMNI_HOME", raising=False)
     result = _default_graph_dir()
     assert result == _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"

--- a/tests/unit/test_graphify_to_memgraph.py
+++ b/tests/unit/test_graphify_to_memgraph.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import pytest
 
 from scripts.graphify_to_memgraph import (
+    _REPO_ROOT,
+    _default_graph_dir,
     build_edge_cypher,
     build_node_cypher,
     parse_graphify_json,
@@ -148,3 +150,20 @@ def test_build_edge_cypher_missing_optional_fields() -> None:
     cypher, params = build_edge_cypher(edge)
     assert params["relation"] == ""
     assert params["confidence_score"] == 0.0
+
+
+@pytest.mark.unit
+def test_default_graph_dir_uses_omni_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNI_HOME", "/fake/omni_home")
+    result = _default_graph_dir()
+    assert result == Path("/fake/omni_home") / ".onex_state" / "graphify-graphs"
+
+
+@pytest.mark.unit
+def test_default_graph_dir_falls_back_to_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNI_HOME", raising=False)
+    result = _default_graph_dir()
+    assert result == _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"
+    assert "/Volumes/PRO-G40/" not in str(result)
+    assert result.parts[-1] == "graphify-graphs"
+    assert result.parts[-2] == ".onex_state"


### PR DESCRIPTION
## Summary

- Makes `--graph-dir` optional in `scripts/graphify_to_memgraph.py` — resolves to `$OMNI_HOME/.onex_state/graphify-graphs` when `OMNI_HOME` is set, or `<repo-root>/../.onex_state/graphify-graphs` when unset
- Removes the machine-specific LAN IP (`192.168.86.201`) from the docstring example
- Audited all other scripts in `omnimemory/scripts/` — no remaining `/Volumes/` or `/Users/jonah/` hardcodes found
- Adds 2 new unit tests covering both resolution paths

Closes OMN-8569. Related: OMN-8557, OMN-8558, OMN-8564

## Test plan
- [x] `uv run pytest tests/unit/test_graphify_to_memgraph.py` — 11 passed
- [x] `test_default_graph_dir_uses_omni_home` — verifies OMNI_HOME path
- [x] `test_default_graph_dir_falls_back_to_repo_root` — verifies __file__-relative fallback, no /Volumes/PRO-G40/ path