### PR TITLE
fix(ci): omit merge method flag — let queue decide (OMN-9354)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -84,7 +84,7 @@ jobs:
           PR: ${{ steps.resolve.outputs.pr }}
         run: |
           set -euo pipefail
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto 2>&1); then
             echo "auto-merge enabled: $output"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Remove hardcoded merge method flag from auto-merge workflow for queue-enabled repos.

Per merge-queue policy: the queue controls the merge method. Hardcoding a method flag bypasses the queue's configured merge method.

Change: `gh pr merge "$PR" --auto --squash` -> `gh pr merge "$PR" --auto` (no method flag)

Queue status verified via GraphQL mergeQueue.id — all repos have an active merge queue.

Ticket: OMN-9354
Related: OMN-9348

[skip-receipt-gate: CI workflow fix — no application code changed, no DoD receipt needed]

## Non-queue repos

`omninode_infra` has no merge queue (null mergeQueue) — no change made there.

## Test plan

- [ ] Workflow triggers on next PR open/reopen
- [ ] Queue merges via its configured SQUASH method without method override