### PR TITLE
test(golden-chain): Qdrant + Memgraph ingestion golden chain tests [OMN-8646]

### DIFF
--- a/tests/integration/test_golden_chain_memgraph_ingestion.py
+++ b/tests/integration/test_golden_chain_memgraph_ingestion.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Golden chain tests for Memgraph ingestion flow (OMN-8646).
+
+Validates the end-to-end path:
+  graph.json input → parse_graphify_json → build_node_cypher / build_edge_cypher
+  → ingest_repo → driver.session → tx.run()
+
+Tests (9 total):
+  Happy path:
+    1. test_ingest_repo_runs_node_cypher_for_each_node
+    2. test_ingest_repo_runs_edge_cypher_for_each_link
+    3. test_ingest_repo_returns_correct_counts
+    4. test_ingest_repo_batches_large_node_sets
+    5. test_ingest_repo_empty_graph_returns_zero_counts
+  Error paths:
+    6. test_ingest_repo_tx_run_raises_propagates
+    7. test_ingest_repo_session_raises_propagates
+  Parse layer:
+    8. test_parse_graphify_json_roundtrip
+    9. test_build_node_and_edge_cypher_contain_merge_keys
+
+Ticket: OMN-8646
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.graphify_to_memgraph import (
+    build_edge_cypher,
+    build_node_cypher,
+    ingest_repo,
+    parse_graphify_json,
+)
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+_NODE_A = {
+    "id": "repo_a::node_foo",
+    "label": "node_foo",
+    "repo": "repo_a",
+    "source_file": "src/repo_a/nodes/node_foo/__init__.py",
+    "node_type": "handler",
+    "community": "core",
+}
+_NODE_B = {
+    "id": "repo_a::node_bar",
+    "label": "node_bar",
+    "repo": "repo_a",
+    "source_file": "src/repo_a/nodes/node_bar/__init__.py",
+    "node_type": "handler",
+    "community": "core",
+}
+_LINK_AB = {
+    "source": "repo_a::node_foo",
+    "target": "repo_a::node_bar",
+    "relation": "calls",
+    "confidence_score": 0.9,
+}
+
+SAMPLE_GRAPH = {"nodes": [_NODE_A, _NODE_B], "links": [_LINK_AB]}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_driver_mock() -> MagicMock:
+    """Return a mock neo4j-style driver whose session context is fully wired."""
+    tx = MagicMock()
+    tx.run = MagicMock()
+    tx.commit = MagicMock()
+    tx.__enter__ = MagicMock(return_value=tx)
+    tx.__exit__ = MagicMock(return_value=False)
+
+    session = MagicMock()
+    session.begin_transaction = MagicMock(return_value=tx)
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+
+    driver = MagicMock()
+    driver.session = MagicMock(return_value=session)
+    driver.close = MagicMock()
+
+    # Expose internals for assertion
+    driver._mock_session = session
+    driver._mock_tx = tx
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# Happy path — ingest_repo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainMemgraphIngestRepo:
+    """Golden chain: ingest_repo → driver.session → tx.run() with correct Cypher."""
+
+    def test_ingest_repo_runs_node_cypher_for_each_node(self) -> None:
+        """Each node produces exactly one tx.run() call with MERGE (n:Node {id: $id})."""
+        driver = _make_driver_mock()
+        tx = driver._mock_tx
+
+        ingest_repo(driver, [_NODE_A, _NODE_B], [])
+
+        run_calls = tx.run.call_args_list
+        assert len(run_calls) == 2
+        for c in run_calls:
+            cypher = c.args[0]
+            assert "MERGE (n:Node {id: $id})" in cypher
+
+    def test_ingest_repo_runs_edge_cypher_for_each_link(self) -> None:
+        """Each link produces exactly one tx.run() call with MERGE (a)-[r:RELATES...]."""
+        driver = _make_driver_mock()
+        tx = driver._mock_tx
+
+        ingest_repo(driver, [], [_LINK_AB])
+
+        run_calls = tx.run.call_args_list
+        assert len(run_calls) == 1
+        cypher = run_calls[0].args[0]
+        assert "MERGE (a)-[r:RELATES" in cypher
+
+    def test_ingest_repo_returns_correct_counts(self) -> None:
+        """ingest_repo returns {'nodes': 2, 'edges': 1} for sample graph."""
+        driver = _make_driver_mock()
+        counts = ingest_repo(driver, [_NODE_A, _NODE_B], [_LINK_AB])
+
+        assert counts["nodes"] == 2
+        assert counts["edges"] == 1
+
+    def test_ingest_repo_batches_large_node_sets(self) -> None:
+        """Nodes exceeding BATCH_SIZE=500 are flushed in multiple transactions."""
+        from scripts.graphify_to_memgraph import BATCH_SIZE
+
+        many_nodes = [
+            {
+                "id": f"repo::node_{i}",
+                "label": f"node_{i}",
+                "repo": "repo",
+                "source_file": "",
+                "node_type": "handler",
+                "community": "",
+            }
+            for i in range(BATCH_SIZE + 5)
+        ]
+
+        driver = _make_driver_mock()
+        session = driver._mock_session
+
+        counts = ingest_repo(driver, many_nodes, [])
+
+        assert counts["nodes"] == BATCH_SIZE + 5
+        # Expect exactly 2 begin_transaction calls for nodes (one full batch + remainder)
+        assert session.begin_transaction.call_count >= 2
+
+    def test_ingest_repo_empty_graph_returns_zero_counts(self) -> None:
+        """Empty nodes and links produces counts of zero with no tx.run calls."""
+        driver = _make_driver_mock()
+        tx = driver._mock_tx
+
+        counts = ingest_repo(driver, [], [])
+
+        assert counts == {"nodes": 0, "edges": 0}
+        tx.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainMemgraphErrors:
+    """Golden chain error paths: adapter raises → propagates from ingest_repo."""
+
+    def test_ingest_repo_tx_run_raises_propagates(self) -> None:
+        """When tx.run raises, the exception propagates out of ingest_repo."""
+        driver = _make_driver_mock()
+        driver._mock_tx.run = MagicMock(side_effect=RuntimeError("Cypher syntax error"))
+
+        with pytest.raises(RuntimeError, match="Cypher syntax error"):
+            ingest_repo(driver, [_NODE_A], [])
+
+    def test_ingest_repo_session_raises_propagates(self) -> None:
+        """When driver.session raises, the exception propagates from ingest_repo."""
+        driver = _make_driver_mock()
+        driver.session = MagicMock(
+            side_effect=ConnectionError("Memgraph not reachable")
+        )
+
+        with pytest.raises(ConnectionError, match="Memgraph not reachable"):
+            ingest_repo(driver, [_NODE_A], [])
+
+
+# ---------------------------------------------------------------------------
+# Parse + cypher layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainMemgraphParseCypher:
+    """Golden chain: parse_graphify_json + build_*_cypher produce correct output."""
+
+    def test_parse_graphify_json_roundtrip(self, tmp_path: Path) -> None:
+        """Parsed nodes and links match SAMPLE_GRAPH exactly."""
+        graph_file = tmp_path / "graph.json"
+        graph_file.write_text(json.dumps(SAMPLE_GRAPH))
+
+        nodes, links = parse_graphify_json(graph_file)
+
+        assert len(nodes) == 2
+        assert len(links) == 1
+        assert nodes[0]["id"] == "repo_a::node_foo"
+        assert links[0]["relation"] == "calls"
+        assert links[0]["confidence_score"] == 0.9
+
+    def test_build_node_and_edge_cypher_contain_merge_keys(self) -> None:
+        """build_node_cypher uses id as merge key; build_edge_cypher uses source+target."""
+        node_cypher, node_params = build_node_cypher(_NODE_A)
+        edge_cypher, edge_params = build_edge_cypher(_LINK_AB)
+
+        assert "MERGE (n:Node {id: $id})" in node_cypher
+        assert node_params["id"] == "repo_a::node_foo"
+        assert node_params["repo"] == "repo_a"
+
+        assert "MATCH (a:Node {id: $source})" in edge_cypher
+        assert "(b:Node {id: $target})" in edge_cypher
+        assert edge_params["source"] == "repo_a::node_foo"
+        assert edge_params["target"] == "repo_a::node_bar"
+        assert edge_params["confidence_score"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Optional smoke test (live Memgraph on .201)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.memgraph
+def test_smoke_memgraph_live_ingest() -> None:
+    """Smoke test: live Memgraph on 192.168.86.201:7687.
+
+    Skipped when Memgraph is unreachable.
+    """
+    import socket
+
+    try:
+        sock = socket.create_connection(("192.168.86.201", 7687), timeout=2)
+        sock.close()
+    except OSError:
+        pytest.skip("Live Memgraph at 192.168.86.201:7687 not reachable")
+
+    try:
+        from neo4j import GraphDatabase
+    except ImportError:
+        pytest.skip("neo4j package not installed")
+
+    driver = GraphDatabase.driver("bolt://192.168.86.201:7687", auth=None)
+    try:
+        counts = ingest_repo(driver, [_NODE_A, _NODE_B], [_LINK_AB])
+        assert counts["nodes"] == 2
+        assert counts["edges"] == 1
+    finally:
+        driver.close()

--- a/tests/integration/test_golden_chain_memgraph_ingestion.py
+++ b/tests/integration/test_golden_chain_memgraph_ingestion.py
@@ -250,30 +250,26 @@ class TestGoldenChainMemgraphParseCypher:
 @pytest.mark.integration
 @pytest.mark.memgraph
 def test_smoke_memgraph_live_ingest() -> None:
-    """Smoke test: live Memgraph on 192.168.86.201:7687.  # onex-allow-internal-ip
+    """Smoke test: live Memgraph on the dev host (port 7687).
 
     Skipped when Memgraph is unreachable.
     """
     import socket
 
+    _host = "192.168.86.201"  # onex-allow-internal-ip
+    _bolt = f"bolt://{_host}:7687"  # onex-allow-internal-ip
     try:
-        sock = socket.create_connection(
-            ("192.168.86.201", 7687), timeout=2
-        )  # onex-allow-internal-ip
+        sock = socket.create_connection((_host, 7687), timeout=2)
         sock.close()
     except OSError:
-        pytest.skip(
-            "Live Memgraph at 192.168.86.201:7687 not reachable"
-        )  # onex-allow-internal-ip
+        pytest.skip(f"Live Memgraph at {_host}:7687 not reachable")
 
     try:
         from neo4j import GraphDatabase
     except ImportError:
         pytest.skip("neo4j package not installed")
 
-    driver = GraphDatabase.driver(
-        "bolt://192.168.86.201:7687", auth=None
-    )  # onex-allow-internal-ip
+    driver = GraphDatabase.driver(_bolt, auth=None)
     try:
         counts = ingest_repo(driver, [_NODE_A, _NODE_B], [_LINK_AB])
         assert counts["nodes"] == 2

--- a/tests/integration/test_golden_chain_memgraph_ingestion.py
+++ b/tests/integration/test_golden_chain_memgraph_ingestion.py
@@ -257,17 +257,23 @@ def test_smoke_memgraph_live_ingest() -> None:
     import socket
 
     try:
-        sock = socket.create_connection(("192.168.86.201", 7687), timeout=2)  # onex-allow-internal-ip
+        sock = socket.create_connection(
+            ("192.168.86.201", 7687), timeout=2
+        )  # onex-allow-internal-ip
         sock.close()
     except OSError:
-        pytest.skip("Live Memgraph at 192.168.86.201:7687 not reachable")  # onex-allow-internal-ip
+        pytest.skip(
+            "Live Memgraph at 192.168.86.201:7687 not reachable"
+        )  # onex-allow-internal-ip
 
     try:
         from neo4j import GraphDatabase
     except ImportError:
         pytest.skip("neo4j package not installed")
 
-    driver = GraphDatabase.driver("bolt://192.168.86.201:7687", auth=None)  # onex-allow-internal-ip
+    driver = GraphDatabase.driver(
+        "bolt://192.168.86.201:7687", auth=None
+    )  # onex-allow-internal-ip
     try:
         counts = ingest_repo(driver, [_NODE_A, _NODE_B], [_LINK_AB])
         assert counts["nodes"] == 2

--- a/tests/integration/test_golden_chain_memgraph_ingestion.py
+++ b/tests/integration/test_golden_chain_memgraph_ingestion.py
@@ -250,24 +250,24 @@ class TestGoldenChainMemgraphParseCypher:
 @pytest.mark.integration
 @pytest.mark.memgraph
 def test_smoke_memgraph_live_ingest() -> None:
-    """Smoke test: live Memgraph on 192.168.86.201:7687.
+    """Smoke test: live Memgraph on 192.168.86.201:7687.  # onex-allow-internal-ip
 
     Skipped when Memgraph is unreachable.
     """
     import socket
 
     try:
-        sock = socket.create_connection(("192.168.86.201", 7687), timeout=2)
+        sock = socket.create_connection(("192.168.86.201", 7687), timeout=2)  # onex-allow-internal-ip
         sock.close()
     except OSError:
-        pytest.skip("Live Memgraph at 192.168.86.201:7687 not reachable")
+        pytest.skip("Live Memgraph at 192.168.86.201:7687 not reachable")  # onex-allow-internal-ip
 
     try:
         from neo4j import GraphDatabase
     except ImportError:
         pytest.skip("neo4j package not installed")
 
-    driver = GraphDatabase.driver("bolt://192.168.86.201:7687", auth=None)
+    driver = GraphDatabase.driver("bolt://192.168.86.201:7687", auth=None)  # onex-allow-internal-ip
     try:
         counts = ingest_repo(driver, [_NODE_A, _NODE_B], [_LINK_AB])
         assert counts["nodes"] == 2

--- a/tests/integration/test_golden_chain_qdrant_ingestion.py
+++ b/tests/integration/test_golden_chain_qdrant_ingestion.py
@@ -321,25 +321,25 @@ class TestGoldenChainQdrantErrors:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_smoke_qdrant_live_index_and_search() -> None:
-    """Smoke test: live Qdrant on 192.168.86.201:6333.
+    """Smoke test: live Qdrant on 192.168.86.201:6333.  # onex-allow-internal-ip
 
     Skipped when Qdrant is unreachable.
     """
     import socket
 
     try:
-        sock = socket.create_connection(("192.168.86.201", 6333), timeout=2)
+        sock = socket.create_connection(("192.168.86.201", 6333), timeout=2)  # onex-allow-internal-ip
         sock.close()
     except OSError:
-        pytest.skip("Live Qdrant at 192.168.86.201:6333 not reachable")
+        pytest.skip("Live Qdrant at 192.168.86.201:6333 not reachable")  # onex-allow-internal-ip
 
     handler = HandlerQdrant(
         config=ModelHandlerQdrantConfig(
-            qdrant_host="192.168.86.201",
+            qdrant_host="192.168.86.201",  # onex-allow-internal-ip
             qdrant_port=6333,
             collection_name="golden_chain_smoke_test",
             vector_size=4,
-            embedding_server_url="http://192.168.86.201:8002",
+            embedding_server_url="http://192.168.86.201:8002",  # onex-allow-internal-ip
             max_chunk_chars=2000,
         )
     )

--- a/tests/integration/test_golden_chain_qdrant_ingestion.py
+++ b/tests/integration/test_golden_chain_qdrant_ingestion.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2025 OmniNode Team
+"""Golden chain tests for Qdrant ingestion flow (OMN-8646).
+
+Validates the end-to-end path:
+  command input → HandlerQdrant.execute() → qdrant_client.upsert() / search()
+
+Tests (8 total):
+  Happy path:
+    1. test_index_command_calls_upsert_with_correct_args
+    2. test_index_two_chunks_upserts_twice
+    3. test_search_command_calls_embedding_then_qdrant_search
+    4. test_search_returns_mapped_results
+  Error paths:
+    5. test_index_adapter_raises_returns_error_response
+    6. test_search_embedding_raises_returns_error_response
+    7. test_execute_before_initialize_raises
+    8. test_unsupported_operation_returns_error_response
+
+Ticket: OMN-8646
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant import (
+    HandlerQdrant,
+)
+from omnimemory.nodes.node_memory_retrieval_effect.models import (
+    ModelHandlerQdrantConfig,
+    ModelMemoryRetrievalRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VECTOR_SIZE = 4
+_EMBEDDING = [0.1, 0.2, 0.3, 0.4]
+
+
+def _make_config() -> ModelHandlerQdrantConfig:
+    return ModelHandlerQdrantConfig(
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="test_col",
+        vector_size=_VECTOR_SIZE,
+        embedding_server_url="http://localhost:8100",
+        max_chunk_chars=2000,
+    )
+
+
+def _make_qdrant_mock() -> MagicMock:
+    client = MagicMock()
+    client.collection_exists = MagicMock(return_value=True)
+    client.create_collection = MagicMock()
+    client.search = MagicMock(return_value=[])
+    client.upsert = MagicMock()
+    client.close = MagicMock()
+    return client
+
+
+def _make_embedding_mock(vector: list[float] | None = None) -> AsyncMock:
+    emb = AsyncMock()
+    emb.connect = AsyncMock()
+    emb.close = AsyncMock()
+    emb.get_embedding = AsyncMock(return_value=vector or _EMBEDDING)
+    return emb
+
+
+async def _to_thread_passthrough(fn, *args, **kwargs):  # type: ignore[no-untyped-def]
+    """Drop-in for asyncio.to_thread that calls the function synchronously."""
+    return fn(*args, **kwargs)
+
+
+def _initialized_handler(
+    qdrant: MagicMock | None = None,
+    emb: AsyncMock | None = None,
+) -> HandlerQdrant:
+    """Return a HandlerQdrant already marked initialized with injected mocks."""
+    handler = HandlerQdrant(config=_make_config())
+    handler._initialized = True
+    handler._qdrant_client = qdrant or _make_qdrant_mock()
+    handler._embedding_client = emb or _make_embedding_mock()
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Happy path — index (upsert) flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainQdrantIndex:
+    """Golden chain: index command → HandlerQdrant → qdrant_client.upsert()."""
+
+    @pytest.mark.asyncio
+    async def test_index_command_calls_upsert_with_correct_args(self) -> None:
+        """Single-chunk document: upsert called once with deterministic point ID."""
+        qdrant = _make_qdrant_mock()
+        emb = _make_embedding_mock()
+        handler = _initialized_handler(qdrant=qdrant, emb=emb)
+
+        request = SimpleNamespace(
+            operation="index", document_id="doc-abc", content="Hello world."
+        )
+
+        with patch(
+            "omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant.asyncio.to_thread",
+            new=_to_thread_passthrough,
+        ):
+            response = await handler.execute(request)
+
+        assert response.status == "success"
+        assert qdrant.upsert.call_count == 1
+
+        call_kwargs = qdrant.upsert.call_args.kwargs
+        assert call_kwargs["collection_name"] == "test_col"
+        point = call_kwargs["points"][0]
+        expected_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, "doc-abc:0"))
+        assert point.id == expected_id
+        assert point.vector == _EMBEDDING
+        assert point.payload["document_id"] == "doc-abc"
+
+    @pytest.mark.asyncio
+    async def test_index_two_chunks_upserts_twice(self) -> None:
+        """Two-paragraph document produces two upsert calls with sequential IDs."""
+        qdrant = _make_qdrant_mock()
+        emb = _make_embedding_mock()
+        handler = _initialized_handler(qdrant=qdrant, emb=emb)
+
+        content = "First paragraph.\n\nSecond paragraph."
+        request = SimpleNamespace(
+            operation="index", document_id="doc-xy", content=content
+        )
+
+        with patch(
+            "omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant.asyncio.to_thread",
+            new=_to_thread_passthrough,
+        ):
+            response = await handler.execute(request)
+
+        assert response.status == "success"
+        assert response.total_count == 2
+        assert qdrant.upsert.call_count == 2
+        assert emb.get_embedding.await_count == 2
+
+        ids = [c.kwargs["points"][0].id for c in qdrant.upsert.call_args_list]
+        assert ids[0] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "doc-xy:0"))
+        assert ids[1] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "doc-xy:1"))
+
+
+# ---------------------------------------------------------------------------
+# Happy path — search flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainQdrantSearch:
+    """Golden chain: search command → HandlerQdrant → embedding → qdrant.search()."""
+
+    @pytest.mark.asyncio
+    async def test_search_command_calls_embedding_then_qdrant_search(self) -> None:
+        """Search embeds query text and passes vector to qdrant.search."""
+        qdrant = _make_qdrant_mock()
+        qdrant.search = MagicMock(return_value=[])
+        emb = _make_embedding_mock(vector=[0.5, 0.5, 0.5, 0.5])
+        handler = _initialized_handler(qdrant=qdrant, emb=emb)
+
+        request = ModelMemoryRetrievalRequest(
+            operation="search", query_text="test query"
+        )
+
+        with patch(
+            "omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant.asyncio.to_thread",
+            new=_to_thread_passthrough,
+        ):
+            response = await handler.execute(request)
+
+        emb.get_embedding.assert_awaited_once_with("test query")
+        qdrant.search.assert_called_once()
+        call_args = qdrant.search.call_args
+        assert call_args.args[0] == "test_col"
+        assert call_args.kwargs["query_vector"] == [0.5, 0.5, 0.5, 0.5]
+
+        assert response.status == "no_results"
+        assert response.query_embedding_used == [0.5, 0.5, 0.5, 0.5]
+
+    @pytest.mark.asyncio
+    async def test_search_returns_mapped_results(self) -> None:
+        """Qdrant hits are mapped to ModelSearchResult with correct score/distance."""
+        fake_payload = {
+            "snapshot_id": "00000000-0000-0000-0000-000000000001",
+            "version": 1,
+            "corpus_id": None,
+            "parent_snapshot_id": None,
+            "subject": {
+                "subject_type": "agent",
+                "subject_id": "00000000-0000-0000-0000-000000000002",
+                "namespace": None,
+                "subject_key": None,
+            },
+            "decisions": [],
+            "failures": [],
+            "cost_ledger": {
+                "ledger_id": "00000000-0000-0000-0000-000000000003",
+                "budget_total": 100.0,
+                "budget_remaining": 100.0,
+                "entries": [],
+                "total_spent": 0.0,
+                "escalation_count": 0,
+                "last_escalation_reason": None,
+                "warning_threshold": 0.8,
+                "hard_ceiling": 1.0,
+            },
+            "execution_annotations": {},
+            "schema_version": "1.0.0",
+            "content_hash": "",
+            "created_at": "2025-01-01T00:00:00Z",
+            "tags": [],
+        }
+        fake_hit = MagicMock()
+        fake_hit.score = 0.85
+        fake_hit.payload = fake_payload
+
+        qdrant = _make_qdrant_mock()
+        qdrant.search = MagicMock(return_value=[fake_hit])
+        handler = _initialized_handler(qdrant=qdrant)
+
+        request = ModelMemoryRetrievalRequest(operation="search", query_text="find me")
+
+        with patch(
+            "omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant.asyncio.to_thread",
+            new=_to_thread_passthrough,
+        ):
+            response = await handler.execute(request)
+
+        assert response.status == "success"
+        assert len(response.results) == 1
+        assert response.results[0].score == 0.85
+        assert response.results[0].distance == pytest.approx(1.0 - 0.85)
+        assert response.total_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoldenChainQdrantErrors:
+    """Golden chain error paths: adapter raises → handler returns error response."""
+
+    @pytest.mark.asyncio
+    async def test_index_adapter_raises_returns_error_response(self) -> None:
+        """When qdrant.upsert raises, execute() propagates the exception."""
+        qdrant = _make_qdrant_mock()
+        qdrant.upsert = MagicMock(side_effect=RuntimeError("Qdrant unavailable"))
+        handler = _initialized_handler(qdrant=qdrant)
+
+        request = SimpleNamespace(
+            operation="index", document_id="doc-err", content="Some content."
+        )
+
+        with (
+            patch(
+                "omnimemory.nodes.node_memory_retrieval_effect.handlers.handler_qdrant.asyncio.to_thread",
+                new=_to_thread_passthrough,
+            ),
+            pytest.raises(RuntimeError, match="Qdrant unavailable"),
+        ):
+            await handler.execute(request)
+
+    @pytest.mark.asyncio
+    async def test_search_embedding_raises_returns_error_response(self) -> None:
+        """When embedding client raises, execute() propagates the exception."""
+        emb = _make_embedding_mock()
+        emb.get_embedding = AsyncMock(
+            side_effect=ConnectionError("embedding server down")
+        )
+        handler = _initialized_handler(emb=emb)
+
+        request = ModelMemoryRetrievalRequest(operation="search", query_text="hello")
+
+        with pytest.raises(ConnectionError, match="embedding server down"):
+            await handler.execute(request)
+
+    @pytest.mark.asyncio
+    async def test_execute_before_initialize_raises(self) -> None:
+        """execute() before initialize() raises RuntimeError with 'initialize'."""
+        handler = HandlerQdrant(config=_make_config())
+        request = ModelMemoryRetrievalRequest(operation="search", query_text="test")
+
+        with pytest.raises(RuntimeError, match="initialize"):
+            await handler.execute(request)
+
+    @pytest.mark.asyncio
+    async def test_unsupported_operation_returns_error_response(self) -> None:
+        """Unsupported operation returns error status without raising."""
+        handler = _initialized_handler()
+        request = SimpleNamespace(operation="delete")
+
+        response = await handler.execute(request)
+
+        assert response.status == "error"
+        assert "unsupported operation" in (response.error_message or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Optional smoke test (live Qdrant on .201)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_smoke_qdrant_live_index_and_search() -> None:
+    """Smoke test: live Qdrant on 192.168.86.201:6333.
+
+    Skipped when Qdrant is unreachable.
+    """
+    import socket
+
+    try:
+        sock = socket.create_connection(("192.168.86.201", 6333), timeout=2)
+        sock.close()
+    except OSError:
+        pytest.skip("Live Qdrant at 192.168.86.201:6333 not reachable")
+
+    handler = HandlerQdrant(
+        config=ModelHandlerQdrantConfig(
+            qdrant_host="192.168.86.201",
+            qdrant_port=6333,
+            collection_name="golden_chain_smoke_test",
+            vector_size=4,
+            embedding_server_url="http://192.168.86.201:8002",
+            max_chunk_chars=2000,
+        )
+    )
+    try:
+        await handler.initialize()
+    except Exception as exc:
+        pytest.skip(f"Live Qdrant initialization failed (auth/config): {exc}")
+    try:
+        req = SimpleNamespace(
+            operation="index",
+            document_id="smoke-test-doc",
+            content="Smoke test paragraph one.\n\nSmoke test paragraph two.",
+        )
+        response = await handler.execute(req)
+        assert response.status == "success"
+        assert response.total_count == 2
+    finally:
+        await handler.shutdown()

--- a/tests/integration/test_golden_chain_qdrant_ingestion.py
+++ b/tests/integration/test_golden_chain_qdrant_ingestion.py
@@ -328,10 +328,14 @@ async def test_smoke_qdrant_live_index_and_search() -> None:
     import socket
 
     try:
-        sock = socket.create_connection(("192.168.86.201", 6333), timeout=2)  # onex-allow-internal-ip
+        sock = socket.create_connection(
+            ("192.168.86.201", 6333), timeout=2
+        )  # onex-allow-internal-ip
         sock.close()
     except OSError:
-        pytest.skip("Live Qdrant at 192.168.86.201:6333 not reachable")  # onex-allow-internal-ip
+        pytest.skip(
+            "Live Qdrant at 192.168.86.201:6333 not reachable"
+        )  # onex-allow-internal-ip
 
     handler = HandlerQdrant(
         config=ModelHandlerQdrantConfig(

--- a/tests/integration/test_golden_chain_qdrant_ingestion.py
+++ b/tests/integration/test_golden_chain_qdrant_ingestion.py
@@ -321,29 +321,27 @@ class TestGoldenChainQdrantErrors:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_smoke_qdrant_live_index_and_search() -> None:
-    """Smoke test: live Qdrant on 192.168.86.201:6333.  # onex-allow-internal-ip
+    """Smoke test: live Qdrant on the dev host (port 6333).
 
     Skipped when Qdrant is unreachable.
     """
     import socket
 
+    _host = "192.168.86.201"  # onex-allow-internal-ip
+    _emb_url = f"http://{_host}:8002"  # onex-allow-internal-ip
     try:
-        sock = socket.create_connection(
-            ("192.168.86.201", 6333), timeout=2
-        )  # onex-allow-internal-ip
+        sock = socket.create_connection((_host, 6333), timeout=2)
         sock.close()
     except OSError:
-        pytest.skip(
-            "Live Qdrant at 192.168.86.201:6333 not reachable"
-        )  # onex-allow-internal-ip
+        pytest.skip(f"Live Qdrant at {_host}:6333 not reachable")
 
     handler = HandlerQdrant(
         config=ModelHandlerQdrantConfig(
-            qdrant_host="192.168.86.201",  # onex-allow-internal-ip
+            qdrant_host=_host,
             qdrant_port=6333,
             collection_name="golden_chain_smoke_test",
             vector_size=4,
-            embedding_server_url="http://192.168.86.201:8002",  # onex-allow-internal-ip
+            embedding_server_url=_emb_url,
             max_chunk_chars=2000,
         )
     )


### PR DESCRIPTION
## Summary

Closes the audit-identified gap (OMN-8646, parent: OMN-8541) where Wave 2 storage shipped without end-to-end tests covering the command → handler → adapter.store() path.

- **test_golden_chain_qdrant_ingestion.py** (8 tests): validates `HandlerQdrant.execute()` index/search flows against a mock `qdrant_client` — deterministic point IDs, embedding call chain, result mapping, and error propagation
- **test_golden_chain_memgraph_ingestion.py** (9 tests): validates `graphify_to_memgraph.ingest_repo()` → `driver.session` → `tx.run()` path — batch flush logic, parse/cypher layer, error propagation. Includes `@pytest.mark.memgraph` smoke test gated on live `.201:7687` reachability

All 17 mock tests pass; 2 live smoke tests skip gracefully when infra is unreachable.

## Test plan

- [x] 2707 tests passing (0 regressions)
- [x] `uv run ruff format` + `uv run ruff check --fix` clean
- [x] mypy clean on new files
- [x] Live Qdrant smoke skips on 401 (auth not configured here)
- [x] Live Memgraph smoke passes on `.201:7687`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the Memgraph ingestion golden-chain: node/edge ingestion, batching, parsing/Cypher behavior, error propagation, and optional live smoke test.
  * Added comprehensive integration tests for the Qdrant ingestion golden-chain: indexing and search flows, multi-chunk handling, embedding interactions, error propagation, unsupported-op handling, and optional live smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->