### PR TITLE
chore(nodes): strip onex.node_package entry point post-migration [OMN-8302]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "omninode-memory"
 version = "0.15.0"
-description = "OmniNode document ingestion and semantic retrieval"
+description = "OmniNode memory primitives — models, protocols, and storage adapters for Qdrant, Memgraph, and PostgreSQL backends."
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 license = { text = "MIT" }
@@ -89,9 +89,6 @@ Changelog = "https://github.com/OmniNode-ai/omnimemory/blob/main/CHANGELOG.md"
 
 [project.entry-points."onex.domain_plugins"]
 memory = "omnimemory.runtime.plugin:PluginMemory"
-
-[project.entry-points."onex.node_package"]
-omnimemory = "omnimemory.nodes"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/omnimemory"]

--- a/src/omnimemory/nodes/__init__.py
+++ b/src/omnimemory/nodes/__init__.py
@@ -2,26 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2025 OmniNode Team
-"""OmniMemory ONEX Nodes - Core 8 Foundation.
+"""OmniMemory nodes package — base classes and storage adapters.
 
-This package contains the Core 8 ONEX-compliant nodes for omnimemory:
-
-EFFECT (2):
-- node_memory_storage_effect: CRUD operations to storage backends
-- node_memory_retrieval_effect: Semantic/temporal/contextual search
-
-COMPUTE (2):
-- node_semantic_analyzer_compute: Semantic analysis and embeddings
-- node_similarity_compute: Vector similarity calculations
-
-REDUCER (3):
-- node_memory_consolidator_reducer: Merge similar memories
-- node_statistics_reducer: Generate memory statistics
-- node_navigation_history_reducer: Persist navigation sessions (OMN-2584)
-
-ORCHESTRATOR (2):
-- node_memory_lifecycle_orchestrator: Full lifecycle management
-- node_agent_coordinator_orchestrator: Cross-agent coordination
+Node handlers have migrated to omnimarket. This package retains only
+the base classes used by storage adapters within omnimemory.
 """
 
 from omnimemory.nodes.base import (
@@ -32,57 +16,12 @@ from omnimemory.nodes.base import (
     BaseReducerNode,
     ContainerType,
 )
-from omnimemory.nodes.node_filesystem_crawler_effect import (
-    HandlerFilesystemCrawler,
-    ModelFilesystemCrawlerConfig,
-    ModelFilesystemCrawlResult,  # omnimemory-model-exempt: handler result
-)
-from omnimemory.nodes.node_intent_event_consumer_effect import (
-    HandlerIntentEventConsumer,
-    ModelIntentEventConsumerConfig,
-    ModelIntentEventConsumerHealth,
-)
-from omnimemory.nodes.node_navigation_history_reducer import (
-    HandlerNavigationHistoryReducer,
-    ModelNavigationHistoryRequest,
-    ModelNavigationHistoryResponse,
-    ModelNavigationSession,
-    ModelPlanStep,
-    NavigationOutcome,
-    NodeNavigationHistoryReducer,
-)
 
 __all__: list[str] = [
-    # Base classes
     "BaseNode",
     "BaseEffectNode",
     "BaseComputeNode",
     "BaseReducerNode",
     "BaseOrchestratorNode",
     "ContainerType",
-    # Effect nodes
-    "node_memory_storage_effect",
-    "node_memory_retrieval_effect",
-    "HandlerIntentEventConsumer",
-    "ModelIntentEventConsumerConfig",
-    "ModelIntentEventConsumerHealth",
-    "HandlerFilesystemCrawler",
-    "ModelFilesystemCrawlResult",
-    "ModelFilesystemCrawlerConfig",
-    # Compute nodes
-    "node_semantic_analyzer_compute",
-    "node_similarity_compute",
-    # Reducer nodes
-    "node_memory_consolidator_reducer",
-    "node_statistics_reducer",
-    "NodeNavigationHistoryReducer",
-    "HandlerNavigationHistoryReducer",
-    "ModelNavigationHistoryRequest",
-    "ModelNavigationHistoryResponse",
-    "ModelNavigationSession",
-    "ModelPlanStep",
-    "NavigationOutcome",
-    # Orchestrator nodes
-    "node_memory_lifecycle_orchestrator",
-    "node_agent_coordinator_orchestrator",
 ]

--- a/tests/test_node_imports.py
+++ b/tests/test_node_imports.py
@@ -51,21 +51,38 @@ class TestNodeImports:
             # Expected during scaffold phase
             pytest.skip(f"Node package pending implementation: {e}")
 
-    def test_nodes_package_exports_core_nodes(self) -> None:
-        """Verify __all__ in nodes package lists all Core 8 nodes.
+    def test_nodes_package_exports_base_classes(self) -> None:
+        """Verify __all__ in nodes package exports base classes only.
 
-        The nodes package __init__.py should export all Core 8 node
-        names in its __all__ list for proper package discoverability.
+        After node migration to omnimarket (OMN-8302), the nodes package
+        __init__.py retains only base class re-exports used by storage
+        adapters.  Individual node handler names must NOT appear in __all__.
         """
+        expected_base_classes = {
+            "BaseNode",
+            "BaseEffectNode",
+            "BaseComputeNode",
+            "BaseReducerNode",
+            "BaseOrchestratorNode",
+            "ContainerType",
+        }
         try:
             from omnimemory.nodes import __all__ as nodes_all
 
+            nodes_all_set = set(nodes_all)
+            for cls_name in expected_base_classes:
+                assert cls_name in nodes_all_set, (
+                    f"Base class {cls_name!r} missing from nodes __all__"
+                )
+            # Node handler names must not be exported from the package root
             for node_name in CORE_8_NODES:
-                # Only check nodes whose directories exist
                 node_dir: Path = NODES_DIR / node_name
                 if not node_dir.exists():
                     continue
-                assert node_name in nodes_all, f"Missing from __all__: {node_name}"
+                assert node_name not in nodes_all_set, (
+                    f"Node handler {node_name!r} must not be in __all__ "
+                    f"after migration (OMN-8302)"
+                )
         except ImportError:
             pytest.skip("nodes package not properly configured")
 

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
-"""Tests for onex.node_package entry point declaration."""
+"""Tests verifying onex.node_package entry point is absent post-migration.
+
+After all nodes migrated to omnimarket (OMN-8302), omnimemory no longer
+declares an onex.node_package entry point.  The runtime must not attempt
+to discover handlers from this package.
+"""
 
 import importlib.metadata
 
@@ -8,17 +13,11 @@ import pytest
 
 
 @pytest.mark.unit
-def test_node_package_entry_point_declared() -> None:
-    """onex.node_package entry point must be declared and importable."""
+def test_node_package_entry_point_absent() -> None:
+    """onex.node_package entry point must NOT be declared after migration."""
     eps = importlib.metadata.entry_points(group="onex.node_package")
     names = [ep.name for ep in eps]
-    assert "omnimemory" in names, f"Expected 'omnimemory' in {names}"
-
-
-@pytest.mark.unit
-def test_node_package_entry_point_loads() -> None:
-    """Entry point value must be an importable package."""
-    eps = importlib.metadata.entry_points(group="onex.node_package")
-    ep = next(ep for ep in eps if ep.name == "omnimemory")
-    pkg = ep.load()
-    assert hasattr(pkg, "__path__"), "Entry point must resolve to a package"
+    assert "omnimemory" not in names, (
+        "omnimemory must not declare onex.node_package after node migration "
+        f"(OMN-8302). Found: {names}"
+    )

--- a/tests/unit/test_graphify_to_memgraph.py
+++ b/tests/unit/test_graphify_to_memgraph.py
@@ -166,6 +166,5 @@ def test_default_graph_dir_falls_back_to_repo_root(
     monkeypatch.delenv("OMNI_HOME", raising=False)
     result = _default_graph_dir()
     assert result == _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"
-    assert "/Volumes/PRO-G40/" not in str(result)
     assert result.parts[-1] == "graphify-graphs"
     assert result.parts[-2] == ".onex_state"


### PR DESCRIPTION
## Summary

- Removes `[project.entry-points."onex.node_package"]` from `pyproject.toml` so the runtime no longer attempts to discover handlers from `omnimemory.nodes` after all 17 nodes migrated to omnimarket (Waves 1–5)
- Updates package description to reflect the new role as memory primitives / storage adapters
- Strips handler re-exports from `nodes/__init__.py`; retains only base classes used by storage adapters
- Updates tests to assert the entry point is absent (not present), and to verify base classes (not node handler names) are in `__all__`
- Fixes a pre-existing machine-specific path assertion in `test_graphify_to_memgraph.py` that always failed on `/Volumes/PRO-G40/` machines

## Ticket

Closes OMN-8302

## Test plan

- [x] `uv run pytest tests/ -v` — 2688 passed, 220 skipped, 0 failed
- [x] `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — all checks passed
- [x] `pre-commit run --all-files` — all hooks passed
- [x] `importlib.metadata.entry_points(group="onex.node_package")` returns no omnimemory entries (verified by updated test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified module exports to expose only foundational base classes and core utilities.
  * Removed legacy entry point declarations to streamline package structure.
  * Updated package description to explicitly document supported storage backends (Qdrant, Memgraph, PostgreSQL).

* **Tests**
  * Updated tests to reflect reorganized entry point configuration and module exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->