### PR TITLE
fix(OMN-10735): remove 5 silent env fallbacks in omnimemory + add validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
   # onex-validation | validate-http-imports             | python scripts/validation/validate_http_imports.py src/
   # onex-validation | validate-kafka-imports            | python scripts/validation/validate_kafka_imports.py src/
   # onex-validation | validate-model-locations          | python scripts/validation/validate_model_locations.py src/
+  # onex-validation | validate-no-env-fallbacks         | python scripts/validation/validate_no_env_fallbacks.py
   # transport-import-guard | validate-no-transport-imports | python scripts/validate_no_transport_imports.py --src-dir src/omnimemory --exclude src/omnimemory/runtime --whitelist tests/audit/transport_import_whitelist.yaml
   # contract-validation | contract-linter                | python -m omnimemory.tools.contract_linter <contracts>
   # io-audit        | io-audit                          | python -m omnimemory.audit
@@ -196,6 +197,11 @@ jobs:
       - name: Validate Kafka import boundary (ARCH-002)
         run: uv run python scripts/validation/validate_kafka_imports.py src/
 
+      # SYNC: Pre-commit hook 'validate-no-env-fallbacks' at pre-commit stage (OMN-10735)
+      # Prevents silent fallback to localhost defaults via os.getenv/os.environ.get
+      - name: Validate no silent env fallbacks
+        run: uv run python scripts/validation/validate_no_env_fallbacks.py
+
       - name: ONEX validation summary
         if: always()
         run: |
@@ -211,6 +217,7 @@ jobs:
           echo "- HTTP import boundary enforcement" >> $GITHUB_STEP_SUMMARY
           echo "- Kafka import boundary enforcement (ARCH-002)" >> $GITHUB_STEP_SUMMARY
           echo "- Pydantic model location enforcement" >> $GITHUB_STEP_SUMMARY
+          echo "- No silent env fallbacks (OMN-10735)" >> $GITHUB_STEP_SUMMARY
 
   # Phase 1 - Transport Import Guard (ARCH-002)
   # SYNC: Pre-commit hook 'validate-no-transport-imports' at pre-commit stage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -241,6 +241,16 @@ repos:
         exclude: ^(tests/|src/omnimemory/protocols/).*\.py$
         stages: [pre-commit]
 
+      # Silent env-fallback guard (OMN-10735)
+      # Prevents os.getenv/os.environ.get with localhost defaults in src/
+      - id: validate-no-env-fallbacks
+        name: ONEX No Silent Env Fallbacks
+        entry: python scripts/validation/validate_no_env_fallbacks.py
+        language: python
+        pass_filenames: false
+        files: ^src/.*\.py$
+        stages: [pre-commit]
+
       # ONEX No Backward Compatibility Anti-Pattern Detection
       - id: validate-no-backward-compatibility
         name: ONEX Backward Compatibility Anti-Pattern Detection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ known-first-party = ["omnimemory"]
     "S607",  # start process with partial path
     "N802",  # AST visitor methods must use CamelCase names (visit_Import, visit_ClassDef)
     "ERA001",  # Commented-out code (validation scripts document code patterns in comments)
+    "T201",  # print() is intentional user-facing output in CLI validator scripts
 ]
 # Transport import guard uses AST visitor methods (visit_Import, visit_ImportFrom, visit_If)
 "scripts/validate_no_transport_imports.py" = [
@@ -268,6 +269,7 @@ known-first-party = ["omnimemory"]
 # CI alignment script uses simple file parsing
 "scripts/validate_ci_precommit_alignment.py" = [
     "ERA001",  # Commented-out code in examples
+    "T201",  # print() is intentional user-facing output
 ]
 # Tools and audit modules use AST visitors for analysis
 "src/omnimemory/tools/*" = [

--- a/scripts/graphify_to_memgraph.py
+++ b/scripts/graphify_to_memgraph.py
@@ -159,12 +159,15 @@ def main() -> None:
     )
     parser.add_argument(
         "--bolt-uri",
-        default=os.environ.get("MEMGRAPH_URL", "bolt://localhost:7687"),
-        help="Memgraph Bolt URI (env: MEMGRAPH_URL, default: bolt://localhost:7687)",
+        default=os.environ.get("MEMGRAPH_URL"),
+        required=os.environ.get("MEMGRAPH_URL") is None,
+        help="Memgraph Bolt URI (env: MEMGRAPH_URL)",
     )
     args = parser.parse_args()
 
-    graph_dir = Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
+    graph_dir = (
+        Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
+    )
     if not graph_dir.is_dir():
         logger.error("graph-dir does not exist: %s", graph_dir)
         sys.exit(1)

--- a/scripts/graphify_to_qdrant.py
+++ b/scripts/graphify_to_qdrant.py
@@ -86,7 +86,9 @@ def build_embedding_text(node: dict[str, Any]) -> str:
     if community:
         parts.append(f"community: {community}")
 
-    repo = node.get("repo", node.get("id", "").split("::")[0] if "::" in node.get("id", "") else "")
+    repo = node.get(
+        "repo", node.get("id", "").split("::")[0] if "::" in node.get("id", "") else ""
+    )
     if repo:
         parts.append(f"repo: {repo}")
 
@@ -166,7 +168,9 @@ def embed_batch(
                     exc,
                 )
 
-    raise RuntimeError(f"Embedding failed after {EMBED_RETRY_ATTEMPTS} attempts") from last_exc
+    raise RuntimeError(
+        f"Embedding failed after {EMBED_RETRY_ATTEMPTS} attempts"
+    ) from last_exc
 
 
 def _stable_point_id(node_id: str) -> int:
@@ -238,7 +242,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--qdrant-url",
-        default=os.environ.get("QDRANT_URL", "http://localhost:6333"),
+        default=os.environ.get("QDRANT_URL"),
+        required=os.environ.get("QDRANT_URL") is None,
         help="Qdrant base URL (env: QDRANT_URL)",
     )
     _embedding_url = os.environ.get("EMBEDDING_MODEL_URL")
@@ -255,7 +260,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    graph_dir = Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
+    graph_dir = (
+        Path(args.graph_dir) if args.graph_dir is not None else _default_graph_dir()
+    )
     if not graph_dir.is_dir():
         logger.error("graph-dir does not exist: %s", graph_dir)
         sys.exit(1)

--- a/scripts/validate_ci_precommit_alignment.py
+++ b/scripts/validate_ci_precommit_alignment.py
@@ -61,6 +61,7 @@ EXPECTED_ALIGNMENTS: list[tuple[str, str, str]] = [
     ("validate-http-imports", "onex-validation", "validate_http_imports.py"),
     ("validate-kafka-imports", "onex-validation", "validate_kafka_imports.py"),
     ("validate-model-locations", "onex-validation", "validate_model_locations.py"),
+    ("validate-no-env-fallbacks", "onex-validation", "validate_no_env_fallbacks.py"),
     # Infrastructure hooks
     ("migration-freeze-check", "migration-freeze", "check_migration_freeze.sh"),
     # New hooks from OMN-2218

--- a/scripts/validation/validate_no_env_fallbacks.py
+++ b/scripts/validation/validate_no_env_fallbacks.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validate that no silent localhost/hardcoded-endpoint fallbacks exist in src/.
+
+Scans src/**/*.py for patterns like:
+  - os.environ.get("KEY", "localhost...")
+  - os.getenv("KEY", "localhost...")
+  - os.getenv("KEY", "bolt://localhost...")
+  - os.getenv("KEY", "http://localhost...")
+  - default="bolt://localhost..."
+  - default="http://localhost..."
+
+Skips docstrings and comments. Exits non-zero if any violations are found.
+
+Usage:
+    uv run python scripts/validation/validate_no_env_fallbacks.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SRC_DIR = REPO_ROOT / "src"
+
+FALLBACK_PATTERNS = [
+    re.compile(
+        r'os\.environ\.get\([^)]*,\s*["\'].*(?:localhost|bolt://|http://localhost|redis://localhost|postgresql://localhost)'
+    ),
+    re.compile(
+        r'os\.getenv\([^)]*,\s*["\'].*(?:localhost|bolt://|http://localhost|redis://localhost|postgresql://localhost)'
+    ),
+    re.compile(
+        r'default\s*=\s*["\'](?:bolt://localhost|http://localhost|redis://localhost|postgresql://localhost)'
+    ),
+]
+
+SKIP_DIRS = {"tests", "__tests__", "test", "__pycache__"}
+
+
+def scan_file(filepath: Path) -> list[tuple[int, str]]:
+    violations: list[tuple[int, str]] = []
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    in_docstring = False
+    docstring_delim: str | None = None
+
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+
+        # Track triple-quoted docstring boundaries
+        for delim in ('"""', "'''"):
+            count = stripped.count(delim)
+            if in_docstring and docstring_delim == delim and count >= 1:
+                in_docstring = False
+                docstring_delim = None
+                break
+            if not in_docstring and count == 1:
+                in_docstring = True
+                docstring_delim = delim
+                break
+            if count >= 2:
+                break  # opens and closes on the same line — not a block docstring
+
+        if in_docstring:
+            continue
+        if stripped.startswith("#"):
+            continue
+
+        for pattern in FALLBACK_PATTERNS:
+            if pattern.search(line):
+                violations.append((lineno, stripped))
+                break
+
+    return violations
+
+
+def main() -> int:
+    if not SRC_DIR.is_dir():
+        print(f"ERROR: src directory not found at {SRC_DIR}", file=sys.stderr)
+        return 1
+
+    all_violations: list[tuple[str, int, str]] = []
+
+    for py_file in sorted(SRC_DIR.rglob("*.py")):
+        if any(part in SKIP_DIRS for part in py_file.parts):
+            continue
+        for lineno, line in scan_file(py_file):
+            all_violations.append((str(py_file.relative_to(REPO_ROOT)), lineno, line))
+
+    if all_violations:
+        print(f"FAIL: {len(all_violations)} silent env-fallback violation(s) found:\n")
+        for filepath, lineno, line in all_violations:
+            print(f"  {filepath}:{lineno}: {line}")
+        print(
+            "\nReplace os.getenv/os.environ.get with localhost fallbacks with "
+            "os.environ[KEY] (fail-fast) or remove the hardcoded default."
+        )
+        return 1
+
+    print("OK: No silent env-fallback violations found in src/.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/omnimemory/nodes/node_intent_query_effect/__init__.py
+++ b/src/omnimemory/nodes/node_intent_query_effect/__init__.py
@@ -30,8 +30,8 @@ Example::
 
         # Initialize handler (creates and owns adapter internally)
         await handler.initialize(
-            connection_uri=os.getenv("MEMGRAPH_URI", "bolt://{OMNIMEMORY_MEMGRAPH_HOST}:{OMNIMEMORY_MEMGRAPH_PORT}"),
-            auth=(os.getenv("MEMGRAPH_USER", ""), os.getenv("MEMGRAPH_PASSWORD", "")),
+            connection_uri=os.environ["MEMGRAPH_URI"],
+            auth=(os.environ.get("MEMGRAPH_USER", ""), os.environ.get("MEMGRAPH_PASSWORD", "")),
         )
 
         # Handler processes Kafka events automatically

--- a/src/omnimemory/nodes/node_intent_query_effect/handlers/__init__.py
+++ b/src/omnimemory/nodes/node_intent_query_effect/handlers/__init__.py
@@ -19,8 +19,8 @@ Example::
     container = ModelONEXContainer()
     handler = HandlerIntentQuery(container)
     await handler.initialize(
-        connection_uri=os.getenv("MEMGRAPH_URI", "bolt://{OMNIMEMORY_MEMGRAPH_HOST}:{OMNIMEMORY_MEMGRAPH_PORT}"),
-        auth=(os.getenv("MEMGRAPH_USER", ""), os.getenv("MEMGRAPH_PASSWORD", "")),
+        connection_uri=os.environ["MEMGRAPH_URI"],
+        auth=(os.environ.get("MEMGRAPH_USER", ""), os.environ.get("MEMGRAPH_PASSWORD", "")),
     )
 
     # Execute query

--- a/src/omnimemory/nodes/node_intent_query_effect/handlers/handler_intent_query.py
+++ b/src/omnimemory/nodes/node_intent_query_effect/handlers/handler_intent_query.py
@@ -226,8 +226,8 @@ class HandlerIntentQuery:
 
         # Initialize (creates and owns adapter internally)
         await handler.initialize(
-            connection_uri=os.getenv("MEMGRAPH_URI", "bolt://{OMNIMEMORY_MEMGRAPH_HOST}:{OMNIMEMORY_MEMGRAPH_PORT}"),
-            auth=(os.getenv("MEMGRAPH_USER", ""), os.getenv("MEMGRAPH_PASSWORD", "")),
+            connection_uri=os.environ["MEMGRAPH_URI"],
+            auth=(os.environ.get("MEMGRAPH_USER", ""), os.environ.get("MEMGRAPH_PASSWORD", "")),
         )
 
         # Execute a query

--- a/tests/unit/test_validate_ci_precommit_alignment.py
+++ b/tests/unit/test_validate_ci_precommit_alignment.py
@@ -581,7 +581,7 @@ class TestAlignmentCount:
         Update the expected count here when legitimately adding or removing
         alignment entries.
         """
-        expected_count = 18
+        expected_count = 19
         assert len(EXPECTED_ALIGNMENTS) == expected_count, (
             f"EXPECTED_ALIGNMENTS has {len(EXPECTED_ALIGNMENTS)} entries, "
             f"expected {expected_count}. If you added or removed entries, "


### PR DESCRIPTION
## Summary

Fixes OMN-10735 — 5 silent env-fallback violations in omnimemory, adds `validate_no_env_fallbacks.py` validator wired as pre-commit hook and CI gate.

### Violations fixed

| File | Line | Change |
|------|------|--------|
| `src/omnimemory/nodes/node_intent_query_effect/__init__.py` | 33 | `os.getenv("MEMGRAPH_URI", "bolt://...")` → `os.environ["MEMGRAPH_URI"]` |
| `src/omnimemory/nodes/node_intent_query_effect/handlers/__init__.py` | 22 | same |
| `src/omnimemory/nodes/node_intent_query_effect/handlers/handler_intent_query.py` | 229 | same |
| `scripts/graphify_to_memgraph.py` | 162 | `os.environ.get("MEMGRAPH_URL", "bolt://localhost:7687")` → required arg |
| `scripts/graphify_to_qdrant.py` | 241 | `os.environ.get("QDRANT_URL", "http://localhost:6333")` → required arg |

### Validator added

`scripts/validation/validate_no_env_fallbacks.py` — adapted from canonical omnibase_core/omnibase_infra version. Scans `src/**/*.py`, skips docstrings and comments, fails on `os.getenv/os.environ.get` with localhost defaults.

Wired in:
- `.pre-commit-config.yaml` as `validate-no-env-fallbacks` (pre-commit stage)
- `.github/workflows/ci.yml` in the `onex-validation` job
- `scripts/validate_ci_precommit_alignment.py` EXPECTED_ALIGNMENTS list
- `tests/unit/test_validate_ci_precommit_alignment.py` count sentinel (18→19)

Also fixes pre-existing T201 (print in CLI scripts) ruff violations by adding `T201` to `per-file-ignores` for `scripts/validation/*` and `scripts/validate_ci_precommit_alignment.py`.

## DoD evidence

- `validate_no_env_fallbacks.py` runs clean: `OK: No silent env-fallback violations found in src/`
- All pre-commit hooks pass (commit + push)
- 1180 unit tests pass (excluding pre-existing broken `test_adapter_rate_limiter.py`)
- mypy passes: exit 0

OMN-10735