### PR TITLE
chore(ci): propagate normalization-symmetry-hook to .pre-commit-config.yaml [bot]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -528,3 +528,11 @@ ci:
   autofix_prs: true
   autoupdate_schedule: weekly
   submodules: false
+
+  - repo: local
+    hooks:
+      - id: normalization-symmetry
+        name: normalization-symmetry
+        entry: uv run python -m omnibase_core.validators.normalization-symmetry
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
Automated config propagation emitted by `omnibase_core/propagate-config.yml`.

- Propagation: `normalization-symmetry-hook`
- Hook ID: `normalization-symmetry`
- Release tag: `manual-24706598976`
- Source: https://github.com/OmniNode-ai/omnibase_core/releases/tag/manual-24706598976
- Tracking: OMN-9344

Idempotent — if the hook already exists in `.pre-commit-config.yaml`, the bot skips this repo.