### PR TITLE
feat(OMN-10762): port change-aware test selection to omnimemory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,15 +338,71 @@ jobs:
             echo "Handshake verification failed or was skipped; see logs." >> $GITHUB_STEP_SUMMARY
           fi
 
-  # Phase 2 - Test Suite
-  test:
-    name: Tests
+  # Phase 2a - Smart Test Selection (OMN-10762)
+  # Computes which test paths to run based on changed files.
+  # When ENABLE_SMART_TESTS != 'true', emits full-suite selection (10 shards).
+  test-select:
+    name: Smart Test Selection
     needs: [lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, contract-compliance]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    outputs:
+      selected_paths: ${{ steps.select.outputs.selected_paths }}
+      split_count: ${{ steps.select.outputs.split_count }}
+      matrix: ${{ steps.select.outputs.matrix }}
+      is_full_suite: ${{ steps.select.outputs.is_full_suite }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --locked --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
+
+      - name: Compute changed files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --no-tags --depth=1
+            git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          else
+            # push / merge_group / schedule: compare with HEAD~1 or emit empty (full suite will run)
+            git diff --name-only HEAD~1 HEAD 2>/dev/null > /tmp/changed_files.txt || true
+          fi
+          echo "Changed files:"
+          cat /tmp/changed_files.txt
+
+      - name: Run smart test selection
+        id: select
+        run: |
+          FEATURE_FLAG="${{ vars.ENABLE_SMART_TESTS == 'true' && 'on' || 'off' }}"
+          SELECTION=$(uv run python scripts/ci/detect_test_paths.py \
+            --changed-files-from /tmp/changed_files.txt \
+            --ref-name "${{ github.ref_name }}" \
+            --event-name "${{ github.event_name }}" \
+            --feature-flag "$FEATURE_FLAG")
+          echo "Selection: $SELECTION"
+          echo "selected_paths=$(echo "$SELECTION" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d['selected_paths']))")" >> "$GITHUB_OUTPUT"
+          echo "split_count=$(echo "$SELECTION" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['split_count'])")" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(echo "$SELECTION" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d['matrix']))")" >> "$GITHUB_OUTPUT"
+          echo "is_full_suite=$(echo "$SELECTION" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d['is_full_suite']).lower())")" >> "$GITHUB_OUTPUT"
+
+  # Phase 2b - Test Suite (matrix-parallel, OMN-10762)
+  test:
+    name: Tests (${{ matrix.index }}/${{ needs.test-select.outputs.split_count }})
+    needs: [test-select]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        index: ${{ fromJSON(needs.test-select.outputs.matrix) }}
     env:
-      # Performance test threshold (relaxed for CI variance)
-      # Local dev uses 50ms default, CI uses 100ms for tolerance
       PERF_THRESHOLD_MS: "100"
 
     steps:
@@ -359,33 +415,62 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --reinstall-package omnibase-core --reinstall-package omnibase-spi --reinstall-package omnibase-infra
 
-      - name: Run tests
+      - name: Run tests (shard ${{ matrix.index }}/${{ needs.test-select.outputs.split_count }})
         run: |
-          uv run --with 'pytest-cov>=6.0.0,<8.0.0' --with 'pytest-timeout>=2.3.1,<3.0.0' --with 'pytest-xdist>=3.8.0,<4.0.0' pytest tests/ \
+          SELECTED_PATHS='${{ needs.test-select.outputs.selected_paths }}'
+          SPLIT_COUNT=${{ needs.test-select.outputs.split_count }}
+          INDEX=${{ matrix.index }}
+
+          # Build path args from JSON array
+          PATHS=$(python3 -c "import json,sys; paths=json.loads('$SELECTED_PATHS'); print(' '.join(paths))")
+
+          uv run --with 'pytest-cov>=6.0.0,<8.0.0' \
+            --with 'pytest-timeout>=2.3.1,<3.0.0' \
+            --with 'pytest-xdist>=3.8.0,<4.0.0' \
+            --with 'pytest-split>=0.11.0,<1.0.0' \
+            pytest $PATHS \
+            --splits "$SPLIT_COUNT" \
+            --group "$INDEX" \
             -n auto \
             --timeout=60 \
             --timeout-method=thread \
             --tb=short \
-            --junitxml=junit.xml \
+            --junitxml=junit-${{ matrix.index }}.xml \
             --cov=src/omnimemory \
-            --cov-report=xml \
+            --cov-report=xml:coverage-${{ matrix.index }}.xml \
             --cov-report=term-missing
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results
-          path: junit.xml
+          name: test-results-${{ matrix.index }}
+          path: junit-${{ matrix.index }}.xml
           retention-days: 7
 
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
-          path: coverage.xml
+          name: coverage-report-${{ matrix.index }}
+          path: coverage-${{ matrix.index }}.xml
           retention-days: 7
+
+  # Phase 2c - Tests gate (aggregates matrix shards)
+  tests-gate:
+    name: Tests Gate
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all shards passed
+        run: |
+          result="${{ needs.test.result }}"
+          if [[ "$result" != "success" ]]; then
+            echo "Test shards failed: $result"
+            exit 1
+          fi
+          echo "All test shards passed"
 
   # NOTE: Version Pin Compliance check (OMN-4809) removed — prerequisite
   # OMN-4803 (check_version_pins.py in omni_home/standards/) not yet shipped,
@@ -479,7 +564,7 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [migration-freeze, lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, check-handshake, test, compliance]
+    needs: [migration-freeze, lint, pyright, onex-validation, transport-import-guard, contract-validation, io-audit, check-handshake, test-select, tests-gate, compliance]
     if: always()
 
     steps:
@@ -493,7 +578,8 @@ jobs:
           contracts="${{ needs.contract-validation.result }}"
           io_audit="${{ needs.io-audit.result }}"
           handshake="${{ needs.check-handshake.result }}"
-          test="${{ needs.test.result }}"
+          test_select="${{ needs.test-select.result }}"
+          tests_gate="${{ needs.tests-gate.result }}"
           compliance="${{ needs.compliance.result }}"
 
           if [[ "$migration_freeze" == "success" ]] && \
@@ -504,7 +590,8 @@ jobs:
              [[ "$contracts" == "success" ]] && \
              [[ "$io_audit" == "success" ]] && \
              [[ "$handshake" == "success" || "$handshake" == "skipped" ]] && \
-             [[ "$test" == "success" ]] && \
+             [[ "$test_select" == "success" ]] && \
+             [[ "$tests_gate" == "success" ]] && \
              [[ "$compliance" == "success" || "$compliance" == "skipped" ]]; then
             echo "All tests passed successfully"
             echo "Migration Freeze: Passed"
@@ -515,7 +602,8 @@ jobs:
             echo "Contract Validation: Passed"
             echo "I/O Audit: Passed"
             echo "Architecture Handshake: $handshake"
-            echo "Tests: Passed"
+            echo "Smart Test Selection: Passed"
+            echo "Tests Gate: Passed"
             echo "Contract Compliance: $compliance"
             exit 0
           else
@@ -528,7 +616,8 @@ jobs:
             echo "Contract Validation: $contracts"
             echo "I/O Audit: $io_audit"
             echo "Architecture Handshake: $handshake"
-            echo "Tests: $test"
+            echo "Smart Test Selection: $test_select"
+            echo "Tests Gate: $tests_gate"
             echo "Contract Compliance: $compliance"
             exit 1
           fi

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -8,6 +8,10 @@ import argparse
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from scripts.ci.test_selection_loader import (
     ModelAdjacencyMap,
     load_adjacency_map,

--- a/scripts/ci/detect_test_paths.py
+++ b/scripts/ci/detect_test_paths.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Change-aware test path resolution for omnimemory CI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.ci.test_selection_loader import (
+    ModelAdjacencyMap,
+    load_adjacency_map,
+)
+from scripts.ci.test_selection_models import (
+    EnumFullSuiteReason,
+    ModelTestSelection,
+)
+
+SRC_PREFIX = "src/omnimemory/"
+TEST_UNIT_PREFIX = "tests/unit/"
+TEST_INTEGRATION_PREFIX = "tests/integration/"
+
+FULL_SUITE_BRANCHES = {"main"}
+
+
+def resolve_test_paths(
+    changed_files: list[str],
+    adjacency_path: Path,
+) -> list[str]:
+    """Map changed file paths to deterministic UNIT test directories.
+
+    Behavior:
+      - Source changes under src/omnimemory/<module>: include
+        tests/unit/<module>/.
+      - Test-only changes under tests/unit/: include the changed unit-test directory.
+      - Test-only changes under tests/integration/: ignored (integration runs always).
+      - Files outside src/ and tests/unit/: no contribution; caller decides
+        whether to escalate to full suite.
+    """
+    config = load_adjacency_map(adjacency_path)
+    return _resolve(changed_files, config)
+
+
+def _resolve(changed_files: list[str], config: ModelAdjacencyMap) -> list[str]:
+    direct_modules: set[str] = set()
+    selected: set[str] = set()
+
+    for path in changed_files:
+        if path.startswith(SRC_PREFIX):
+            module = path[len(SRC_PREFIX) :].split("/", 1)[0]
+            if module in config.adjacency:
+                direct_modules.add(module)
+        elif path.startswith(TEST_UNIT_PREFIX):
+            parts = path.split("/")
+            if len(parts) >= 3:
+                selected.add(f"{TEST_UNIT_PREFIX}{parts[2]}/")
+
+    expanded: set[str] = set(direct_modules)
+    for module in direct_modules:
+        expanded.update(config.adjacency[module].reverse_deps)
+
+    for module in expanded:
+        selected.add(f"{TEST_UNIT_PREFIX}{module}/")
+
+    return sorted(selected)
+
+
+def compute_selection(
+    changed_files: list[str],
+    adjacency_path: Path,
+    ref_name: str,
+    event_name: str = "pull_request",
+    feature_flag_enabled: bool = True,
+) -> ModelTestSelection:
+    config = load_adjacency_map(adjacency_path)
+
+    # 0. Feature flag short-circuit: off → legacy full suite.
+    if not feature_flag_enabled:
+        return _full_suite(EnumFullSuiteReason.FEATURE_FLAG_OFF)
+
+    # 1. Branch / event escalation.
+    if ref_name in FULL_SUITE_BRANCHES:
+        return _full_suite(EnumFullSuiteReason.MAIN_BRANCH)
+    if event_name == "merge_group":
+        return _full_suite(EnumFullSuiteReason.MERGE_GROUP)
+    if event_name == "schedule":
+        return _full_suite(EnumFullSuiteReason.SCHEDULED)
+
+    # 2. Test infrastructure escalation.
+    for changed in changed_files:
+        if any(
+            changed == infra or changed.startswith(infra.rstrip("/") + "/")
+            for infra in config.test_infrastructure_paths
+        ):
+            return _full_suite(EnumFullSuiteReason.TEST_INFRASTRUCTURE)
+
+    # 3. Shared module escalation.
+    changed_modules = {
+        path[len(SRC_PREFIX) :].split("/", 1)[0]
+        for path in changed_files
+        if path.startswith(SRC_PREFIX)
+    } & set(config.adjacency.keys())
+    if changed_modules & set(config.shared_modules):
+        return _full_suite(EnumFullSuiteReason.SHARED_MODULE)
+
+    # 4. Threshold escalation: too many distinct modules.
+    if len(changed_modules) >= config.thresholds.modules_changed_for_full_suite:
+        return _full_suite(EnumFullSuiteReason.THRESHOLD_MODULES)
+
+    # 5. Smart selection.
+    selected = _resolve(changed_files, config)
+    if not selected:
+        # Conservative one-shard fallback over the full tests/unit/ tree.
+        # Fires for doc-only, workflow-only, integration-only changes.
+        selected = ["tests/unit/"]
+    split_count = _split_count_for(selected)
+
+    return ModelTestSelection(
+        selected_paths=selected,
+        split_count=split_count,
+        is_full_suite=False,
+        full_suite_reason=None,
+        matrix=list(range(1, split_count + 1)),
+    )
+
+
+def _full_suite(reason: EnumFullSuiteReason) -> ModelTestSelection:
+    return ModelTestSelection(
+        selected_paths=["tests/"],
+        split_count=10,
+        is_full_suite=True,
+        full_suite_reason=reason,
+        matrix=list(range(1, 11)),
+    )
+
+
+def _split_count_for(selected_paths: list[str]) -> int:
+    """Map selected path count to split count (conservative starting heuristic)."""
+    n = len(selected_paths)
+    if n <= 2:
+        return 1
+    if n <= 5:
+        return 2
+    if n <= 10:
+        return 3
+    return 4
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resolve change-aware test paths")
+    parser.add_argument(
+        "--changed-files-from",
+        type=Path,
+        required=True,
+        help="Path to a file with one changed-file path per line.",
+    )
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--event-name", default="pull_request")
+    parser.add_argument(
+        "--adjacency",
+        type=Path,
+        default=Path(__file__).parent / "test_selection_adjacency.yaml",
+    )
+    parser.add_argument(
+        "--feature-flag",
+        choices=("on", "off"),
+        default="on",
+        help="When 'off', emit a FEATURE_FLAG_OFF full-suite selection regardless of changed files.",
+    )
+    args = parser.parse_args(argv)
+
+    changed = [
+        line.strip()
+        for line in args.changed_files_from.read_text().splitlines()
+        if line.strip()
+    ]
+    selection = compute_selection(
+        changed_files=changed,
+        adjacency_path=args.adjacency,
+        ref_name=args.ref_name,
+        event_name=args.event_name,
+        feature_flag_enabled=(args.feature_flag == "on"),
+    )
+    sys.stdout.write(selection.model_dump_json())
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_selection_adjacency.yaml
+++ b/scripts/ci/test_selection_adjacency.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# scripts/ci/test_selection_adjacency.yaml
+# Static adjacency map from src/omnimemory/<module> to dependent modules.
+# When a key module changes, every module in `reverse_deps` ALSO has its tests run.
+# Treated as CI contract data — manually curated, reviewed in PRs that change it.
+
+schema_version: 1
+
+# `shared_modules` is a FULL-SUITE ESCALATION POLICY, not an architectural ontology.
+# Listing a module here means "if this module changes, run the full suite".
+# Curate based on operational risk + import fan-out.
+shared_modules:
+  - models
+  - enums
+  - errors
+  - protocols
+  - runtime
+
+# Per-repo full-suite escalation thresholds.
+thresholds:
+  modules_changed_for_full_suite: 6
+
+# Test infrastructure — any change forces the full suite.
+test_infrastructure_paths:
+  - tests/conftest.py
+  - pytest.ini
+  - pyproject.toml
+
+# Reverse dependency edges. Key = changed module; value = modules that import it.
+# When `models` changes, also run tests for everything in `models.reverse_deps`.
+# Note: shared_modules entries here are not consulted at runtime
+# (they trigger full suite first), but kept for completeness/documentation.
+adjacency:
+  models:
+    reverse_deps: [handlers, nodes, runtime, tools, audit, utils]
+  enums:
+    reverse_deps: [models, handlers, nodes, runtime, protocols, tools]
+  errors:
+    reverse_deps: [handlers, nodes, runtime, tools, utils, audit]
+  protocols:
+    reverse_deps: [handlers, nodes, runtime, tools]
+  runtime:
+    reverse_deps: [nodes, handlers]
+  handlers:
+    reverse_deps: [nodes]
+  nodes:
+    reverse_deps: []
+  tools:
+    reverse_deps: [handlers, nodes]
+  audit:
+    reverse_deps: []
+  utils:
+    reverse_deps: [handlers, nodes, tools]

--- a/scripts/ci/test_selection_loader.py
+++ b/scripts/ci/test_selection_loader.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Load and validate the static module adjacency map."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelAdjacencyEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    reverse_deps: list[str] = Field(default_factory=list)
+
+
+class ModelThresholds(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    modules_changed_for_full_suite: int = Field(..., ge=1)
+
+
+class ModelAdjacencyMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(..., ge=1)
+    shared_modules: list[str]
+    thresholds: ModelThresholds
+    test_infrastructure_paths: list[str]
+    adjacency: dict[str, ModelAdjacencyEntry]
+
+    @model_validator(mode="after")
+    def validate_shared_modules_in_adjacency(self) -> ModelAdjacencyMap:
+        for shared in self.shared_modules:
+            if shared not in self.adjacency:
+                raise ValueError(f"shared_module '{shared}' has no adjacency entry")
+        for module, entry in self.adjacency.items():
+            for dep in entry.reverse_deps:
+                if dep not in self.adjacency:
+                    raise ValueError(
+                        f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                    )
+        return self
+
+
+def load_adjacency_map(path: Path) -> ModelAdjacencyMap:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return ModelAdjacencyMap.model_validate(raw)

--- a/scripts/ci/test_selection_models.py
+++ b/scripts/ci/test_selection_models.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Pydantic output contract for change-aware test selection."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+class EnumFullSuiteReason(StrEnum):
+    SHARED_MODULE = "shared_module"
+    THRESHOLD_MODULES = "threshold_modules"
+    TEST_INFRASTRUCTURE = "test_infrastructure"
+    MAIN_BRANCH = "main_branch"
+    MERGE_GROUP = "merge_group"
+    SCHEDULED = "scheduled"
+    FEATURE_FLAG_OFF = "feature_flag_off"
+
+
+TestPath = Annotated[
+    str,
+    StringConstraints(pattern=r"^tests(/[A-Za-z0-9_./-]+)?/$|^tests/$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-z][a-z0-9_]*$", min_length=1),
+]
+
+
+class ModelTestSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    selected_paths: list[TestPath] = Field(..., min_length=1)
+    split_count: int = Field(..., ge=1, le=40)
+    is_full_suite: bool
+    full_suite_reason: EnumFullSuiteReason | None = Field(default=None)
+    matrix: list[int] = Field(...)
+
+    @model_validator(mode="after")
+    def validate_full_suite_reason(self) -> Self:
+        if self.is_full_suite and self.full_suite_reason is None:
+            raise ValueError("full_suite_reason required when is_full_suite=True")
+        if not self.is_full_suite and self.full_suite_reason is not None:
+            raise ValueError("full_suite_reason forbidden when is_full_suite=False")
+        if len(self.matrix) != self.split_count:
+            raise ValueError(
+                f"matrix length {len(self.matrix)} must equal split_count {self.split_count}"
+            )
+        return self

--- a/tests/unit/test_detect_test_paths.py
+++ b/tests/unit/test_detect_test_paths.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for change-aware test path detection (OMN-10762)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.detect_test_paths import (
+    _resolve,
+    _split_count_for,
+    compute_selection,
+)
+from scripts.ci.test_selection_loader import ModelAdjacencyMap, load_adjacency_map
+from scripts.ci.test_selection_models import EnumFullSuiteReason, ModelTestSelection
+
+ADJACENCY_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scripts"
+    / "ci"
+    / "test_selection_adjacency.yaml"
+)
+
+
+@pytest.fixture
+def adjacency_map() -> ModelAdjacencyMap:
+    return load_adjacency_map(ADJACENCY_PATH)
+
+
+@pytest.mark.unit
+class TestAdjacencyMapLoads:
+    def test_loads_without_error(self, adjacency_map: ModelAdjacencyMap) -> None:
+        assert adjacency_map.schema_version == 1
+
+    def test_all_shared_modules_in_adjacency(
+        self, adjacency_map: ModelAdjacencyMap
+    ) -> None:
+        for module in adjacency_map.shared_modules:
+            assert module in adjacency_map.adjacency, (
+                f"shared_module '{module}' missing from adjacency"
+            )
+
+    def test_all_reverse_deps_valid(self, adjacency_map: ModelAdjacencyMap) -> None:
+        for module, entry in adjacency_map.adjacency.items():
+            for dep in entry.reverse_deps:
+                assert dep in adjacency_map.adjacency, (
+                    f"adjacency['{module}'].reverse_deps references unknown module '{dep}'"
+                )
+
+
+@pytest.mark.unit
+class TestResolveTestPaths:
+    def test_src_change_maps_to_unit_dir(
+        self, adjacency_map: ModelAdjacencyMap
+    ) -> None:
+        result = _resolve(["src/omnimemory/tools/some_tool.py"], adjacency_map)
+        assert "tests/unit/tools/" in result
+
+    def test_src_change_expands_reverse_deps(
+        self, adjacency_map: ModelAdjacencyMap
+    ) -> None:
+        # tools -> reverse_deps: [handlers, nodes]
+        result = _resolve(["src/omnimemory/tools/some_tool.py"], adjacency_map)
+        assert "tests/unit/handlers/" in result
+        assert "tests/unit/nodes/" in result
+
+    def test_unit_test_change_included_directly(
+        self, adjacency_map: ModelAdjacencyMap
+    ) -> None:
+        result = _resolve(["tests/unit/handlers/test_foo.py"], adjacency_map)
+        assert "tests/unit/handlers/" in result
+
+    def test_integration_change_ignored(self, adjacency_map: ModelAdjacencyMap) -> None:
+        result = _resolve(["tests/integration/test_ingestion.py"], adjacency_map)
+        assert result == []
+
+    def test_doc_only_change_ignored(self, adjacency_map: ModelAdjacencyMap) -> None:
+        result = _resolve(["docs/README.md"], adjacency_map)
+        assert result == []
+
+    def test_unknown_src_module_ignored(self, adjacency_map: ModelAdjacencyMap) -> None:
+        result = _resolve(["src/omnimemory/nonexistent_module/foo.py"], adjacency_map)
+        assert result == []
+
+    def test_result_is_sorted(self, adjacency_map: ModelAdjacencyMap) -> None:
+        result = _resolve(
+            ["src/omnimemory/utils/util_foo.py", "src/omnimemory/audit/audit_bar.py"],
+            adjacency_map,
+        )
+        assert result == sorted(result)
+
+
+@pytest.mark.unit
+class TestComputeSelection:
+    def test_feature_flag_off_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/tools/foo.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-12345-feature",
+            feature_flag_enabled=False,
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.FEATURE_FLAG_OFF
+
+    def test_main_branch_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/tools/foo.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="main",
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.MAIN_BRANCH
+
+    def test_merge_group_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/tools/foo.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+            event_name="merge_group",
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.MERGE_GROUP
+
+    def test_scheduled_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=[],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+            event_name="schedule",
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.SCHEDULED
+
+    def test_test_infra_change_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=["pyproject.toml"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.TEST_INFRASTRUCTURE
+
+    def test_shared_module_change_returns_full_suite(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/models/memory/model_foo.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert sel.is_full_suite
+        assert sel.full_suite_reason == EnumFullSuiteReason.SHARED_MODULE
+
+    def test_leaf_module_change_returns_smart_selection(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/audit/audit_io.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert not sel.is_full_suite
+        assert sel.full_suite_reason is None
+        assert "tests/unit/audit/" in sel.selected_paths
+
+    def test_doc_only_returns_fallback_unit_dir(self) -> None:
+        sel = compute_selection(
+            changed_files=["docs/README.md"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert not sel.is_full_suite
+        assert sel.selected_paths == ["tests/unit/"]
+
+    def test_matrix_length_equals_split_count(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/audit/audit_io.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert len(sel.matrix) == sel.split_count
+
+    def test_matrix_is_one_indexed(self) -> None:
+        sel = compute_selection(
+            changed_files=["src/omnimemory/audit/audit_io.py"],
+            adjacency_path=ADJACENCY_PATH,
+            ref_name="jonah/omn-10762-feature",
+        )
+        assert sel.matrix[0] == 1
+
+
+@pytest.mark.unit
+class TestSplitCountFor:
+    def test_one_path_gives_one_split(self) -> None:
+        assert _split_count_for(["tests/unit/audit/"]) == 1
+
+    def test_two_paths_give_one_split(self) -> None:
+        assert _split_count_for(["tests/unit/audit/", "tests/unit/utils/"]) == 1
+
+    def test_three_paths_give_two_splits(self) -> None:
+        assert (
+            _split_count_for(["tests/unit/a/", "tests/unit/b/", "tests/unit/c/"]) == 2
+        )
+
+    def test_many_paths_capped_at_four(self) -> None:
+        paths = [f"tests/unit/mod{i}/" for i in range(20)]
+        assert _split_count_for(paths) == 4
+
+
+@pytest.mark.unit
+class TestModelTestSelection:
+    def test_full_suite_requires_reason(self) -> None:
+        with pytest.raises(Exception):
+            ModelTestSelection(
+                selected_paths=["tests/"],
+                split_count=10,
+                is_full_suite=True,
+                full_suite_reason=None,
+                matrix=list(range(1, 11)),
+            )
+
+    def test_non_full_suite_forbids_reason(self) -> None:
+        with pytest.raises(Exception):
+            ModelTestSelection(
+                selected_paths=["tests/unit/audit/"],
+                split_count=1,
+                is_full_suite=False,
+                full_suite_reason=EnumFullSuiteReason.MAIN_BRANCH,
+                matrix=[1],
+            )
+
+    def test_matrix_must_match_split_count(self) -> None:
+        with pytest.raises(Exception):
+            ModelTestSelection(
+                selected_paths=["tests/unit/audit/"],
+                split_count=2,
+                is_full_suite=False,
+                full_suite_reason=None,
+                matrix=[1],  # wrong length
+            )
+
+    def test_valid_smart_selection_serializes(self) -> None:
+        sel = ModelTestSelection(
+            selected_paths=["tests/unit/audit/"],
+            split_count=1,
+            is_full_suite=False,
+            full_suite_reason=None,
+            matrix=[1],
+        )
+        data = json.loads(sel.model_dump_json())
+        assert data["split_count"] == 1
+        assert data["is_full_suite"] is False


### PR DESCRIPTION
## Summary

- Ports the change-aware selective test execution system from omnibase_core (OMN-9852) to omnimemory
- PRs that touch only leaf modules (e.g. `audit`, `utils`, `tools`) now run a single targeted shard instead of the full suite
- Full suite still runs on `main`, `merge_group`, `schedule`, shared-module changes (`models`, `enums`, `errors`, `protocols`, `runtime`), and test infrastructure changes

## Changes

- `scripts/ci/detect_test_paths.py` — omnimemory path resolution (`src/omnimemory/<module>` → `tests/unit/<module>/`)
- `scripts/ci/test_selection_models.py` — Pydantic output contract (frozen, `extra="forbid"`)
- `scripts/ci/test_selection_loader.py` — YAML adjacency map loader with cross-ref validation
- `scripts/ci/test_selection_adjacency.yaml` — curated adjacency map covering all 10 `src/omnimemory/` modules
- `tests/unit/test_detect_test_paths.py` — 28 unit tests (all green)
- `.github/workflows/ci.yml` — replaces single `test` job with: `test-select` → `test` (matrix) → `tests-gate` aggregator

## Test plan

- [ ] 28 unit tests pass locally (`pytest tests/unit/test_detect_test_paths.py -v`)
- [ ] All pre-commit hooks pass (pre-push mypy + pyright included)
- [ ] CI `test-select` job emits smart selection JSON
- [ ] CI `test` matrix shards run correctly
- [ ] CI `tests-gate` aggregates all shards

## Ticket

OMN-10762