### PR TITLE
feat(OMN-10316): wire docs-validate as required CI gate in omnimemory

### DIFF
--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+name: docs-validate
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'README.md'
+      - 'CLAUDE.md'
+  push:
+    branches: [main]
+
+jobs:
+  call:
+    uses: OmniNode-ai/omnibase_core/.github/workflows/validate-docs.yml@main

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -5,11 +5,6 @@ name: docs-validate
 
 on:
   pull_request:
-    paths:
-      - '**.md'
-      - 'docs/**'
-      - 'README.md'
-      - 'CLAUDE.md'
   push:
     branches: [main]
 

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -10,7 +10,8 @@
         ".venv/**",
         "venv/**",
         "node_modules/**",
-        "archived/**"
+        "archived/**",
+        "omni_worktrees/**"
     ],
     "checkExternal": false,
     "externalTimeout": 5000


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docs-validate.yml` calling `OmniNode-ai/omnibase_core/.github/workflows/validate-docs.yml@main`
- Adds `omni_worktrees/**` to `.markdown-link-check.json` excludeFiles per OMN-9607 pattern

## Ticket

OMN-10316

## dod_evidence

- `pre-commit run --all-files`: PASSED
- Workflow file wired: `.github/workflows/docs-validate.yml`
- Link-check config updated: `.markdown-link-check.json`

## Post-merge

Branch protection update required: add `docs-validate / call` to required status checks via `gh api`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated documentation validation in CI/CD pipeline for pull requests and main branch pushes.
  * Updated link validation configuration to exclude additional paths from checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->