### PR TITLE
feat: graphify Memgraph + Qdrant ingestion pipelines [OMN-8541]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,9 @@ dependencies = [
 [project.optional-dependencies]
 graph = [
     "neo4j>=5.0.0,<6.0.0",
-    # qdrant-client and httpx are already in core dependencies
+    # qdrant-client ceiling held at <1.18.0 (see core dep comment re: Python 3.12 TypeError)
+    "qdrant-client>=1.9.0,<1.18.0",
+    "httpx>=0.27.0,<1.0.0",
 ]
 
 [project.urls]

--- a/scripts/graphify_to_memgraph.py
+++ b/scripts/graphify_to_memgraph.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -179,6 +180,9 @@ def main() -> None:
         logger.error("neo4j package not installed — run: uv sync --extra graph")
         sys.exit(1)
 
+    correlation_id = str(uuid.uuid4())
+    logger.info("Starting ingestion run correlation_id=%s", correlation_id)
+
     driver = GraphDatabase.driver(args.bolt_uri, auth=None)
     try:
         total_nodes = 0
@@ -194,7 +198,8 @@ def main() -> None:
             total_nodes += counts["nodes"]
             total_edges += counts["edges"]
         logger.info(
-            "Done. Total: %d nodes, %d edges across %d repos",
+            "Done. correlation_id=%s total_nodes=%d total_edges=%d repos=%d",
+            correlation_id,
             total_nodes,
             total_edges,
             len(graph_files),

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -6,7 +6,7 @@
 
 For each node, builds a rich embedding text from label, source_file, community,
 repo, node_type, relations, protocols, and contract refs, then embeds via the
-Qwen3-Embedding model (default; configurable via --embedding-model) and upserts
+gte-Qwen2-1.5B-instruct model (default; configurable via --embedding-model) and upserts
 into a Qdrant collection.
 
 Usage:
@@ -120,7 +120,7 @@ def chunk_nodes(
 def embed_batch(
     texts: list[str],
     embedding_url: str,
-    model: str = "Qwen3-Embedding",
+    model: str = "Alibaba-NLP/gte-Qwen2-1.5B-instruct",
 ) -> list[list[float]]:
     """Call the embedding API with retry/backoff. Returns list of embedding vectors."""
     try:

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -6,7 +6,8 @@
 
 For each node, builds a rich embedding text from label, source_file, community,
 repo, node_type, relations, protocols, and contract refs, then embeds via the
-Qwen3-Embedding model and upserts into a Qdrant collection.
+Qwen3-Embedding model (default; configurable via --embedding-model) and upserts
+into a Qdrant collection.
 
 Usage:
     uv run python scripts/graphify_to_qdrant.py \\
@@ -24,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -118,7 +120,7 @@ def chunk_nodes(
 def embed_batch(
     texts: list[str],
     embedding_url: str,
-    model: str = "gte-Qwen2-1.5B",
+    model: str = "Qwen3-Embedding",
 ) -> list[list[float]]:
     """Call the embedding API with retry/backoff. Returns list of embedding vectors."""
     try:
@@ -139,7 +141,12 @@ def embed_batch(
             )
             resp.raise_for_status()
             data = resp.json()
-            return [item["embedding"] for item in data["data"]]
+            embeddings = [item["embedding"] for item in data["data"]]
+            if len(embeddings) != len(texts):
+                raise RuntimeError(
+                    f"Embedding response size mismatch: expected {len(texts)}, got {len(embeddings)}"
+                )
+            return embeddings
         except Exception as exc:
             last_exc = exc
             if attempt < EMBED_RETRY_ATTEMPTS - 1:
@@ -162,6 +169,16 @@ def embed_batch(
     raise RuntimeError(f"Embedding failed after {EMBED_RETRY_ATTEMPTS} attempts") from last_exc
 
 
+def _stable_point_id(node_id: str) -> int:
+    """Return a stable, deterministic Qdrant point ID for a node ID string.
+
+    Uses blake2b so the same node_id produces the same integer across
+    interpreter processes (unlike Python's salted built-in hash).
+    """
+    digest = hashlib.blake2b(node_id.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="big", signed=False) % (2**63)
+
+
 def upsert_to_qdrant(
     client: Any,
     collection: str,
@@ -173,7 +190,7 @@ def upsert_to_qdrant(
 
     points = [
         PointStruct(
-            id=abs(hash(node["id"])) % (2**63),
+            id=_stable_point_id(node["id"]),
             vector=vector,
             payload={
                 "id": node["id"],

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 import time
 import uuid
@@ -48,6 +49,19 @@ def _default_graph_dir() -> Path:
     if omni_home:
         return Path(omni_home) / ".onex_state" / "graphify-graphs"
     return _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"
+
+
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+_PHONE_RE = re.compile(r"(?:\+?1[\s\-.]?)?\(?\d{3}\)?[\s\-.]?\d{3}[\s\-.]?\d{4}")
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+def screen_or_redact_pii(text: str) -> str:
+    """Strip emails, phone numbers, and SSN patterns from text before embedding."""
+    text = _EMAIL_RE.sub("[EMAIL]", text)
+    text = _PHONE_RE.sub("[PHONE]", text)
+    text = _SSN_RE.sub("[SSN]", text)
+    return text
 
 
 def build_embedding_text(node: dict[str, Any]) -> str:
@@ -163,9 +177,9 @@ def upsert_to_qdrant(
             vector=vector,
             payload={
                 "id": node["id"],
-                "label": node.get("label", ""),
+                "label": screen_or_redact_pii(node.get("label", "")),
                 "repo": node.get("repo", ""),
-                "source_file": node.get("source_file", ""),
+                "source_file": screen_or_redact_pii(node.get("source_file", "")),
                 "node_type": node.get("node_type", ""),
                 "community": node.get("community", ""),
             },
@@ -210,9 +224,17 @@ def main() -> None:
         default=os.environ.get("QDRANT_URL", "http://localhost:6333"),
         help="Qdrant base URL (env: QDRANT_URL)",
     )
+    _embedding_url = os.environ.get("EMBEDDING_MODEL_URL")
+    if not _embedding_url and "--embedding-url" not in sys.argv:
+        logger.error(
+            "EMBEDDING_MODEL_URL env var is required but not set. "
+            "Pass --embedding-url or set EMBEDDING_MODEL_URL."
+        )
+        sys.exit(1)
     parser.add_argument(
         "--embedding-url",
-        default=os.environ.get("EMBEDDING_MODEL_URL", "http://192.168.86.200:8100"),
+        default=_embedding_url,
+        required=_embedding_url is None,
         help="Embedding model base URL (env: EMBEDDING_MODEL_URL)",
     )
     parser.add_argument(
@@ -258,7 +280,7 @@ def main() -> None:
         repo_upserted = 0
 
         for batch in chunk_nodes(nodes, batch_size=UPSERT_BATCH_SIZE):
-            texts = [build_embedding_text(n) for n in batch]
+            texts = [screen_or_redact_pii(build_embedding_text(n)) for n in batch]
             try:
                 vectors = embed_batch(texts, args.embedding_url)
             except RuntimeError as exc:

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -12,13 +12,13 @@ into a Qdrant collection.
 Usage:
     uv run python scripts/graphify_to_qdrant.py \\
         --graph-dir /path/to/graphify-graphs/ \\
-        --qdrant-url http://192.168.86.201:6333 \\
-        --embedding-url http://192.168.86.200:8100 \\
+        --qdrant-url http://localhost:6333 \\
+        --embedding-url http://localhost:8100 \\
         --collection onex-graphify
 
     # Or via env vars:
-    QDRANT_URL=http://192.168.86.201:6333 \\
-    EMBEDDING_MODEL_URL=http://192.168.86.200:8100 \\
+    QDRANT_URL=http://localhost:6333 \\
+    EMBEDDING_MODEL_URL=http://localhost:8100 \\
     uv run python scripts/graphify_to_qdrant.py
 """
 
@@ -242,12 +242,6 @@ def main() -> None:
         help="Qdrant base URL (env: QDRANT_URL)",
     )
     _embedding_url = os.environ.get("EMBEDDING_MODEL_URL")
-    if not _embedding_url and "--embedding-url" not in sys.argv:
-        logger.error(
-            "EMBEDDING_MODEL_URL env var is required but not set. "
-            "Pass --embedding-url or set EMBEDDING_MODEL_URL."
-        )
-        sys.exit(1)
     parser.add_argument(
         "--embedding-url",
         default=_embedding_url,

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Embed graphify graph.json node descriptions into Qdrant.
+
+For each node, builds a rich embedding text from label, source_file, community,
+repo, node_type, relations, protocols, and contract refs, then embeds via the
+Qwen3-Embedding model and upserts into a Qdrant collection.
+
+Usage:
+    uv run python scripts/graphify_to_qdrant.py \\
+        --graph-dir /path/to/graphify-graphs/ \\
+        --qdrant-url http://192.168.86.201:6333 \\
+        --embedding-url http://192.168.86.200:8100 \\
+        --collection onex-graphify
+
+    # Or via env vars:
+    QDRANT_URL=http://192.168.86.201:6333 \\
+    EMBEDDING_MODEL_URL=http://192.168.86.200:8100 \\
+    uv run python scripts/graphify_to_qdrant.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+UPSERT_BATCH_SIZE = 100
+EMBED_RETRY_ATTEMPTS = 3
+EMBED_BACKOFF_SECONDS = [1, 2, 4]
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _default_graph_dir() -> Path:
+    omni_home = os.environ.get("OMNI_HOME")
+    if omni_home:
+        return Path(omni_home) / ".onex_state" / "graphify-graphs"
+    return _REPO_ROOT.parent / ".onex_state" / "graphify-graphs"
+
+
+def build_embedding_text(node: dict[str, Any]) -> str:
+    """Build a rich text representation of a node for embedding.
+
+    Combines label, source_file, community, repo, node_type, relations,
+    protocols, and contract_refs into a single string.
+    """
+    parts: list[str] = []
+
+    label = node.get("label", "")
+    if label:
+        parts.append(f"label: {label}")
+
+    source_file = node.get("source_file", "")
+    if source_file:
+        parts.append(f"source: {source_file}")
+
+    community = node.get("community", "")
+    if community:
+        parts.append(f"community: {community}")
+
+    repo = node.get("repo", node.get("id", "").split("::")[0] if "::" in node.get("id", "") else "")
+    if repo:
+        parts.append(f"repo: {repo}")
+
+    node_type = node.get("node_type", "")
+    if node_type:
+        parts.append(f"type: {node_type}")
+
+    relations: list[str] = node.get("relations", [])
+    if relations:
+        parts.append("relations: " + ", ".join(relations))
+
+    protocols: list[str] = node.get("protocols", [])
+    if protocols:
+        parts.append("protocols: " + ", ".join(protocols))
+
+    contract_refs: list[str] = node.get("contract_refs", [])
+    if contract_refs:
+        parts.append("contracts: " + ", ".join(contract_refs))
+
+    return " | ".join(parts)
+
+
+def chunk_nodes(
+    nodes: list[dict[str, Any]], batch_size: int = UPSERT_BATCH_SIZE
+) -> Generator[list[dict[str, Any]], None, None]:
+    """Yield successive batch_size-sized chunks from nodes."""
+    for i in range(0, len(nodes), batch_size):
+        yield nodes[i : i + batch_size]
+
+
+def embed_batch(
+    texts: list[str],
+    embedding_url: str,
+    model: str = "gte-Qwen2-1.5B",
+) -> list[list[float]]:
+    """Call the embedding API with retry/backoff. Returns list of embedding vectors."""
+    try:
+        import httpx
+    except ImportError:
+        logger.error("httpx not installed — run: uv sync --extra graph")
+        sys.exit(1)
+
+    payload = {"model": model, "input": texts}
+    last_exc: Exception | None = None
+
+    for attempt, backoff in enumerate(EMBED_BACKOFF_SECONDS):
+        try:
+            resp = httpx.post(
+                f"{embedding_url}/v1/embeddings",
+                json=payload,
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return [item["embedding"] for item in data["data"]]
+        except Exception as exc:
+            last_exc = exc
+            if attempt < EMBED_RETRY_ATTEMPTS - 1:
+                logger.warning(
+                    "Embedding attempt %d/%d failed: %s — retrying in %ds",
+                    attempt + 1,
+                    EMBED_RETRY_ATTEMPTS,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
+            else:
+                logger.warning(
+                    "Embedding exhausted %d attempts for batch of %d texts: %s — skipping",
+                    EMBED_RETRY_ATTEMPTS,
+                    len(texts),
+                    exc,
+                )
+
+    raise RuntimeError(f"Embedding failed after {EMBED_RETRY_ATTEMPTS} attempts") from last_exc
+
+
+def upsert_to_qdrant(
+    client: Any,
+    collection: str,
+    nodes: list[dict[str, Any]],
+    vectors: list[list[float]],
+) -> int:
+    """Upsert node+vector pairs into Qdrant. Returns count upserted."""
+    from qdrant_client.models import PointStruct  # type: ignore[import-untyped]
+
+    points = [
+        PointStruct(
+            id=abs(hash(node["id"])) % (2**63),
+            vector=vector,
+            payload={
+                "id": node["id"],
+                "label": node.get("label", ""),
+                "repo": node.get("repo", ""),
+                "source_file": node.get("source_file", ""),
+                "node_type": node.get("node_type", ""),
+                "community": node.get("community", ""),
+            },
+        )
+        for node, vector in zip(nodes, vectors, strict=True)
+    ]
+    client.upsert(collection_name=collection, points=points)
+    return len(points)
+
+
+def _ensure_collection(client: Any, collection: str, vector_size: int) -> None:
+    from qdrant_client.models import (  # type: ignore[import-untyped]
+        Distance,
+        VectorParams,
+    )
+
+    existing = {c.name for c in client.get_collections().collections}
+    if collection not in existing:
+        client.create_collection(
+            collection_name=collection,
+            vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+        )
+        logger.info("Created Qdrant collection '%s' (dim=%d)", collection, vector_size)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Embed graphify graph.json nodes into Qdrant"
+    )
+    parser.add_argument(
+        "--graph-dir",
+        default=None,
+        help=(
+            "Directory containing per-repo graph.json files. "
+            "Defaults to $OMNI_HOME/.onex_state/graphify-graphs/"
+        ),
+    )
+    parser.add_argument(
+        "--qdrant-url",
+        default=os.environ.get("QDRANT_URL", "http://localhost:6333"),
+        help="Qdrant base URL (env: QDRANT_URL)",
+    )
+    parser.add_argument(
+        "--embedding-url",
+        default=os.environ.get("EMBEDDING_MODEL_URL", "http://192.168.86.200:8100"),
+        help="Embedding model base URL (env: EMBEDDING_MODEL_URL)",
+    )
+    parser.add_argument(
+        "--collection",
+        default=os.environ.get("QDRANT_COLLECTION", "onex-graphify"),
+        help="Qdrant collection name (env: QDRANT_COLLECTION)",
+    )
+    args = parser.parse_args()
+
+    graph_dir = Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
+    if not graph_dir.is_dir():
+        logger.error("graph-dir does not exist: %s", graph_dir)
+        sys.exit(1)
+
+    graph_files = sorted(graph_dir.rglob("graph.json"))
+    if not graph_files:
+        logger.error("No graph.json files found under %s", graph_dir)
+        sys.exit(1)
+
+    try:
+        from qdrant_client import QdrantClient  # type: ignore[import-untyped]
+    except ImportError:
+        logger.error("qdrant-client not installed — run: uv sync --extra graph")
+        sys.exit(1)
+
+    correlation_id = str(uuid.uuid4())
+    logger.info("Starting embedding run correlation_id=%s", correlation_id)
+
+    qdrant = QdrantClient(url=args.qdrant_url)
+    collection_created = False
+    total_upserted = 0
+
+    for graph_file in graph_files:
+        repo_name = graph_file.parent.name
+        with open(graph_file) as f:
+            data = json.load(f)
+        nodes: list[dict[str, Any]] = data.get("nodes", [])
+        if not nodes:
+            logger.info("  %s: no nodes, skipping", repo_name)
+            continue
+
+        logger.info("  %s: embedding %d nodes ...", repo_name, len(nodes))
+        repo_upserted = 0
+
+        for batch in chunk_nodes(nodes, batch_size=UPSERT_BATCH_SIZE):
+            texts = [build_embedding_text(n) for n in batch]
+            try:
+                vectors = embed_batch(texts, args.embedding_url)
+            except RuntimeError as exc:
+                logger.warning("Skipping batch in %s: %s", repo_name, exc)
+                continue
+
+            if not collection_created:
+                _ensure_collection(qdrant, args.collection, len(vectors[0]))
+                collection_created = True
+
+            repo_upserted += upsert_to_qdrant(qdrant, args.collection, batch, vectors)
+
+        logger.info("  %s: upserted %d points", repo_name, repo_upserted)
+        total_upserted += repo_upserted
+
+    logger.info(
+        "Done. correlation_id=%s total_upserted=%d repos=%d",
+        correlation_id,
+        total_upserted,
+        len(graph_files),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_graphify_to_qdrant.py
+++ b/tests/unit/test_graphify_to_qdrant.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for graphify_to_qdrant script.
+
+Tests build_embedding_text and chunk_nodes without requiring live services.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.graphify_to_qdrant import build_embedding_text, chunk_nodes
+
+SAMPLE_NODE_FULL = {
+    "id": "omniclaude::node_delegation_orchestrator",
+    "label": "node_delegation_orchestrator",
+    "repo": "omniclaude",
+    "source_file": "src/omniclaude/nodes/node_delegation_orchestrator/__init__.py",
+    "node_type": "handler",
+    "community": "delegation",
+    "relations": ["calls:node_quality_gate", "subscribes:onex.cmd.delegate.v1"],
+    "protocols": ["DelegationProtocol"],
+    "contract_refs": ["contract.yaml#dispatch"],
+}
+
+SAMPLE_NODE_MINIMAL = {
+    "id": "omniclaude::bare_node",
+    "label": "bare_node",
+}
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_label() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "node_delegation_orchestrator" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_repo() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "omniclaude" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_source_file() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "node_delegation_orchestrator/__init__.py" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_community() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "delegation" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_node_type() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "handler" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_relations() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "calls:node_quality_gate" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_protocols() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "DelegationProtocol" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_includes_contract_refs() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert "contract.yaml#dispatch" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_handles_missing_optional_fields() -> None:
+    text = build_embedding_text(SAMPLE_NODE_MINIMAL)
+    assert "bare_node" in text
+    assert "omniclaude" in text
+
+
+@pytest.mark.unit
+def test_build_embedding_text_returns_string() -> None:
+    text = build_embedding_text(SAMPLE_NODE_FULL)
+    assert isinstance(text, str)
+    assert len(text) > 0
+
+
+@pytest.mark.unit
+def test_chunk_nodes_empty_list() -> None:
+    result = list(chunk_nodes([], batch_size=10))
+    assert result == []
+
+
+@pytest.mark.unit
+def test_chunk_nodes_single_batch() -> None:
+    nodes = [{"id": f"n{i}"} for i in range(5)]
+    chunks = list(chunk_nodes(nodes, batch_size=10))
+    assert len(chunks) == 1
+    assert chunks[0] == nodes
+
+
+@pytest.mark.unit
+def test_chunk_nodes_exact_multiple() -> None:
+    nodes = [{"id": f"n{i}"} for i in range(10)]
+    chunks = list(chunk_nodes(nodes, batch_size=5))
+    assert len(chunks) == 2
+    assert chunks[0] == nodes[:5]
+    assert chunks[1] == nodes[5:]
+
+
+@pytest.mark.unit
+def test_chunk_nodes_remainder() -> None:
+    nodes = [{"id": f"n{i}"} for i in range(7)]
+    chunks = list(chunk_nodes(nodes, batch_size=3))
+    assert len(chunks) == 3
+    assert chunks[0] == nodes[:3]
+    assert chunks[1] == nodes[3:6]
+    assert chunks[2] == nodes[6:]
+
+
+@pytest.mark.unit
+def test_chunk_nodes_batch_size_one() -> None:
+    nodes = [{"id": f"n{i}"} for i in range(3)]
+    chunks = list(chunk_nodes(nodes, batch_size=1))
+    assert len(chunks) == 3
+    for i, chunk in enumerate(chunks):
+        assert chunk == [nodes[i]]

--- a/uv.lock
+++ b/uv.lock
@@ -747,7 +747,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -756,7 +755,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1521,7 +1519,9 @@ dependencies = [
 
 [package.optional-dependencies]
 graph = [
+    { name = "httpx" },
     { name = "neo4j" },
+    { name = "qdrant-client" },
 ]
 
 [package.dev-dependencies]
@@ -1552,6 +1552,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=6.2.4,<8.0.0" },
     { name = "fastapi", specifier = ">=0.120.1,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
+    { name = "httpx", marker = "extra == 'graph'", specifier = ">=0.27.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
     { name = "omnibase-core", specifier = "==0.39.0" },
@@ -1565,6 +1566,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "qdrant-client", specifier = ">=1.7.0,<1.18.0" },
+    { name = "qdrant-client", marker = "extra == 'graph'", specifier = ">=1.9.0,<1.18.0" },
     { name = "redis", specifier = ">=6.4.0,<8.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0.0" },
     { name = "structlog", specifier = ">=23.3.0,<26.0.0" },


### PR DESCRIPTION
## Summary

- **Task 14**: Verified `omnimemory-memgraph` and `omnimemory-qdrant` containers already running healthy on .201 (22h uptime). bolt://192.168.86.201:7687 and http://192.168.86.201:6333/readyz both respond.
- **Task 15**: Added `graph` optional-dependency group to `pyproject.toml` (`neo4j>=5.0`, `qdrant-client>=1.9/<1.18.0`, `httpx>=0.27`). `uv sync --extra graph` succeeds.
- **Task 16**: Implemented `scripts/graphify_to_memgraph.py` with `parse_graphify_json`, `build_node_cypher` (MERGE on `id`), `build_edge_cypher`, `ingest_repo` (500/tx batching), `correlation_id` UUID logged per run. 11 unit tests, all passing.
- **Task 17**: **BLOCKED** — `.onex_state/graphify-graphs/` does not exist on .201 or locally. No graphify output has been generated yet. Data load cannot proceed until the graphify pipeline is run.
- **Task 18**: Implemented `scripts/graphify_to_qdrant.py` with `build_embedding_text` (label+source_file+community+repo+node_type+relations+protocols+contract_refs), `chunk_nodes`, `embed_batch` (3 attempts, exponential backoff 1/2/4s, skip+warn on exhaustion), `upsert_to_qdrant` (100/batch), `correlation_id` UUID per run. Env vars: `MEMGRAPH_URL`, `QDRANT_URL`, `EMBEDDING_MODEL_URL`, `QDRANT_COLLECTION`. 15 unit tests, all passing.
- **Task 19**: **BLOCKED** — same `.onex_state/graphify-graphs/` STOP condition as Task 17. Embedding endpoint at http://192.168.86.200:8100 is healthy (`Qwen3-Embedding-8B-4bit-DWQ`, dim=4096).

## Test results

```
tests/unit/test_graphify_to_memgraph.py  11 passed
tests/unit/test_graphify_to_qdrant.py    15 passed
Total: 26 passed in 0.03s
```

## Ingestion counts

Tasks 17 + 19 not run — STOP condition: `.onex_state/graphify-graphs/` missing. Unblock by running the graphify pipeline first.

## Anti-pattern compliance

- No hardcoded IPs — all URLs via env vars (`MEMGRAPH_URL`, `QDRANT_URL`, `EMBEDDING_MODEL_URL`)
- No hardcoded paths — uses `$OMNI_HOME` env var with fallback
- `correlation_id` UUID logged at start and completion of each run
- No `# noqa` or `# type: ignore` (except unavoidable untyped import stubs)
- All ruff checks pass

## Test plan

- [ ] Run `uv sync --extra graph` and verify all three deps import
- [ ] Run `uv run pytest tests/unit/test_graphify_to_memgraph.py tests/unit/test_graphify_to_qdrant.py -v`
- [ ] Once graphify pipeline generates `.onex_state/graphify-graphs/`, run Task 17: `uv run python scripts/graphify_to_memgraph.py --bolt-uri bolt://192.168.86.201:7687`
- [ ] Run Task 19: `uv run python scripts/graphify_to_qdrant.py --qdrant-url http://192.168.86.201:6333 --embedding-url http://192.168.86.200:8100`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI tool to embed and index graph nodes into Qdrant with per-run correlation IDs, progress logging, automatic collection creation, batched upserts, and retry/backoff for embedding calls.
  * Embedding pipeline redacts PII before indexing.

* **Chores**
  * Explicitly pin graph-related client and HTTP dependencies to compatible version ranges.

* **Tests**
  * Added unit tests for embedding-text construction and batching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->