### PR TITLE
fix(OMN-10276): run CR gate for Dependabot PRs

### DIFF
--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -17,8 +17,7 @@ jobs:
   gate:
     if: >-
       github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
-      github.actor != 'dependabot[bot]')
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
     uses: ./.github/workflows/cr-thread-gate.yml
     with:
       pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}


### PR DESCRIPTION
## Summary
- remove the Dependabot actor skip from the CodeRabbit thread gate caller
- preserve issue-comment and merge_group guards
- unblocks green Dependabot PRs whose required `gate / CodeRabbit Thread Check` never materializes

## Verification
- `python3 - <<PY ... yaml.safe_load(...) ... PY`
- `git diff --check`
- commit hooks
- pre-push hooks

## Queue evidence
GitHub refused `omnimemory#290/#292/#293/#294` merge-queue enqueue with:

```text
Pull request Required status check "gate / CodeRabbit Thread Check" is expected.
```

The caller workflow skipped Dependabot PR events, so the required check could not be produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal infrastructure improvements with no user-facing changes.

* **Chores**
  * Updated internal workflow automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->