### PR TITLE
chore(OMN-10169): refresh uv.lock to omnibase-spi 0.20.5

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1474,16 +1474,16 @@ wheels = [
 
 [[package]]
 name = "omnibase-spi"
-version = "0.20.4"
+version = "0.20.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/ed/23668a820fea9b87a88f619f8df1944e8522d7f2ff8d2e34993709be69f7/omnibase_spi-0.20.4.tar.gz", hash = "sha256:79a81568150d89c97f97661cd7ad1443258cc5fdb46c380c9306b02c65001073", size = 1119882, upload-time = "2026-04-03T08:29:09.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c4/d2198088d22006d197ce75c335ac5b79d7be08e9fd82da1b23a71c56e88a/omnibase_spi-0.20.5.tar.gz", hash = "sha256:6245001d2c263dec93ac12612dbe2c19ce215b28413e8e7f208fae857d0c4747", size = 1143592, upload-time = "2026-04-23T15:49:56.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/1f/e41b898a9f023795376e2a254e64c27889427155c42555a872cdcc0ee67e/omnibase_spi-0.20.4-py3-none-any.whl", hash = "sha256:dc263d4e0474a9031f5159e90ba05c3cb318703740e236b717d61072962921b7", size = 758280, upload-time = "2026-04-03T08:29:07.755Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f4/bdf41eefebadc983ef36bc44c2b32ac2c1695f5acfe779a103670ba0bc3e/omnibase_spi-0.20.5-py3-none-any.whl", hash = "sha256:57b4be9e53b630062032254fb9e98f98601712e8e372df7fd8bfc6c3ee792cba", size = 790932, upload-time = "2026-04-23T15:49:57.886Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
OMN-10169

## Summary
- omnibase_spi 0.20.4 wheel on PyPI is missing the `protocols/runtime/` and `protocols/services/` trees (regression from omnibase_spi#194 / OMN-9414).
- 0.20.5 republishes the package with the missing tree included.
- omnimemory's `pyproject.toml` already declares `>=0.20.4`, so only the lockfile needed refreshing to pull in 0.20.5.

## dod_evidence
- type: import_resolution
  proof: |
    $ uv run python -c "import omnibase_spi.protocols.runtime.protocol_handler_ownership_query as m; print('ok:', m.__file__)"
    ok: /Users/jonah/Code/omni_worktrees/OMN-10169/omnimemory/.venv/lib/python3.12/site-packages/omnibase_spi/protocols/runtime/protocol_handler_ownership_query.py
- type: cross_repo_boundary
  consumer: omnimemory
  producer: omnibase_spi
  version: 0.20.4 -> 0.20.5

## Local gates
- `uv run pytest tests/ -v` → 2724 passed, 220 skipped, 0 failed
- `uv run ruff format src/ tests/` → 455 files left unchanged
- `uv run ruff check src/ tests/` → All checks passed
- `uv run mypy src/ --strict` → Success: no issues found in 335 source files
- `pre-commit run --all-files` → all gates passed

## Test plan
- [x] Full local pytest suite green (no `-k` filter)
- [x] mypy --strict clean
- [x] pre-commit clean
- [x] Import proof of previously-broken protocol module
- [ ] CI green