### PR TITLE
build(OMN-12929): update memory redis dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "alembic>=1.18.4,<2.0.0",
 
     # Redis support for caching and ephemeral memory
-    "redis>=6.4.0,<8.0.0",
+    "redis>=8.0.0,<9.0.0",
 
     # Vector database support
     # Pinecone for vector memory storage
@@ -61,7 +61,7 @@ dependencies = [
     # ONEX dependencies - versioned releases from PyPI
     "omnibase-core==0.43.0",
     "omnibase-spi==0.22.0",
-    "omnibase-infra==0.36.1",
+    "omnibase-infra==0.38.3",
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
@@ -394,7 +394,7 @@ markers = [
 override-dependencies = [
     "omnibase-core==0.43.0",
     "omnibase-spi==0.22.0",
-    "omnibase-infra==0.36.1",
+    "omnibase-infra==0.38.3",
     "omnibase-compat==0.4.1",
     "omninode-memory==0.16.0",
     "omnimarket==0.3.1",
@@ -404,7 +404,7 @@ override-dependencies = [
 [tool.uv.sources]
 omninode-memory = { workspace = true }
 # Pinned to release tags while 2026-05-21 release wave 2 upstream packages are unpublished on PyPI.
-# Switch to PyPI pins after omnibase-core v0.43.0 / omnibase-infra v0.36.1 / omnibase-spi v0.21.0 / omnibase-compat v0.4.1 publish.
+# Switch to PyPI pins after omnibase-core v0.43.0 / omnibase-infra v0.38.3 / omnibase-spi v0.21.0 / omnibase-compat v0.4.1 publish.
 omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", tag = "v0.43.0" }
 omnibase-infra = { git = "https://github.com/OmniNode-ai/omnibase_infra.git", branch = "main" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }

--- a/src/omnimemory/handlers/adapters/adapter_valkey.py
+++ b/src/omnimemory/handlers/adapters/adapter_valkey.py
@@ -50,14 +50,15 @@ import asyncio
 import inspect
 import logging
 import warnings
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, TypeAlias, TypeVar, cast, overload
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 _T = TypeVar("_T")
 type _ResetPipeline = Callable[[], Awaitable[None]]
+type _RedisScalar = bytes | bytearray | memoryview[int] | str | int | float
 
 # redis-py is compatible with both Redis and Valkey
 # Type alias for Redis client - provides IDE support while handling incomplete stubs
@@ -450,6 +451,12 @@ class AdapterValkey:
         """
         return f"{self._config.key_prefix}{key}"
 
+    @overload
+    async def _ensure_awaited(self, result: Awaitable[_T]) -> _T: ...
+
+    @overload
+    async def _ensure_awaited(self, result: _T) -> _T: ...
+
     async def _ensure_awaited(  # stub-ok: redis-py-awaitable-helper-deferred
         self, result: _T | Awaitable[_T]
     ) -> _T:
@@ -771,7 +778,7 @@ class AdapterValkey:
     async def hset(
         self,
         key: str,
-        mapping: dict[str, str],
+        mapping: Mapping[str, str],
     ) -> int:
         """Set multiple hash fields.
 
@@ -785,8 +792,9 @@ class AdapterValkey:
         if not mapping:
             return 0
         client = self._ensure_initialized()
+        redis_mapping = cast("Mapping[_RedisScalar, _RedisScalar]", mapping)
         result = await self._ensure_awaited(
-            client.hset(self._prefixed_key(key), mapping=mapping)  # pyright: ignore[reportArgumentType]
+            client.hset(self._prefixed_key(key), mapping=redis_mapping)
         )
         return int(result)
 

--- a/uv.lock
+++ b/uv.lock
@@ -19,22 +19,18 @@ overrides = [
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.2"
+version = "0.3.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "culsans", marker = "python_full_version < '3.13'" },
     { name = "google-api-core" },
-    { name = "googleapis-common-protos" },
     { name = "httpx" },
     { name = "httpx-sse" },
-    { name = "json-rpc" },
-    { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/f3/1c312eae0298542eef1a096be378a3ad2d20b171ea0ac6be26b81f542720/a2a_sdk-1.0.2.tar.gz", hash = "sha256:e4ee4dd509894c32c9a6df728319875fa4f049e70ae82476fa447353e3a4b648", size = 375193, upload-time = "2026-04-24T13:50:24.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/97/a6840e01795b182ce751ca165430d46459927cde9bfab838087cbb24aef7/a2a_sdk-0.3.26.tar.gz", hash = "sha256:44068e2d037afbb07ab899267439e9bc7eaa7ac2af94f1e8b239933c993ad52d", size = 274598, upload-time = "2026-04-09T15:21:13.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/03/58c92a44e7b94a42614880df2365f074969e47067c4c736e31e855aca2fd/a2a_sdk-1.0.2-py3-none-any.whl", hash = "sha256:4dbc083b6808ee28207ac6daad263360f87612c37b2d06f5521efb530318141c", size = 234302, upload-time = "2026-04-24T13:50:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/51f4ee1bf3b736add42a542d3c8a3fd3fa85f3d36c17972127defc46c26f/a2a_sdk-0.3.26-py3-none-any.whl", hash = "sha256:754e0573f6d33b225c1d8d51f640efa69cbbed7bdfb06ce9c3540ea9f58d4a91", size = 151016, upload-time = "2026-04-09T15:21:12.35Z" },
 ]
 
 [[package]]
@@ -140,20 +136,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/e8/105a1ef62b091b1fa7d5f236668140c776736dc87da66d8bc1aa26d4f84d/aiokafka-0.11.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:818a6f8e44b02113b9e795bee6029c8a4e525ab38f29d7adb0201f3fec74c808", size = 1170166, upload-time = "2024-06-30T16:53:02.441Z" },
     { url = "https://files.pythonhosted.org/packages/55/00/81c805688d5aa286be1ab57ed30fe665ebec74ad2305fa9aa2b29018e140/aiokafka-0.11.0-cp312-cp312-win32.whl", hash = "sha256:8ba981956243767b37c929845c398fda2a2e35a4034d218badbe2b62e6f98f96", size = 347690, upload-time = "2024-06-30T16:53:04.259Z" },
     { url = "https://files.pythonhosted.org/packages/55/94/f532c5789cdef414bb185ac9a62c30a817fd6eae5364339a90d317166bca/aiokafka-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a478a14fd23fd1ffe9c7a21238d818b5f5e0626f7f06146b687f3699298391b", size = 365916, upload-time = "2024-06-30T16:53:06.126Z" },
-]
-
-[[package]]
-name = "aiologic"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/13/50b91a3ea6b030d280d2654be97c48b6ed81753a50286ee43c646ba36d3c/aiologic-0.16.0.tar.gz", hash = "sha256:c267ccbd3ff417ec93e78d28d4d577ccca115d5797cdbd16785a551d9658858f", size = 225952, upload-time = "2025-11-27T23:48:41.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/27/206615942005471499f6fbc36621582e24d0686f33c74b2d018fcfd4fe67/aiologic-0.16.0-py3-none-any.whl", hash = "sha256:e00ce5f68c5607c864d26aec99c0a33a83bdf8237aa7312ffbb96805af67d8b6", size = 135193, upload-time = "2025-11-27T23:48:40.099Z" },
 ]
 
 [[package]]
@@ -527,19 +509,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
     { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
     { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
-]
-
-[[package]]
-name = "culsans"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
 ]
 
 [[package]]
@@ -971,15 +940,6 @@ wheels = [
 ]
 
 [[package]]
-name = "json-rpc"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1332,8 +1292,8 @@ dependencies = [
 
 [[package]]
 name = "omnibase-infra"
-version = "0.36.1"
-source = { git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main#4389973ac2274eaa21b1017a287a414dfc34deb0" }
+version = "0.38.3"
+source = { git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main#5ffe2978911ab17d2b7e5446299c77688e04ae0d" }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "aiofiles" },
@@ -1448,7 +1408,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3,<7.0.0" },
     { name = "qdrant-client", specifier = ">=1.18.0,<1.19.0" },
     { name = "qdrant-client", marker = "extra == 'graph'", specifier = ">=1.18.0,<1.19.0" },
-    { name = "redis", specifier = ">=6.4.0,<8.0.0" },
+    { name = "redis", specifier = ">=8.0.0,<9.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0.0" },
     { name = "structlog", specifier = ">=25.5.0,<26.0.0" },
     { name = "supabase", specifier = ">=2.30.1,<3.0.0" },
@@ -2242,11 +2202,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "6.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]
@@ -2474,15 +2434,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the stale Dependabot Redis 8 branch with a ticket-bound OMN-12929 branch
- update omnimemory Redis to >=8,<9 and align omnibase-infra to 0.38.3 so the resolver accepts Redis 8
- refresh uv.lock with the minimal dependency changes needed for Redis 8 compatibility

## Supersedes
- https://github.com/OmniNode-ai/omnimemory/pull/359

## Evidence
Evidence-Ticket: OMN-12929
Evidence-Source: OCC#2441
Evidence-PR: https://github.com/OmniNode-ai/onex_change_control/pull/2441

## Verification
- uv lock --check
- uv sync --frozen --all-extras --all-groups --no-install-project
- uv run ruff check src/ tests/
- uv run pyright (0 errors, existing warnings only)
- uv run --with pytest --with pytest-asyncio --with pytest-cov python -m pytest tests/handlers/adapters/test_adapter_rate_limiter.py tests/test_health_manager.py tests/handlers/adapters/test_adapter_embedding_http.py -q (124 passed)