### PR TITLE
chore(deps): bump omnibase-core 0.39.0 → 0.40.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "pyyaml>=6.0.3,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.39.0",
+    "omnibase-core==0.40.0",
     "omnibase-spi==0.20.4",
     "omnibase-infra==0.32.0",
 
@@ -368,6 +368,6 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.39.0",
+    "omnibase-core==0.40.0",
     "omnibase-spi==0.20.4",
 ]

--- a/tests/integration/test_golden_chain_qdrant_ingestion.py
+++ b/tests/integration/test_golden_chain_qdrant_ingestion.py
@@ -221,7 +221,7 @@ class TestGoldenChainQdrantSearch:
                 "hard_ceiling": 1.0,
             },
             "execution_annotations": {},
-            "schema_version": "1.0.0",
+            "schema_version": {"major": 1, "minor": 0, "patch": 0},
             "content_hash": "",
             "created_at": "2025-01-01T00:00:00Z",
             "tags": [],

--- a/tests/nodes/node_memory_retrieval_effect/test_memory_retrieval_effect.py
+++ b/tests/nodes/node_memory_retrieval_effect/test_memory_retrieval_effect.py
@@ -33,6 +33,7 @@ from omnibase_core.models.omnimemory import (
     ModelMemorySnapshot,
     ModelSubjectRef,
 )
+from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 from omnimemory.nodes.node_memory_retrieval_effect import (
     HandlerMemoryRetrieval,
@@ -89,7 +90,7 @@ def create_snapshot(
         snapshot_id=uuid4(),
         subject=subject,
         cost_ledger=ledger,
-        schema_version="1.0.0",
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
         tags=tags,
     )
 

--- a/tests/nodes/node_memory_storage_effect/test_memory_storage_effect.py
+++ b/tests/nodes/node_memory_storage_effect/test_memory_storage_effect.py
@@ -36,6 +36,7 @@ from omnibase_core.models.omnimemory import (
     ModelMemorySnapshot,
     ModelSubjectRef,
 )
+from omnibase_core.models.primitives.model_semver import ModelSemVer
 
 from omnimemory.nodes.node_memory_storage_effect import (
     HandlerFileSystemAdapter,
@@ -79,7 +80,7 @@ def sample_snapshot() -> ModelMemorySnapshot:
         snapshot_id=uuid4(),
         subject=subject,
         cost_ledger=ledger,
-        schema_version="1.0.0",
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
     )
 
 
@@ -111,7 +112,7 @@ def sample_snapshot_with_id() -> ModelMemorySnapshot:
         snapshot_id=uuid4(),
         subject=subject,
         cost_ledger=ledger,
-        schema_version="1.0.0",
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
         tags=("test", "sample"),
     )
 
@@ -139,7 +140,7 @@ def create_unique_snapshot(
         version=version,
         subject=subject,
         cost_ledger=ledger,
-        schema_version="1.0.0",
+        schema_version=ModelSemVer(major=1, minor=0, patch=0),
         tags=tags,
     )
 

--- a/tests/unit/nodes/test_handler_qdrant.py
+++ b/tests/unit/nodes/test_handler_qdrant.py
@@ -189,7 +189,7 @@ class TestHandlerQdrantExecute:
                 "hard_ceiling": 1.0,
             },
             "execution_annotations": {},
-            "schema_version": "1.0.0",
+            "schema_version": {"major": 1, "minor": 0, "patch": 0},
             "content_hash": "",
             "created_at": "2025-01-01T00:00:00Z",
             "tags": [],

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", specifier = "==0.39.0" },
+    { name = "omnibase-core", specifier = "==0.40.0" },
     { name = "omnibase-spi", specifier = "==0.20.4" },
 ]
 
@@ -747,6 +747,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -755,6 +756,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1398,7 +1400,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.39.0"
+version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -1412,9 +1414,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/63/a75be3539b4046c2f9757b5da02fc5539ff0f382da84695bd1dee875b298/omnibase_core-0.39.0.tar.gz", hash = "sha256:3f57556cd65aba3af0be8e1517614f4a970b57101c9ac5e35e2b578bec5da2b9", size = 8149272, upload-time = "2026-04-06T16:36:03.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c9/1355af40289d83d868d35a9c3570b20604e912b9b5472a2fbc7b07b6fef6/omnibase_core-0.40.0.tar.gz", hash = "sha256:39896c65c13561093634a0b0caec031f80beffa590d4a19e67992d17e24f5dca", size = 8321776, upload-time = "2026-04-21T19:16:33.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/9f/c08ea924136d55fd6fe8bdd41f2cbe767eb672b4510db923ad0ff0b33f16/omnibase_core-0.39.0-py3-none-any.whl", hash = "sha256:f772e2100c655beb150a899ccd2875af69fe43d9636624c6adfb30db31a5cd36", size = 5370710, upload-time = "2026-04-06T16:36:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d0/5ee5a95416694670032a332b715d0d4e8b8a3d1b7984e55b6028e5df85c8/omnibase_core-0.40.0-py3-none-any.whl", hash = "sha256:1f6ecda1753a2a4d579dd9b68e24decf3b49622a8ef8195e3331e2042e5356c7", size = 5481360, upload-time = "2026-04-21T19:16:36.331Z" },
 ]
 
 [[package]]
@@ -1555,7 +1557,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'graph'", specifier = ">=0.28.1,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
-    { name = "omnibase-core", specifier = "==0.39.0" },
+    { name = "omnibase-core", specifier = "==0.40.0" },
     { name = "omnibase-infra", specifier = "==0.32.0" },
     { name = "omnibase-spi", specifier = "==0.20.4" },
     { name = "pinecone-client", specifier = ">=4.1.0,<7.0.0" },


### PR DESCRIPTION
## Summary

- Completes the omnibase-core pin bump that automated PR #284 started (that PR updated `uv.lock` but left the declared pin in `pyproject.toml` at `0.39.0`)
- Updates both `[project.dependencies]` and `[tool.uv] override-dependencies` to `omnibase-core==0.40.0`
- Fixes 4 test fixture files broken by `ModelMemorySnapshot.schema_version` changing from `str` to `ModelSemVer` in 0.40.0

## Upstream change

`omnibase-core` 0.40.0 changed `ModelMemorySnapshot.schema_version` type from `str` to `ModelSemVer`. Test fixtures that passed the string `"1.0.0"` now need the structured form: kwarg sites use `ModelSemVer(major=1, minor=0, patch=0)`, dict-payload sites use `{"major": 1, "minor": 0, "patch": 0}`.

## Test plan

- [x] `uv run pytest tests/ -v` — 2723 passed, 0 failed, 219 skipped
- [x] `pre-commit run --all-files` — all hooks passed
- [ ] CI green via `gh pr checks`

## Unblocks

omnimarket PRs #371, #377, #378 — uv resolver was failing for `python >=3.14` split because omnimemory pinned `0.39.0` while omnibase-core main is `0.40.0`.