### PR TITLE
ci(OMN-11718): add dev branch workflow triggers

### DIFF
--- a/.github/workflows/ban-hardcoded-runner-ip.yml
+++ b/.github/workflows/ban-hardcoded-runner-ip.yml
@@ -9,7 +9,7 @@ name: Ban Hardcoded Runner IP
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - .github/workflows/**
   merge_group:

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -3,7 +3,7 @@
 name: Build and push migration image to ECR
 on:
   push:
-    branches: [main]
+    branches: [main, 'hotfix/**']
     paths:
       - 'deployment/docker/Dockerfile.migrate'
       - 'deployment/database/migrations/**'

--- a/.github/workflows/call-reject-skip.yml
+++ b/.github/workflows/call-reject-skip.yml
@@ -15,7 +15,7 @@ name: Reject skip-gate bypass tokens
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev]
   merge_group:
 
 permissions:

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -4,9 +4,9 @@ name: Check Architecture Handshake
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'hotfix/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'hotfix/**']
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/contract-validation.yml
+++ b/.github/workflows/contract-validation.yml
@@ -22,7 +22,7 @@ name: Contract Validation
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -6,7 +6,7 @@ name: docs-validate
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'hotfix/**']
   merge_group:
 
 jobs:

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -5,9 +5,9 @@ name: Omni* Ecosystem Standards Compliance
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'hotfix/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev, develop]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ name: Pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'hotfix/**']
   merge_group:
 
 jobs:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,9 +9,9 @@ name: Security Scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'hotfix/**']
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   merge_group:
   schedule:
     # Run weekly on Monday at 06:00 UTC

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -19,7 +19,7 @@ name: Stale TODO Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   merge_group:
 
 jobs:

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -28,6 +28,7 @@ on:
     types: [closed]
     branches:
       - main
+      - dev
 
 jobs:
   todo-audit:


### PR DESCRIPTION
## Summary
- Adds dev alongside main for PR workflow branch filters.
- Adds dev coverage to merge_group branch filters where branch filters exist.
- Keeps release or deploy-only workflows scoped to main where they are not PR validation gates.

Evidence-Ticket: OMN-11718
Evidence-Source: OCC#1383
Related: OMN-11730, OMN-11731

## Verification
- Workflow YAML parse passed.
- Trigger audit passed: no main-targeted PR or merge_group branch filter is missing dev.
- git diff --check.
- actionlint scoped to modified files passed or only reported pre-existing findings outside this trigger edit.