### PR TITLE
docs(OMN-8287): refresh omnimemory CLAUDE.md and fix broken model path ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,8 @@ class MyRequest(BaseModel):
 ### Models in domain subdirectory
 
 ```python
-# CORRECT location: src/omnimemory/models/memory/model_search_request.py
-class ModelSearchRequest(BaseModel):
+# CORRECT location: src/omnimemory/models/memory/model_memory_query.py
+class ModelMemoryQuery(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
     query: str = Field(..., description="Semantic search query")
@@ -240,8 +240,11 @@ Canonical spec: `omnibase_core/docs/conventions/FILE_HEADERS.md`
 | Stub protocols | `docs/stub_protocols.md` |
 | Architecture (ONEX 4-node) | `docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md` |
 | Architecture (Kafka abstraction) | `docs/architecture/ARCH_002_KAFKA_ABSTRACTION.md` |
+| Architecture (data ownership) | `docs/architecture/MEMORY_DATA_OWNERSHIP.md` |
 | CI monitoring | `docs/ci/CI_MONITORING_GUIDE.md` |
 | Runtime plugins | `docs/runtime/RUNTIME_PLUGINS.md` |
+| Market migration boundary | `docs/migrations/MARKET_MIGRATION_BOUNDARY.md` |
+| Starting memory services | `docs/runbooks/STARTING_MEMORY_SERVICES.md` |
 
 For project overview, mission, and technology stack, see `README.md`.
 


### PR DESCRIPTION
## Summary

- Fix broken model path reference: `model_search_request.py` / `ModelSearchRequest` cited as the correct example location in CLAUDE.md do not exist. Updated to `model_memory_query.py` / `ModelMemoryQuery` (the actual file at `src/omnimemory/models/memory/model_memory_query.py`).
- Add three new docs shipped under OMN-9604 (`MEMORY_DATA_OWNERSHIP.md`, `MARKET_MIGRATION_BOUNDARY.md`, `STARTING_MEMORY_SERVICES.md`) to the Documentation table.

## DoD evidence

Ticket: OMN-8287

- Broken path reference corrected to verified-existing file `src/omnimemory/models/memory/model_memory_query.py`
- All 10 existing doc links in CLAUDE.md verified present on disk
- 3 new OMN-9604 docs added to Documentation table
- `pre-commit run --all-files` — all hooks passed (exit 0)
- No skip tokens used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples with corrected references for improved clarity and accuracy.
  * Extended documentation index with three new comprehensive topics: data ownership architecture, market migration boundary details, and a practical runbook for starting memory services in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->