### PR TITLE
feat(OMN-10603): migrate runner selector to vars.OMNI_TRUSTED_CI_RUNS_ON_JSON

### DIFF
--- a/.github/workflows/ban-hardcoded-runner-ip.yml
+++ b/.github/workflows/ban-hardcoded-runner-ip.yml
@@ -1,0 +1,21 @@
+---
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Calls the reusable ban-hardcoded-runner-ip check from omniclaude.
+# Implements OMN-10603.
+
+name: Ban Hardcoded Runner IP
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+
+jobs:
+  ban-hardcoded-runner-ip:
+    uses: OmniNode-ai/omniclaude/.github/workflows/ban-hardcoded-runner-ip.yml@main
+    permissions:
+      contents: read
+

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -39,15 +39,12 @@ concurrency:
 jobs:
   contract-validation:
     name: contract-validation
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     timeout-minutes: 10
 

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -21,15 +21,12 @@ env:
 jobs:
   type-union-check:
     name: PEP 604 Type Union Check (UP007)
-    # OMNINODE_SELF_HOSTED_RUNS_ON_V1 — do not edit inline; update plan + all occurrences together
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
     runs-on: >-
       ${{
-        (vars.USE_SELF_HOSTED_RUNNERS == 'true' &&
-         (github.event_name == 'push' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'schedule'))
-        && fromJSON('["self-hosted","omnibase-ci"]')
-        || fromJSON('["ubuntu-latest"]')
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
     steps:
       - name: Checkout code

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -26,9 +26,9 @@ jobs:
     name: Stale TODO Gate
     runs-on: >-
       ${{
-        vars.USE_SELF_HOSTED_RUNNERS == 'true'
-        && 'self-hosted, omnibase-ci'
-        || 'ubuntu-latest'
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
       }}
 
     steps:


### PR DESCRIPTION
## Summary

- Migrates runner selector from hardcoded \`OMNINODE_SELF_HOSTED_RUNS_ON_V1\` / \`USE_SELF_HOSTED_RUNNERS\` pattern to the canonical \`OMNI_RUNNER_SELECTOR_V1\` pattern using \`vars.OMNI_TRUSTED_CI_RUNS_ON_JSON\` and \`vars.OMNI_PUBLIC_PR_RUNS_ON_JSON\` repository variables
- Adds \`ban-hardcoded-runner-ip.yml\` caller workflow that enforces the IP literal ban going forward

## Implements OMN-10603

Evidence-Source: OCC#949

Runner routing must be config/variable-driven for portability and to enable incident disable/restore. Hardcoded runner labels create non-portable pipelines.

## Test plan

- [ ] CI passes on all workflow files
- [ ] No \`vars.USE_SELF_HOSTED_RUNNERS\` / \`OMNINODE_SELF_HOSTED_RUNS_ON_V1\` patterns remain
- [ ] \`ban-hardcoded-runner-ip\` check blocks new \`192.168.86.201\` literals in workflow files