### PR TITLE
test(OMN-11621): cover ai slop validator [omnimemory]

### DIFF
--- a/scripts/validation/check_ai_slop.py
+++ b/scripts/validation/check_ai_slop.py
@@ -275,49 +275,71 @@ def _check_lines(filename: str, source_lines: list[str]) -> list[SlopViolation]:
     Line-based regex checks for patterns that don't require AST analysis.
     Only applies outside of docstrings (we use a simple heuristic: skip
     lines inside triple-quoted strings by tracking quote depth).
+
+    step_narration is only checked in Markdown files (.md), not Python files.
+    In Python code, '# Step N:' is a legitimate ordered-step comment pattern
+    (e.g., documenting multi-step functions). In Markdown, it is LLM boilerplate.
+
+    For Markdown files, lines inside fenced code blocks (``` ... ```) are skipped
+    so that quoted Python examples with '# Step N:' comments are not flagged.
     """
     violations: list[SlopViolation] = []
+    is_markdown = filename.endswith(".md")
 
     in_triple_quote = False
     triple_char = ""
+    in_md_code_fence = False
 
     for lineno, line in enumerate(source_lines, start=1):
         stripped = line.rstrip()
 
-        # Toggle triple-quote tracking (simple heuristic)
+        # Toggle triple-quote tracking for Python files (simple heuristic)
         # Count occurrences of """ and '''
-        for tq in ('"""', "'''"):
-            count = stripped.count(tq)
-            if count:
-                if not in_triple_quote:
-                    if count % 2 == 1:
-                        in_triple_quote = True
-                        triple_char = tq
-                elif tq == triple_char:
-                    if count % 2 == 1:
-                        in_triple_quote = False
-                        triple_char = ""
+        if not is_markdown:
+            for tq in ('"""', "'''"):
+                count = stripped.count(tq)
+                if count:
+                    if not in_triple_quote:
+                        if count % 2 == 1:
+                            in_triple_quote = True
+                            triple_char = tq
+                    elif tq == triple_char:
+                        if count % 2 == 1:
+                            in_triple_quote = False
+                            triple_char = ""
 
-        if in_triple_quote:
-            continue
+            if in_triple_quote:
+                continue
 
-        # Step narration: "# Step N:" outside docstrings
-        comment_match = re.search(r"#(.+)", stripped)
-        if comment_match:
-            comment_text = comment_match.group(0)
-            if _STEP_NARRATION_RE.search(comment_text):
-                # Check for suppression on this line
-                if SUPPRESSION_MARKER not in stripped:
-                    violations.append(
-                        SlopViolation(
-                            filename=filename,
-                            line=lineno,
-                            check=CHECK_STEP_NARRATION,
-                            severity=SEVERITY_WARNING,
-                            message=f"Step narration comment: {comment_text.strip()!r}",
-                            source_line=stripped,
+        # For Markdown: track fenced code blocks (``` or ~~~) to skip their content.
+        # Lines inside code fences are quoted code examples, not prose patterns.
+        if is_markdown:
+            if stripped.startswith(("```", "~~~")):
+                in_md_code_fence = not in_md_code_fence
+            if in_md_code_fence or stripped.startswith(("```", "~~~")):
+                continue
+
+        # Step narration: "# Step N:" — Markdown files only, outside code fences.
+        # Python inline comments like "# Step 1: Clone repo" are legitimate code
+        # documentation for ordered multi-step functions; only flag in .md files
+        # where "## Step N:" / "### Step N:" is LLM-generated structural boilerplate.
+        if is_markdown:
+            comment_match = re.search(r"#(.+)", stripped)
+            if comment_match:
+                comment_text = comment_match.group(0)
+                if _STEP_NARRATION_RE.search(comment_text):
+                    # Check for suppression on this line
+                    if SUPPRESSION_MARKER not in stripped:
+                        violations.append(
+                            SlopViolation(
+                                filename=filename,
+                                line=lineno,
+                                check=CHECK_STEP_NARRATION,
+                                severity=SEVERITY_WARNING,
+                                message=f"Step narration comment: {comment_text.strip()!r}",
+                                source_line=stripped,
+                            )
                         )
-                    )
 
     return violations
 

--- a/tests/unit/scripts/__init__.py
+++ b/tests/unit/scripts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/scripts/test_check_ai_slop.py
+++ b/tests/unit/scripts/test_check_ai_slop.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _load_checker() -> Any:
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "validation" / "check_ai_slop.py"
+    spec = importlib.util.spec_from_file_location("check_ai_slop", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_file_reports_docstring_errors_and_warnings(tmp_path: Path) -> None:
+    checker = _load_checker()
+    source_file = tmp_path / "sloppy.py"
+    source_file.write_text(
+        '''
+def eager_helper() -> None:
+    """Absolutely! Here's a helper."""
+
+
+def rest_helper() -> None:
+    """
+    Helper function.
+
+    :param value: ignored
+    """
+
+
+def boilerplate_helper() -> None:
+    """This function handles the specified input."""
+''',
+        encoding="utf-8",
+    )
+
+    violations = checker.check_file(source_file)
+    found = {(violation.check, violation.severity) for violation in violations}
+
+    assert (checker.CHECK_SYCOPHANCY, checker.SEVERITY_ERROR) in found
+    assert (checker.CHECK_REST_DOCSTRING, checker.SEVERITY_ERROR) in found
+    assert (checker.CHECK_BOILERPLATE_DOCSTRING, checker.SEVERITY_WARNING) in found
+
+
+def test_suppression_marker_ignores_next_docstring_violation(tmp_path: Path) -> None:
+    checker = _load_checker()
+    source_file = tmp_path / "suppressed.py"
+    source_file.write_text(
+        '''
+# ai-slop-ok
+def preserved_phrase() -> None:
+    """Absolutely! Here's a preserved fixture phrase."""
+''',
+        encoding="utf-8",
+    )
+
+    assert checker.check_file(source_file) == []
+
+
+def test_markdown_step_narration_skips_fenced_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    checker = _load_checker()
+    markdown_file = tmp_path / "notes.md"
+    markdown_file.write_text(
+        """
+# Notes
+
+## Step 1: Replace boilerplate prose
+
+```python
+# Step 2: This is a legitimate code comment.
+```
+""",
+        encoding="utf-8",
+    )
+
+    exit_code = checker.main(["--report", "--json", str(markdown_file)])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert [violation["check"] for violation in output] == [
+        checker.CHECK_STEP_NARRATION
+    ]
+    assert "Step 1" in output[0]["message"]
+
+
+def test_python_step_comments_are_allowed(tmp_path: Path) -> None:
+    checker = _load_checker()
+    source_file = tmp_path / "ordered_steps.py"
+    source_file.write_text(
+        """
+def deploy() -> None:
+    # Step 1: validate local state.
+    # Step 2: publish evidence.
+    return None
+""",
+        encoding="utf-8",
+    )
+
+    assert checker.check_file(source_file) == []
+
+
+def test_strict_mode_blocks_warnings(tmp_path: Path) -> None:
+    checker = _load_checker()
+    source_file = tmp_path / "warning_only.py"
+    source_file.write_text(
+        '''
+def boilerplate_helper() -> None:
+    """This function handles the specified input."""
+''',
+        encoding="utf-8",
+    )
+
+    assert checker.main(["--strict", str(source_file)]) == 2
+    assert checker.main([str(source_file)]) == 0


### PR DESCRIPTION
## Summary\n- Add direct tests for scripts/validation/check_ai_slop.py.\n- Cover docstring errors/warnings, suppression marker behavior, Markdown step narration, fenced Markdown code examples, Python ordered-step comments, and strict-mode warning exit codes.\n- Normalized check_ai_slop Markdown behavior to skip fenced code blocks and keep Python ordered-step comments allowed, matching newer validator copies.\n\n## Verification\n- env -u PYTHONPATH uv run pytest tests/unit/scripts/test_check_ai_slop.py -q\n- env -u PYTHONPATH uv run ruff check tests/unit/scripts/test_check_ai_slop.py tests/unit/scripts/__init__.py\n- env -u PYTHONPATH uv run python scripts/validation/check_ai_slop.py --strict tests/unit/scripts/test_check_ai_slop.py\n- commit hooks passed\n\n## Worktree Cleanup\n- Worktree: /Users/jonah/Code/omni_home/omni_worktrees/OMN-11621/omnimemory\n- Status before PR: clean, branch pushed and tracking origin.\n- Cleanup deferred until PR merge per workspace closeout policy.\n\nRefs OMN-11621