### PR TITLE
fix: replace hardcoded topic strings with registry and declare transports [OMN-8633]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,9 +81,7 @@ repos:
     rev: 8d7e85bc00e7f1b1306d1cb40949be1ab6e7e91a  # pragma: allowlist secret
     hooks:
       - id: no-hardcoded-topics
-        # Pre-existing violations — pending migration to canonical topic constants
-        exclude: >-
-          ^src/omnimemory/nodes/(node_filesystem_crawler_effect|node_intent_event_consumer_effect|node_kreuzberg_parse_effect)/models/
+        exclude: ^src/omnimemory/topics\.py$
         stages: [pre-commit]
       - id: no-untracked-todos
         stages: [pre-commit]

--- a/src/omnimemory/nodes/node_filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/node_filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -6,7 +6,7 @@
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from omnimemory.topics import MemoryEventTopic
+from omnimemory.topics import EnumMemoryEventTopic
 
 
 class ModelFilesystemCrawlerConfig(  # omnimemory-model-exempt: handler config
@@ -52,19 +52,19 @@ class ModelFilesystemCrawlerConfig(  # omnimemory-model-exempt: handler config
 
     # Published topic suffixes (env prefix added at runtime)
     publish_topic_discovered: str = Field(
-        default=MemoryEventTopic.DOCUMENT_DISCOVERED,
+        default=EnumMemoryEventTopic.DOCUMENT_DISCOVERED,
         description="Topic suffix for document-discovered events",
     )
     publish_topic_changed: str = Field(
-        default=MemoryEventTopic.DOCUMENT_CHANGED,
+        default=EnumMemoryEventTopic.DOCUMENT_CHANGED,
         description="Topic suffix for document-changed events",
     )
     publish_topic_removed: str = Field(
-        default=MemoryEventTopic.DOCUMENT_REMOVED,
+        default=EnumMemoryEventTopic.DOCUMENT_REMOVED,
         description="Topic suffix for document-removed events",
     )
     publish_topic_indexed: str = Field(
-        default=MemoryEventTopic.DOCUMENT_INDEXED,
+        default=EnumMemoryEventTopic.DOCUMENT_INDEXED,
         description=(
             "Topic suffix for document-indexed events. Emitted after a document "
             "is fully crawled and indexed (discovered or changed). Consumed by "

--- a/src/omnimemory/nodes/node_filesystem_crawler_effect/models/model_filesystem_crawler_config.py
+++ b/src/omnimemory/nodes/node_filesystem_crawler_effect/models/model_filesystem_crawler_config.py
@@ -6,6 +6,8 @@
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnimemory.topics import MemoryEventTopic
+
 
 class ModelFilesystemCrawlerConfig(  # omnimemory-model-exempt: handler config
     BaseModel
@@ -50,19 +52,19 @@ class ModelFilesystemCrawlerConfig(  # omnimemory-model-exempt: handler config
 
     # Published topic suffixes (env prefix added at runtime)
     publish_topic_discovered: str = Field(
-        default="onex.evt.omnimemory.document-discovered.v1",
+        default=MemoryEventTopic.DOCUMENT_DISCOVERED,
         description="Topic suffix for document-discovered events",
     )
     publish_topic_changed: str = Field(
-        default="onex.evt.omnimemory.document-changed.v1",
+        default=MemoryEventTopic.DOCUMENT_CHANGED,
         description="Topic suffix for document-changed events",
     )
     publish_topic_removed: str = Field(
-        default="onex.evt.omnimemory.document-removed.v1",
+        default=MemoryEventTopic.DOCUMENT_REMOVED,
         description="Topic suffix for document-removed events",
     )
     publish_topic_indexed: str = Field(
-        default="onex.evt.omnimemory.document-indexed.v1",
+        default=MemoryEventTopic.DOCUMENT_INDEXED,
         description=(
             "Topic suffix for document-indexed events. Emitted after a document "
             "is fully crawled and indexed (discovered or changed). Consumed by "

--- a/src/omnimemory/nodes/node_intent_event_consumer_effect/models/model_consumer_config.py
+++ b/src/omnimemory/nodes/node_intent_event_consumer_effect/models/model_consumer_config.py
@@ -9,7 +9,7 @@ list format per OMN-1746 for EventBusSubcontractWiring compatibility.
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from omnimemory.topics import MemoryEventTopic
+from omnimemory.topics import EnumMemoryEventTopic
 
 
 # omnimemory-model-exempt: handler config
@@ -35,15 +35,15 @@ class ModelIntentEventConsumerConfig(BaseModel):
     # Topic configuration (suffixes only - env prefix added at runtime)
     # Uses list format matching event_bus.subscribe_topics contract standard
     subscribe_topics: list[str] = Field(
-        default=[MemoryEventTopic.INTENT_CLASSIFIED],
+        default=[EnumMemoryEventTopic.INTENT_CLASSIFIED],
         description="Topic suffixes to subscribe to (env prefix added at runtime)",
     )
     publish_topics: list[str] = Field(
-        default=[MemoryEventTopic.INTENT_STORED],
+        default=[EnumMemoryEventTopic.INTENT_STORED],
         description="Topic suffixes to publish to (env prefix added at runtime)",
     )
     dlq_topics: list[str] = Field(
-        default=[MemoryEventTopic.INTENT_CLASSIFIED_DLQ],
+        default=[EnumMemoryEventTopic.INTENT_CLASSIFIED_DLQ],
         description="Dead letter queue topic suffixes",
     )
 

--- a/src/omnimemory/nodes/node_intent_event_consumer_effect/models/model_consumer_config.py
+++ b/src/omnimemory/nodes/node_intent_event_consumer_effect/models/model_consumer_config.py
@@ -9,6 +9,8 @@ list format per OMN-1746 for EventBusSubcontractWiring compatibility.
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from omnimemory.topics import MemoryEventTopic
+
 
 # omnimemory-model-exempt: handler config
 class ModelIntentEventConsumerConfig(BaseModel):
@@ -33,15 +35,15 @@ class ModelIntentEventConsumerConfig(BaseModel):
     # Topic configuration (suffixes only - env prefix added at runtime)
     # Uses list format matching event_bus.subscribe_topics contract standard
     subscribe_topics: list[str] = Field(
-        default=["onex.evt.omniintelligence.intent-classified.v1"],
+        default=[MemoryEventTopic.INTENT_CLASSIFIED],
         description="Topic suffixes to subscribe to (env prefix added at runtime)",
     )
     publish_topics: list[str] = Field(
-        default=["onex.evt.omnimemory.intent-stored.v1"],
+        default=[MemoryEventTopic.INTENT_STORED],
         description="Topic suffixes to publish to (env prefix added at runtime)",
     )
     dlq_topics: list[str] = Field(
-        default=["onex.evt.omniintelligence.intent-classified.v1.dlq"],
+        default=[MemoryEventTopic.INTENT_CLASSIFIED_DLQ],
         description="Dead letter queue topic suffixes",
     )
 

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
@@ -110,6 +110,10 @@ event_bus:
       schema_ref: "omnimemory.models.crawl.model_document_parse_failed_event.ModelDocumentParseFailedEvent"
       description: "Document parse failed event. Emitted when kreuzberg cannot extract text."
 
+# === TRANSPORT DECLARATIONS ===
+metadata:
+  transport_type: "HTTP"
+
 # === HANDLER CONFIGURATION ===
 handler_config:
   handler_class: "HandlerKreuzbergParse"

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from omnimemory.topics import MemoryEventTopic
+from omnimemory.topics import EnumMemoryEventTopic
 
 
 class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
@@ -71,10 +71,10 @@ class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
         ),
     )
     publish_topic_indexed: str = Field(
-        default=MemoryEventTopic.DOCUMENT_INDEXED,
+        default=EnumMemoryEventTopic.DOCUMENT_INDEXED,
         description="Topic to publish ModelDocumentIndexedKreuzbergEvent messages to",
     )
     publish_topic_parse_failed: str = Field(
-        default=MemoryEventTopic.DOCUMENT_PARSE_FAILED,
+        default=EnumMemoryEventTopic.DOCUMENT_PARSE_FAILED,
         description="Topic to publish ModelDocumentParseFailedEvent messages to",
     )

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from omnimemory.topics import MemoryEventTopic
+
 
 class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
     BaseModel
@@ -69,10 +71,10 @@ class ModelKreuzbergParseConfig(  # omnimemory-model-exempt: handler config
         ),
     )
     publish_topic_indexed: str = Field(
-        default="onex.evt.omnimemory.document-indexed.v1",
+        default=MemoryEventTopic.DOCUMENT_INDEXED,
         description="Topic to publish ModelDocumentIndexedKreuzbergEvent messages to",
     )
     publish_topic_parse_failed: str = Field(
-        default="onex.evt.omnimemory.document-parse-failed.v1",
+        default=MemoryEventTopic.DOCUMENT_PARSE_FAILED,
         description="Topic to publish ModelDocumentParseFailedEvent messages to",
     )

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
@@ -36,6 +36,10 @@ io_operations:
 transaction_management:
   enabled: false
 
+# === TRANSPORT DECLARATIONS ===
+metadata:
+  transport_type: "HTTP"
+
 # === NODE CONFIGURATION ===
 # NOTE: tool_name and main_tool_class are required per ModelContractEffect validation
 tool_specification:
@@ -161,6 +165,8 @@ handler_routing:
     # Semantic similarity search via Qdrant
     - routing_key: "search"
       handler_key: "HandlerQdrantMock"
+      handler:
+        handler_type: "QDRANT"
       priority: 0
       output_events: []
     # Full-text search via PostgreSQL

--- a/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
+++ b/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
@@ -18,6 +18,31 @@ handler_config:
   handler_class: "HandlerNavigationHistoryReducer"
   handler_module: "omnimemory.nodes.node_navigation_history_reducer.handlers.handler_navigation_history_reducer"
 
+# === TRANSPORT DECLARATIONS ===
+metadata:
+  transport_type: "DATABASE"
+
+handler_routing:
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  routing_strategy: operation_match
+  handlers:
+    - routing_key: "qdrant"
+      handler_key: "HandlerQdrant"
+      handler:
+        handler_type: "QDRANT"
+      priority: 0
+      output_events: []
+    - routing_key: "http"
+      handler_key: "HandlerHttp"
+      handler:
+        handler_type: "HTTP"
+      priority: 0
+      output_events: []
+  default_handler: "HandlerNavigationHistoryReducer"
+
 tags:
   - memory
   - reducer

--- a/src/omnimemory/topics.py
+++ b/src/omnimemory/topics.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Canonical Kafka topic registry for omnimemory events and commands.
+
+Defines all omnimemory Kafka topics as StrEnums. All topic names follow
+ONEX canonical format: ``onex.{kind}.{producer}.{event-name}.v{n}``
+
+This module is the single source of truth for omnimemory topic names.
+No hardcoded topic strings should appear in producer or consumer code; use
+these enum values instead.
+
+ONEX Compliance:
+    - Topic names are immutable StrEnum values (no hardcoded strings elsewhere).
+    - All `emitted_at` fields in envelope models must be injected by callers.
+    - No datetime.now() defaults permitted.
+
+Reference: OMN-8605, OMN-8633
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from omnibase_core.utils.util_str_enum_base import StrValueHelper
+
+
+@unique
+class MemoryCommandTopic(StrValueHelper, str, Enum):
+    """Canonical Kafka topic names for omnimemory input commands.
+
+    All topics use ``onex.cmd.omnimemory.*`` as the consumer namespace
+    (producer/consumer: ``omnimemory``, kind: ``cmd``).
+    """
+
+    INTENT_QUERY_REQUESTED = "onex.cmd.omnimemory.intent-query-requested.v1"
+    """Intent query requested command."""
+
+    RUNTIME_TICK = "onex.cmd.omnimemory.runtime-tick.v1"
+    """Lifecycle runtime-tick command."""
+
+    ARCHIVE_MEMORY = "onex.cmd.omnimemory.archive-memory.v1"
+    """Archive memory lifecycle command."""
+
+    EXPIRE_MEMORY = "onex.cmd.omnimemory.expire-memory.v1"
+    """Expire memory lifecycle command."""
+
+    MEMORY_RETRIEVAL_REQUESTED = "onex.cmd.omnimemory.memory-retrieval-requested.v1"
+    """Memory retrieval requested command."""
+
+    GRAPH_MEMORY_QUERY = "onex.cmd.omnimemory.graph-memory-query.v1"
+    """Graph memory query/mutation command (OMN-6578)."""
+
+    INTENT_GRAPH_QUERY = "onex.cmd.omnimemory.intent-graph-query.v1"
+    """Intent graph query/mutation command (OMN-6579)."""
+
+    NAVIGATION_HISTORY_SESSION = "onex.cmd.omnimemory.navigation-history-session.v1"
+    """Navigation history session command (OMN-6583)."""
+
+    SEMANTIC_ANALYSIS = "onex.cmd.omnimemory.semantic-analysis.v1"
+    """Semantic analysis request command (OMN-6585)."""
+
+
+@unique
+class MemoryEventTopic(StrValueHelper, str, Enum):
+    """Canonical Kafka topic names for omnimemory events.
+
+    Includes both events produced by omnimemory (crawl pipeline, intent storage)
+    and cross-domain events consumed by omnimemory from other services.
+    """
+
+    # --- Cross-domain events consumed by omnimemory ---
+
+    INTENT_CLASSIFIED = "onex.evt.omniintelligence.intent-classified.v1"
+    """Intent classified event produced by omniintelligence."""
+
+    INTENT_CLASSIFIED_DLQ = "onex.evt.omniintelligence.intent-classified.v1.dlq"
+    """Dead-letter queue for intent-classified events."""
+
+    # --- Crawl pipeline events produced by omnimemory ---
+
+    DOCUMENT_DISCOVERED = "onex.evt.omnimemory.document-discovered.v1"
+    """Document discovered by filesystem or other crawlers."""
+
+    DOCUMENT_CHANGED = "onex.evt.omnimemory.document-changed.v1"
+    """Document content changed, triggers re-parse."""
+
+    DOCUMENT_REMOVED = "onex.evt.omnimemory.document-removed.v1"
+    """Document removed from crawl scope."""
+
+    DOCUMENT_INDEXED = "onex.evt.omnimemory.document-indexed.v1"
+    """Document successfully indexed (kreuzberg variant or standard)."""
+
+    DOCUMENT_PARSE_FAILED = "onex.evt.omnimemory.document-parse-failed.v1"
+    """Document parse failed (too large, timeout, or parse error)."""
+
+    # --- Memory pipeline events produced by omnimemory ---
+
+    INTENT_STORED = "onex.evt.omnimemory.intent-stored.v1"
+    """Intent stored event after processing intent-classified input."""
+
+    MEMORY_RETRIEVAL_RESPONSE = "onex.evt.omnimemory.memory-retrieval-response.v1"
+    """Memory retrieval response event."""
+
+
+__all__ = ["MemoryCommandTopic", "MemoryEventTopic"]

--- a/src/omnimemory/topics.py
+++ b/src/omnimemory/topics.py
@@ -27,7 +27,7 @@ from omnibase_core.utils.util_str_enum_base import StrValueHelper
 
 
 @unique
-class MemoryCommandTopic(StrValueHelper, str, Enum):
+class EnumMemoryCommandTopic(StrValueHelper, str, Enum):
     """Canonical Kafka topic names for omnimemory input commands.
 
     All topics use ``onex.cmd.omnimemory.*`` as the consumer namespace
@@ -63,7 +63,7 @@ class MemoryCommandTopic(StrValueHelper, str, Enum):
 
 
 @unique
-class MemoryEventTopic(StrValueHelper, str, Enum):
+class EnumMemoryEventTopic(StrValueHelper, str, Enum):
     """Canonical Kafka topic names for omnimemory events.
 
     Includes both events produced by omnimemory (crawl pipeline, intent storage)
@@ -104,4 +104,4 @@ class MemoryEventTopic(StrValueHelper, str, Enum):
     """Memory retrieval response event."""
 
 
-__all__ = ["MemoryCommandTopic", "MemoryEventTopic"]
+__all__ = ["EnumMemoryCommandTopic", "EnumMemoryEventTopic"]


### PR DESCRIPTION
## Summary

- Creates `src/omnimemory/topics.py` as canonical topic registry (`MemoryCommandTopic` / `MemoryEventTopic` StrEnums) covering all crawl pipeline, intent, and memory retrieval topics
- Replaces hardcoded topic strings in 3 model files with enum references (0 HARDCODED_TOPIC violations)
- Adds transport declarations to 3 contract files (0 UNDECLARED_TRANSPORT violations)
- Removes now-redundant pre-commit excludes for fixed files

Sub-ticket of OMN-8605. Resolves OMN-8633.

## Files changed

- `src/omnimemory/topics.py` (new) — canonical topic registry
- `nodes/node_filesystem_crawler_effect/models/model_filesystem_crawler_config.py` — 4 topics
- `nodes/node_intent_event_consumer_effect/models/model_consumer_config.py` — 3 topics
- `nodes/node_kreuzberg_parse_effect/models/model_kreuzberg_parse_config.py` — 2 topics
- `nodes/node_kreuzberg_parse_effect/contract.yaml` — declare HTTP transport
- `nodes/node_memory_retrieval_effect/contract.yaml` — declare HTTP + QDRANT transports
- `nodes/node_navigation_history_reducer/contract.yaml` — declare DATABASE + QDRANT + HTTP transports
- `.pre-commit-config.yaml` — remove stale excludes, add topics.py registry exclude

## Test plan

- [x] HARDCODED_TOPIC scan: 0 violations (was 3 files)
- [x] UNDECLARED_TRANSPORT scan: 0 violations (was 3 files, allowlisted handlers unchanged)
- [x] `uv run pytest tests/ -m unit` — 1200/1200 pass
- [x] `uv run mypy src/omnimemory` — clean
- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format src/` — no changes