### PR TITLE
chore(deps): bump omnibase-core to 0.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "pyyaml>=6.0.3,<7.0.0",
 
     # ONEX dependencies - versioned releases from PyPI
-    "omnibase-core==0.42.0",
+    "omnibase-core==0.43.0",
     "omnibase-spi==0.21.0",
     "omnibase-infra==0.36.1",
 
@@ -392,7 +392,7 @@ markers = [
 [tool.uv]
 # Override omnibase-infra's transitive pins on core/spi so our direct pins win.
 override-dependencies = [
-    "omnibase-core==0.42.0",
+    "omnibase-core==0.43.0",
     "omnibase-spi==0.21.0",
     "omnibase-infra==0.36.1",
     "omnibase-compat==0.4.1",
@@ -403,9 +403,9 @@ override-dependencies = [
 
 [tool.uv.sources]
 omninode-memory = { workspace = true }
-# Pinned to main while 2026-05-21 release wave 2 upstream packages are unpublished on PyPI.
-# Switch to PyPI pins after omnibase-core v0.42.0 / omnibase-infra v0.36.1 / omnibase-spi v0.21.0 / omnibase-compat v0.4.1 publish.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", branch = "main" }
+# Pinned to release tags while 2026-05-21 release wave 2 upstream packages are unpublished on PyPI.
+# Switch to PyPI pins after omnibase-core v0.43.0 / omnibase-infra v0.36.1 / omnibase-spi v0.21.0 / omnibase-compat v0.4.1 publish.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", tag = "v0.43.0" }
 omnibase-infra = { git = "https://github.com/OmniNode-ai/omnibase_infra.git", branch = "main" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 omnibase-compat = { git = "https://github.com/OmniNode-ai/omnibase_compat.git", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -1305,8 +1305,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.41.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#27aeae055648c535bc6397dfc7018c4cb4dba4fb" }
+version = "0.42.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#875a4ff7c1e7026fe5c619a0125a974ff6d0731b" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "omnibase-compat", git = "https://github.com/OmniNode-ai/omnibase_compat.git?branch=main" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.43.0" },
     { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "omnimarket", git = "https://github.com/OmniNode-ai/omnimarket.git?rev=e6cc7c603f1d4e7ed287f9ec9a6d3c85328b8d64" },
@@ -1305,8 +1305,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.42.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main#875a4ff7c1e7026fe5c619a0125a974ff6d0731b" }
+version = "0.43.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.43.0#1df6b8119506dc3c03f849db3f1fbd33b5e78f05" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -1428,7 +1428,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'graph'", specifier = ">=0.28.1,<1.0.0" },
     { name = "mcp", specifier = ">=1.27.1,<2.0.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?branch=main" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.43.0" },
     { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "pinecone-client", specifier = ">=6.0.0,<7.0.0" },


### PR DESCRIPTION
## Summary

Automated dependency bump triggered by a new release of `omnibase_core` (v0.43.0).

- Updates `uv.lock` via `uv lock --upgrade-package omnibase_core`
- No source code changes -- lockfile only

## Triggered by

Release workflow: https://github.com/OmniNode-ai/omnibase_core/actions/runs/26792849454

## Test plan

- [ ] CI passes (lockfile resolution is valid)
- [ ] Downstream tests pass with the new dependency version