### PR TITLE
chore: release omnimemory v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## v0.16.0 (2026-05-21)
+
+### Features
+- feat(OMN-10762): port change-aware test selection to omnimemory (#308)
+- feat(OMN-10603): migrate runner selector to vars.OMNI_TRUSTED_CI_RUNS_ON_JSON (#309)
+- feat(OMN-10316): wire docs-validate as required CI gate (#297)
+
+### Bug Fixes
+- fix(OMN-11293): expect lowercase node_type in test_contract_version (#322)
+- fix(OMN-9210, OMN-9211): lowercase node_type + fix dlq topic (#316)
+- fix(OMN-10970): wire skip-token rejection CI gate (#315)
+- fix(OMN-10735): remove 5 silent env fallbacks + add validator (#307)
+- fix(OMN-10276): run CR gate for dependabot PRs (#295)
+
+### Pin Updates (2026-05-21 release wave 2)
+- omnibase-core: `==0.40.1` → `==0.42.0`
+- omnibase-infra: `==0.36.0` → `==0.36.1`
+- omnibase-spi: `==0.20.6` → `==0.21.0`
+- omnibase-compat: archive zip @ ea4239d → `==0.4.1`
+- omnimarket: git rev → `==0.3.1`
+
+### Other Changes
+- chore(OMN-11320, OMN-11321): bump omnibase-infra to 0.36.0 (#323) (superseded by this release's 0.36.1 pin)
+- chore(OMN-10533): update memory dependency pins and lockfile (#306)
+- chore: align omnibase release pins (#300)
+- build(deps): various dependency updates (pinecone-client, fastapi, mypy, pydantic, supabase, qdrant-client, psycopg2-binary)
+
 ## v0.15.0 (2026-04-03)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omninode-memory"
-version = "0.15.0"
+version = "0.16.0"
 description = "OmniNode memory primitives — models, protocols, and storage adapters for Qdrant, Memgraph, and PostgreSQL backends."
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -59,9 +59,9 @@ dependencies = [
     "pyyaml>=6.0.3,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.40.1",
-    "omnibase-spi==0.20.6",
-    "omnibase-infra==0.36.0",
+    "omnibase-core==0.42.0",
+    "omnibase-spi==0.21.0",
+    "omnibase-infra==0.36.1",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -370,15 +370,21 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.40.1",
-    "omnibase-spi==0.20.6",
-    "omnibase-infra==0.36.0",
-    "omnibase-compat @ https://github.com/OmniNode-ai/omnibase_compat/archive/ea4239d357fe07bb7c45afee9edceaa5c428bf32.zip",
-    "omninode-memory==0.15.0",
-    "omnimarket @ git+https://github.com/OmniNode-ai/omnimarket.git@e6cc7c603f1d4e7ed287f9ec9a6d3c85328b8d64",
+    "omnibase-core==0.42.0",
+    "omnibase-spi==0.21.0",
+    "omnibase-infra==0.36.1",
+    "omnibase-compat==0.4.1",
+    "omninode-memory==0.16.0",
+    "omnimarket==0.3.1",
     "onex-change-control @ git+https://github.com/OmniNode-ai/onex_change_control.git@bd30807469c2b570d99ffefb25fb23e6a9d7cfb1",
 ]
 
 [tool.uv.sources]
 omninode-memory = { workspace = true }
+# Pinned to main while 2026-05-21 release wave 2 upstream packages are unpublished on PyPI.
+# Switch to PyPI pins after omnibase-core v0.42.0 / omnibase-infra v0.36.1 / omnibase-spi v0.21.0 / omnibase-compat v0.4.1 publish.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
+omnibase-infra = { git = "https://github.com/OmniNode-ai/omnibase_infra.git", branch = "main" }
+omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
+omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", branch = "main" }
 omnimarket = { git = "https://github.com/OmniNode-ai/omnimarket.git", rev = "e6cc7c603f1d4e7ed287f9ec9a6d3c85328b8d64" }

--- a/src/omnimemory/topics.py
+++ b/src/omnimemory/topics.py
@@ -23,11 +23,11 @@ from __future__ import annotations
 
 from enum import Enum, unique
 
-from omnibase_core.utils.util_str_enum_base import StrValueHelper
+from omnibase_core.utils.util_str_enum_base import UtilStrValueHelper
 
 
 @unique
-class EnumMemoryCommandTopic(StrValueHelper, str, Enum):
+class EnumMemoryCommandTopic(UtilStrValueHelper, str, Enum):
     """Canonical Kafka topic names for omnimemory input commands.
 
     All topics use ``onex.cmd.omnimemory.*`` as the consumer namespace
@@ -63,7 +63,7 @@ class EnumMemoryCommandTopic(StrValueHelper, str, Enum):
 
 
 @unique
-class EnumMemoryEventTopic(StrValueHelper, str, Enum):
+class EnumMemoryEventTopic(UtilStrValueHelper, str, Enum):
     """Canonical Kafka topic names for omnimemory events.
 
     Includes both events produced by omnimemory (crawl pipeline, intent storage)

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,10 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-compat", url = "https://github.com/OmniNode-ai/omnibase_compat/archive/ea4239d357fe07bb7c45afee9edceaa5c428bf32.zip" },
-    { name = "omnibase-core", specifier = "==0.40.1" },
-    { name = "omnibase-infra", specifier = "==0.36.0" },
-    { name = "omnibase-spi", specifier = "==0.20.6" },
+    { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main" },
+    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?rev=e6cc7c603f1d4e7ed287f9ec9a6d3c85328b8d64" },
     { name = "omninode-memory", editable = "." },
     { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=bd30807469c2b570d99ffefb25fb23e6a9d7cfb1" },
@@ -1307,8 +1307,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.40.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.41.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#27aeae055648c535bc6397dfc7018c4cb4dba4fb" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1323,15 +1323,11 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-python" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/ee/437d2a59f3a08827c7688d2ddf62da6d0f2647ef7ca741f092da695c23d2/omnibase_core-0.40.1.tar.gz", hash = "sha256:ed9308f3cbca5dbcdcffd5cc7e6ce9d5ae3e4fa96b89b0dda6f69388fedac3bf", size = 8395663, upload-time = "2026-05-04T02:00:24.88Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/98/20316960a989aa24f5b851bf74402c0b8a0febc0a28ccb67cfc8b518d418/omnibase_core-0.40.1-py3-none-any.whl", hash = "sha256:1fa09caee8e9237397c42154b102704b4faacd4c881edf1d98aa3d1d897b6308", size = 5773507, upload-time = "2026-05-04T02:00:22.44Z" },
-]
 
 [[package]]
 name = "omnibase-infra"
-version = "0.36.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.36.1"
+source = { git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main#4389973ac2274eaa21b1017a287a414dfc34deb0" }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "aiofiles" },
@@ -1380,28 +1376,20 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/9d/ffee802f88611629763e9f71609737595f69728944dc648adddb44d1d9e0/omnibase_infra-0.36.0.tar.gz", hash = "sha256:918494b283f983ead2e6e6e17ba995dd9778586ddd10da2cdecb063a90a86a8c", size = 8167794, upload-time = "2026-05-21T02:30:51.869Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/d9/13c471d6ad8b6bab98d941c576c0297d6a3eca71e06dea1d7b7bc744d19e/omnibase_infra-0.36.0-py3-none-any.whl", hash = "sha256:108812d3bfaff4da1608db983db9c198ff38d02acb82a021fb863ef45be83c93", size = 4833735, upload-time = "2026-05-21T02:31:03.254Z" },
-]
 
 [[package]]
 name = "omnibase-spi"
-version = "0.20.6"
-source = { registry = "https://pypi.org/simple" }
+version = "0.21.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main#63cd72f2532351f92d8a845cd537d81dc7cbedcf" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/52/d7623f3d4a063364639768240fe9d981ed95e4d631f9d477aca54499ed96/omnibase_spi-0.20.6.tar.gz", hash = "sha256:89c70b21fe1aeaa61a7622ae40bcf21e925ebb6d5282039ce5f4258eae22da48", size = 1135612, upload-time = "2026-05-04T02:20:10.286Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/68/b8b917f1c6de94c5cca26a5af673fd164ee656953503000254edad4bd090/omnibase_spi-0.20.6-py3-none-any.whl", hash = "sha256:1e32893d1fabb9215a1cb2e314ca03a5362b89495be5f3ec049491ec4cc0d041", size = 792937, upload-time = "2026-05-04T02:20:08.691Z" },
-]
 
 [[package]]
 name = "omninode-memory"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1442,9 +1430,9 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'graph'", specifier = ">=0.28.1,<1.0.0" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
-    { name = "omnibase-core", specifier = "==0.40.1" },
-    { name = "omnibase-infra", specifier = "==0.36.0" },
-    { name = "omnibase-spi", specifier = "==0.20.6" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main" },
+    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "pinecone-client", specifier = ">=6.0.0,<7.0.0" },
     { name = "psutil", specifier = ">=7.2.2,<8.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.12,<3.0.0" },


### PR DESCRIPTION
## Summary

Release v0.16.0 of omnimemory. Coordinated as part of the 2026-05-21 full org-wide release wave 2.

## Notable changes since v0.15.0

### Features
- feat(OMN-10762): port change-aware test selection
- feat(OMN-10603): migrate runner selector to vars.OMNI_TRUSTED_CI_RUNS_ON_JSON
- feat(OMN-10316): wire docs-validate as required CI gate

### Fixes
- fix(OMN-11293): expect lowercase node_type in test_contract_version
- fix(OMN-9210, OMN-9211): lowercase node_type + fix dlq topic
- fix(OMN-10970): wire skip-token rejection CI gate
- fix(OMN-10735): remove 5 silent env fallbacks + add validator
- fix(OMN-10276): run CR gate for dependabot PRs

## Pin updates

- `omnibase-core`: `==0.40.1` → `==0.42.0`
- `omnibase-infra`: `==0.36.0` → `==0.36.1`
- `omnibase-spi`: `==0.20.6` → `==0.21.0`
- `omnibase-compat`: archive zip @ ea4239d → `==0.4.1`
- `omnimarket`: git rev → `==0.3.1`

`[tool.uv.sources]` adds temporary git+main entries for the upstream wave 2 packages while they are unpublished on PyPI. These will be swapped to PyPI pins after the cascade publishes (omnibase_core v0.42.0, omnibase_infra v0.36.1, omnibase_spi v0.21.0, omnibase_compat v0.4.1).

## Test plan

- [x] pyproject.toml version bumped 0.15.0 → 0.16.0
- [x] Cross-repo pins updated (2 locations: dependencies + tool.uv.override-dependencies)
- [x] tool.uv.sources git+main entries added
- [x] uv.lock regenerated
- [x] CHANGELOG.md v0.16.0 entry added
- [x] Pre-commit hooks pass
- [ ] CI green before merge

OCC evidence will be bound in OmniNode-ai/onex_change_control#1250 via follow-up commit.

Evidence-Source: OCC#1250
Evidence-Ticket: OMN-11348

OMN-11348