### PR TITLE
ci(OMN-11413): add merge_group trigger to gate workflows

### DIFF
--- a/.github/workflows/ban-hardcoded-runner-ip.yml
+++ b/.github/workflows/ban-hardcoded-runner-ip.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/**
+  merge_group:
 
 jobs:
   ban-hardcoded-runner-ip:

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
 
 jobs:
   call:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
 
 jobs:
   pre-commit:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -20,6 +20,7 @@ name: Stale TODO Gate
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   stale-todo-gate:


### PR DESCRIPTION
## Summary

Adds `merge_group:` trigger to gate/quality CI workflows in omnimemory that previously only ran on `pull_request` and `push` events. This ensures these checks block merge queue promotion.

**Workflows updated:**
- `pre-commit.yml` — lint, format, custom ONEX hooks
- `docs-validate.yml` — documentation link/structure validation
- `security-scan.yml` — CodeQL security analysis
- `ban-hardcoded-runner-ip.yml` — workflow IP hardcoding guard
- `stale-todo-gate.yml` — stale TODO/Linear ticket check

**Excluded** (intentionally):
- `auto-merge.yml`, `auto-tag-on-merge.yml`, `todo-audit-on-merge.yml` — post-merge triggers with `types: [closed]`; not applicable to merge_group events
- `pr-title-check.yml` — PR-event-specific types (`opened`, `edited`); no merge_group equivalent

## Ticket

OMN-11413 — Wire receipt + security gates as required checks (epic OMN-11388)

## Test plan
- [ ] Verify each updated workflow appears as a required status check during merge queue runs
- [ ] Confirm no workflow fails in merge_group context due to missing PR context (pr-title excluded for this reason)