### PR TITLE
fix(ci): run contract-compliance on merge_group events so test gate can clear [OMN-8636]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
   contract-compliance:
     name: Contract Compliance Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - name: Checkout onex_change_control

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
   contract-compliance:
     name: Contract Compliance Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v6
       - name: Checkout onex_change_control


### PR DESCRIPTION
## Summary

- `contract-compliance` job had `if: github.event_name == 'pull_request'` only
- On `merge_group` events this job is **skipped**, which GitHub propagates upstream: `test` (which `needs: contract-compliance`) is also skipped
- CI Summary requires `test == "success"` — skipped triggers exit 1, ejecting every PR from the merge queue

Fix: extend the condition to also match `merge_group` and `push`.

## Root cause

PRs #252 and #254 keep getting ejected because this fix was not yet on main.

## Test plan
- [ ] Verify `contract-compliance` job runs (not skipped) on next merge group attempt
- [ ] Verify `test` job runs and completes
- [ ] CI Summary passes → PRs merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration workflow to run contract compliance checks on additional event types during the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->