### PR TITLE
fix(OMN-9210/OMN-9211): lowercase node_type + fix dlq topic (omnimemory)

### DIFF
--- a/src/omnimemory/nodes/node_agent_coordinator_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/node_agent_coordinator_orchestrator/contract.yaml
@@ -12,7 +12,7 @@ contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 2, patch: 0}
 description: "Orchestrator node for cross-agent memory coordination. Manages subscriptions and publishes
   notification events to Kafka for subscriber consumption."
-node_type: "ORCHESTRATOR"
+node_type: orchestrator
 input_model: "ModelAgentCoordinatorRequest"
 output_model: "ModelAgentCoordinatorResponse"
 

--- a/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_agent_learning_retrieval_effect/contract.yaml
@@ -12,7 +12,7 @@ node_version: {major: 0, minor: 1, patch: 0}
 description: "Retrieves agent learning records from Qdrant vector collections. Supports error signature
   matching (high precision, cosine > 0.85) and task context matching (broad recall, cosine > 0.70) with
   freshness decay ranking."
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelAgentLearningRetrievalRequest"
 output_model: "ModelAgentLearningRetrievalResponse"
 

--- a/src/omnimemory/nodes/node_filesystem_crawler_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_filesystem_crawler_effect/contract.yaml
@@ -8,7 +8,7 @@ name: node_filesystem_crawler_effect
 contract_version: {major: 0, minor: 1, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 uuid: "cb6d3224-5f18-4da1-be8c-e5a15a1c659e"
-node_type: EFFECT
+node_type: effect
 input_model: "ModelCrawlTickCommand"
 output_model: "ModelFilesystemCrawlResult"
 description: |

--- a/src/omnimemory/nodes/node_intent_event_consumer_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_event_consumer_effect/contract.yaml
@@ -8,7 +8,7 @@ name: node_intent_event_consumer_effect
 contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 2, patch: 0}
 uuid: "6fc349b1-34f0-4760-b547-6e8bebf0c9c0"
-node_type: EFFECT
+node_type: effect
 input_model: "ModelIntentClassifiedEvent"
 output_model: "ModelIntentStoredEvent"
 description: |
@@ -116,11 +116,11 @@ event_bus:
   # NOTE: DLQ topic included here for publish_topic_metadata consistency
   publish_topics:
     - "onex.evt.omnimemory.intent-stored.v1"
-    - "onex.evt.omniintelligence.intent-classified.v1.dlq"
+    - "onex.evt.omniintelligence.intent-classified-dlq.v1"
 
   # Dead letter queue topics (documentation; also listed in publish_topics)
   dlq_topics:
-    - "onex.evt.omniintelligence.intent-classified.v1.dlq"
+    - "onex.evt.omniintelligence.intent-classified-dlq.v1"
 
   # Metadata for subscribed topics
   subscribe_topic_metadata:
@@ -135,7 +135,7 @@ event_bus:
       schema_ref: "omnibase_core.models.events.ModelIntentStoredEvent"
       description: "Intent storage confirmation events. Emitted after successfully persisting a classified
         intent to Memgraph. Uses status field to indicate success or error."
-    "onex.evt.omniintelligence.intent-classified.v1.dlq":
+    "onex.evt.omniintelligence.intent-classified-dlq.v1":
       schema_ref: "omnimemory.models.events.model_intent_classified_event.ModelIntentClassifiedEvent"
       description: "Dead letter queue for intent-classified events that failed processing after max retries.
         Contains the original event plus error metadata."

--- a/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_query_effect/contract.yaml
@@ -11,7 +11,7 @@ contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Effect node for event-driven intent queries via Kafka. Provides distribution analysis, session-based
   lookups, and recent intent retrieval from Memgraph."
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelIntentQueryRequestedEvent"
 output_model: "ModelIntentQueryResponseEvent"
 

--- a/src/omnimemory/nodes/node_intent_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_intent_storage_effect/contract.yaml
@@ -11,7 +11,7 @@ contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Intent storage effect node for persisting classified intents to Memgraph. Links intents
   to sessions for analytics and pattern learning."
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelIntentStorageRequest"
 output_model: "ModelIntentStorageResponse"
 

--- a/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_kreuzberg_parse_effect/contract.yaml
@@ -9,7 +9,7 @@ name: node_kreuzberg_parse_effect
 contract_version: {major: 0, minor: 1, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 uuid: "a4e72f19-3c8b-4d56-b0a1-7f9e2d45c830"
-node_type: EFFECT
+node_type: effect
 input_model: "ModelDocumentDiscoveredEvent | ModelDocumentChangedEvent"
 output_model: "ModelKreuzbergParseResult"
 description: |

--- a/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_retrieval_effect/contract.yaml
@@ -11,7 +11,7 @@ contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Memory retrieval effect node for search operations. P2A: Qdrant semantic search, PostgreSQL
   full-text search, and Graph traversal backends."
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelMemoryRetrievalRequest"
 output_model: "ModelMemoryRetrievalResponse"
 

--- a/src/omnimemory/nodes/node_memory_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_memory_storage_effect/contract.yaml
@@ -11,7 +11,7 @@ contract_version: {major: 0, minor: 2, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Memory storage effect node for CRUD operations. P1A: FileSystem backend for snapshot persistence.
   Phase 2: PostgreSQL, Redis, and Pinecone backends."
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelMemoryStorageRequest"
 output_model: "ModelMemoryStorageResponse"
 

--- a/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
+++ b/src/omnimemory/nodes/node_navigation_history_reducer/contract.yaml
@@ -7,7 +7,7 @@
 name: node_navigation_history_reducer
 contract_version: {major: 0, minor: 1, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
-node_type: REDUCER
+node_type: reducer
 input_model: "ModelNavigationHistoryRequest"
 output_model: "ModelNavigationHistoryResponse"
 description: |

--- a/src/omnimemory/nodes/node_persona_builder_compute/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_builder_compute/contract.yaml
@@ -13,7 +13,7 @@ description: >
   Pure compute node that takes a batch of PersonaSignal events and an optional existing PersonaProfile,
   then produces an updated PersonaProfile. Classification uses heuristic rules and threshold scoring (no
   ML). Conservatism rules prevent thrashing on weak evidence. Phase 3 Adaptive Personalization (OMN-7305).
-node_type: "COMPUTE"
+node_type: compute
 input_model: "ModelPersonaClassifyRequest"
 output_model: "ModelPersonaClassifyResult"
 

--- a/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_lifecycle_orchestrator/contract.yaml
@@ -8,7 +8,7 @@ node_version: {major: 0, minor: 1, patch: 0}
 description: >
   Orchestrator node that coordinates persona snapshot builds. Handles tick-driven fan-out (up to 100 users
   per tick) and on-demand single-user builds. Phase 3 Adaptive Personalization (OMN-7305).
-node_type: "ORCHESTRATOR"
+node_type: orchestrator
 input_model: "ModelPersonaLifecycleRequest"
 output_model: "ModelPersonaLifecycleResponse"
 

--- a/src/omnimemory/nodes/node_persona_retrieval_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_retrieval_effect/contract.yaml
@@ -8,7 +8,7 @@ node_version: {major: 0, minor: 1, patch: 0}
 description: >
   Read-only EFFECT node that retrieves the latest PersonaSnapshot for a user_id/agent_id from Postgres.
   No event bus (read-only). Phase 3 Adaptive Personalization (OMN-7305).
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelPersonaRetrievalRequest"
 output_model: "ModelPersonaRetrievalResponse"
 

--- a/src/omnimemory/nodes/node_persona_storage_effect/contract.yaml
+++ b/src/omnimemory/nodes/node_persona_storage_effect/contract.yaml
@@ -9,7 +9,7 @@ description: >
   EFFECT node that writes PersonaSnapshot to Postgres (append-only). Emits persona-snapshot-created event
   on successful new insert. Idempotent: duplicate (user_id, persona_version) is caught and logged. Phase
   3 Adaptive Personalization (OMN-7305).
-node_type: "EFFECT"
+node_type: effect
 input_model: "ModelPersonaStorageRequest"
 output_model: "ModelPersonaStorageResponse"
 

--- a/src/omnimemory/nodes/node_semantic_analyzer_compute/contract.yaml
+++ b/src/omnimemory/nodes/node_semantic_analyzer_compute/contract.yaml
@@ -14,7 +14,7 @@ description: >
   Compute node for semantic analysis including embedding generation, entity extraction, and topic modeling.
   Delegates I/O to provider protocols (ProtocolEmbeddingProvider, ProtocolLLMProvider) to maintain compute
   purity. Supports deterministic and best-effort extraction modes.
-node_type: "COMPUTE"
+node_type: compute
 input_model: "ModelSemanticAnalyzerComputeRequest"
 output_model: "ModelSemanticAnalyzerComputeResponse"
 

--- a/src/omnimemory/nodes/node_similarity_compute/contract.yaml
+++ b/src/omnimemory/nodes/node_similarity_compute/contract.yaml
@@ -11,7 +11,7 @@ contract_version: {major: 0, minor: 1, patch: 0}
 node_version: {major: 0, minor: 1, patch: 0}
 description: "Pure compute node for vector similarity calculations. Supports cosine and euclidean distance
   metrics with optional threshold matching. No I/O operations."
-node_type: "COMPUTE"
+node_type: compute
 input_model: "ModelSimilarityComputeRequest"
 output_model: "ModelSimilarityComputeResponse"
 


### PR DESCRIPTION
## Summary

Fixes contract violations detected by the contract sweep validator (OMN-9532 epic).

**OMN-9210 — invalid_node_type (omnimemory portion)**
- 15 contract.yaml files updated: bare uppercase `COMPUTE`, `EFFECT`, `ORCHESTRATOR`, `REDUCER` → lowercase canonical forms

**OMN-9211 — invalid_topic_name**
- `node_intent_event_consumer_effect`: renamed `onex.evt.omniintelligence.intent-classified.v1.dlq` → `onex.evt.omniintelligence.intent-classified-dlq.v1` to comply with the 5-segment grammar

## Test plan
- [x] `pre-commit run --all-files` — all hooks pass including ONEX Contract Linter
- [x] Violation sweep: 0 violations remaining in omnimemory

## Related tickets
- OMN-9210, OMN-9211, OMN-9532 (parent epic)