### PR TITLE
ci(OMN-11867): add imperative contract guard

### DIFF
--- a/.github/workflows/imperative-contract-guard.yml
+++ b/.github/workflows/imperative-contract-guard.yml
@@ -1,0 +1,15 @@
+name: Imperative Contract Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  imperative-contract-guard:
+    # self-gating-ok: central guard is intentionally shared across repos; caller PRs do not modify the referenced workflow.
+    uses: OmniNode-ai/onex_change_control/.github/workflows/imperative-contract-guard.yml@main


### PR DESCRIPTION
## Summary
- Add the central imperative contract guard reusable workflow to CI.
- Blocks unbaselined imperative node/handler drift using onex_change_control baselines.

## Verification
- actionlint .github/workflows/imperative-contract-guard.yml
- uv run pre-commit run --files .github/workflows/imperative-contract-guard.yml
- uv run check-imperative-contracts --repo-root /Users/jonah/Code/omni_home/omni_worktrees/OMN-11867/omnimemory --allowlists-dir allowlists

Linear: OMN-11867
Evidence-Ticket: OMN-11867
Evidence-Source: d4ecc40c8a283706d294f5a0c5e87b108a0fefc6