### PR TITLE
ci(OMN-12245): skip TODO audit without ticket branch

### DIFF
--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -52,12 +52,12 @@ jobs:
 
           # Epic branch: epic/OMN-XXXX/OMN-YYYY/...
           if printf '%s' "$BRANCH" | grep -qiE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)"; then
-            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)" | grep -ioE "OMN-[0-9]+" | tail -1)
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "^epic/OMN-[0-9]+/(OMN-[0-9]+)(/|$)" | grep -ioE "OMN-[0-9]+" | tail -1 || true)
           fi
 
           # Standard: */omn-XXXX-* or omn-XXXX-*
           if [[ -z "$TICKET_ID" ]]; then
-            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "(OMN|omn)-[0-9]+" | head -1 | tr '[:lower:]' '[:upper:]')
+            TICKET_ID=$(printf '%s' "$BRANCH" | grep -ioE "(OMN|omn)-[0-9]+" | head -1 | tr '[:lower:]' '[:upper:]' || true)
           fi
 
           if [[ -z "$TICKET_ID" ]]; then


### PR DESCRIPTION
## Summary\n- keep TODO Audit on Merge from failing under bash -e when a closed PR branch has no OMN ticket id\n- preserve the existing skip behavior for Dependabot-style branches\n\n## Verification\n- local bash -e -o pipefail reproduction with dependabot branch name prints skip and exits 0