### PR TITLE
ci(handshake): drop path filter so gate runs on every PR [OMN-9049]

### DIFF
--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -5,14 +5,8 @@ name: Check Architecture Handshake
 on:
   push:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - '.github/workflows/check-handshake.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - '.claude/architecture-handshake.md'
-      - '.github/workflows/check-handshake.yml'
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Drop the `paths:` filter on `on.push` and `on.pull_request` in `.github/workflows/check-handshake.yml` so the architecture handshake gate fires on every PR.
- `merge_group:` + `workflow_dispatch:` triggers preserved.
- SHA pin (`ref: 330a344c...`) intentionally left alone — OMN-9050 bot owns cross-repo SHA bumps.

## Test plan

- [x] YAML parses cleanly, `merge_group` trigger present, `paths` key absent
- [ ] On PR open, `Check Architecture Handshake / check-handshake` context fires in Actions

## Ticket

- Ticket: [OMN-9049](https://linear.app/omninode/issue/OMN-9049)
- Parent epic: OMN-9048
- Companion: OMN-9050 (automated SHA bump bot)