### PR TITLE
docs(OMN-13181): refresh omnimemory documentation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -13,7 +13,7 @@
 
 - Tests: `uv run pytest -m unit`
 - Lint: `uv run ruff check src/ tests/`
-- Type check: `uv run mypy src/omnimemory/`
+- Type check: `uv run mypy src/omnimemory/ --strict`
 - Pre-commit: `pre-commit run --all-files`
 
 ## Cross-Repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ uv run ruff format src/ tests/
 uv run ruff check --fix src/ tests/
 
 # Type checking
-uv run mypy src/omnimemory
+uv run mypy src/omnimemory --strict
 
 # Testing
 uv run pytest                        # All tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OmniMemory holds three distinct ownership roles in the ONEX platform:
 
 3. **Storage integration owner for Qdrant, Memgraph, Valkey, and Kreuzberg adapters.** The concrete adapter implementations for all memory-layer storage backends live in `omnimemory`. These adapters implement the domain protocols and are injected at runtime via the DI container.
 
-**What is migrating to omnimarket:** The 17 runnable ONEX node handler implementations (those with `contract.yaml`) are moving to `omnimarket` as part of OMN-8295. Protocols, models, adapters, and the runtime plugin stay here. See [docs/migrations/MARKET_MIGRATION_BOUNDARY.md](docs/migrations/MARKET_MIGRATION_BOUNDARY.md).
+**What is migrating to omnimarket:** The 15 runnable ONEX node handler implementations (those with `contract.yaml`) are moving to `omnimarket` as part of OMN-8295. Protocols, models, adapters, and the runtime plugin stay here. See [docs/migrations/MARKET_MIGRATION_BOUNDARY.md](docs/migrations/MARKET_MIGRATION_BOUNDARY.md).
 
 ---
 
@@ -29,7 +29,7 @@ OmniMemory holds three distinct ownership roles in the ONEX platform:
 - **Storage adapters** — Qdrant, Memgraph, Valkey, and filesystem adapter implementations in `handlers/adapters/` and `nodes/*/adapters/`
 - **Runtime plugin** — `PluginMemory` in `src/omnimemory/runtime/` registered as `onex.domain_plugins`
 - **Memory-layer data services** — Qdrant, Memgraph, Valkey, Kreuzberg (owned via `docker-compose.yml`)
-- **Node handlers** — 17 runnable nodes in `src/omnimemory/nodes/` (migrating to omnimarket per OMN-8295)
+- **Node handlers** — 15 runnable nodes in `src/omnimemory/nodes/` (migrating to omnimarket per OMN-8295)
 
 ## What This Repo Does Not Own
 
@@ -50,10 +50,12 @@ Follows the [ONEX Four-Node Architecture](https://github.com/OmniNode-ai/omnibas
 
 ### Node inventory
 
-- **Effect nodes** — `memory_storage_effect`, `memory_retrieval_effect`, `agent_learning_retrieval_effect`, `intent_storage_effect`, `intent_query_effect`, `intent_event_consumer_effect`, `filesystem_crawler_effect`, `kreuzberg_parse_effect`, `persona_storage_effect`, `persona_retrieval_effect`
+- **Effect nodes** — `memory_storage_effect`, `memory_retrieval_effect`, `agent_learning_retrieval_effect`, `intent_storage_effect`, `intent_query_effect`, `intent_event_consumer_effect`, `filesystem_crawler_effect`, `kreuzberg_parse_effect`, `persona_storage_effect`
 - **Compute nodes** — `semantic_analyzer_compute`, `similarity_compute`, `persona_builder_compute`
-- **Reducer nodes** — `navigation_history_reducer` (+ stubs: `memory_consolidator_reducer`, `statistics_reducer`)
-- **Orchestrator nodes** — `memory_lifecycle_orchestrator`, `agent_coordinator_orchestrator`, `persona_lifecycle_orchestrator`
+- **Reducer nodes** — `navigation_history_reducer`, `memory_consolidator_reducer` (stub — no contract.yaml)
+- **Orchestrator nodes** — `memory_lifecycle_orchestrator`, `agent_coordinator_orchestrator`
+
+> `node_persona_lifecycle_orchestrator` and `node_persona_retrieval_effect` were decommissioned in OMN-12172; they never had a `contract.yaml` and are no longer present in the repository.
 
 ### Memory evolution (planned phases)
 
@@ -171,10 +173,10 @@ src/omnimemory/
 │   └── <node>/
 │       ├── adapters/   # Stays in omnimemory (protocol implementations)
 │       └── handlers/   # Migrating to omnimarket (OMN-8295)
+├── adapters/           # Shared utilities with adapter_* prefix (PII detection, retry, health, metrics)
 ├── protocols/          # Protocol interfaces (embedding, intent graph, secrets)
 ├── runtime/            # PluginMemory, DI container wiring, dispatch, introspection
-├── tools/              # Contract linter and stubs
-└── utils/              # Shared utilities (audit logger, PII detection, retry, health)
+└── tools/              # Contract linter and validators
 ```
 
 ---

--- a/docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md
+++ b/docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 # ONEX Four-Node Architecture in OmniMemory
 
-> **Version**: 0.1.0
-> **Last Updated**: 2026-02-19
+> **Version**: 0.2.0
+> **Last Updated**: 2026-06-16
 > **Status**: Active
 
 ## Overview
@@ -84,11 +84,15 @@ to produce side effects.
 
 | Directory | Handler | Responsibility |
 |-----------|---------|----------------|
-| `nodes/intent_event_consumer_effect/` | `HandlerIntentEventConsumer` | Consumes `intent-classified.v1` events from Kafka, persists to Memgraph via `HandlerIntentStorageAdapter` |
-| `nodes/intent_storage_effect/` | `HandlerIntentStorageAdapter` | Writes intent records to the graph store |
-| `nodes/intent_query_effect/` | `HandlerIntentQuery` | Queries stored intents, returns results over the event bus |
-| `nodes/memory_retrieval_effect/` | `HandlerMemoryRetrieval` | Retrieves memory records from Qdrant, PostgreSQL, and Memgraph |
-| `nodes/memory_storage_effect/` | `AdapterFilesystem` | Persists memory payloads to the filesystem adapter |
+| `nodes/node_intent_event_consumer_effect/` | `HandlerIntentEventConsumer` | Consumes `intent-classified.v1` events from Kafka, persists to Memgraph via `HandlerIntentStorageAdapter` |
+| `nodes/node_intent_storage_effect/` | `HandlerIntentStorageAdapter` | Writes intent records to the graph store |
+| `nodes/node_intent_query_effect/` | `HandlerIntentQuery` | Queries stored intents, returns results over the event bus |
+| `nodes/node_memory_retrieval_effect/` | `HandlerMemoryRetrieval` | Retrieves memory records from Qdrant, PostgreSQL, and Memgraph |
+| `nodes/node_memory_storage_effect/` | `AdapterFilesystem` | Persists memory payloads to the filesystem adapter |
+| `nodes/node_filesystem_crawler_effect/` | `HandlerFilesystemCrawler` | Crawls the local filesystem for document discovery |
+| `nodes/node_kreuzberg_parse_effect/` | `HandlerKreuzbergParse` | Sends documents to the Kreuzberg parser service for text extraction |
+| `nodes/node_agent_learning_retrieval_effect/` | `HandlerAgentLearningRetrieval` | Retrieves learning context for agent sessions |
+| `nodes/node_persona_storage_effect/` | `HandlerPersonaStorage` | Persists persona signals and profile updates |
 
 ### COMPUTE Nodes
 
@@ -118,13 +122,12 @@ counters.
 
 **OmniMemory REDUCER nodes:**
 
-| Directory | Responsibility |
-|-----------|----------------|
-| `nodes/statistics_reducer/` | Aggregates memory operation metrics and statistics |
-| `nodes/memory_consolidator_reducer/` | Merges and deduplicates overlapping memory records |
+| Directory | Responsibility | Status |
+|-----------|----------------|--------|
+| `nodes/node_navigation_history_reducer/` | Aggregates and persists agent navigation history | Runnable (has `contract.yaml`) |
+| `nodes/node_memory_consolidator_reducer/` | Merges and deduplicates overlapping memory records | Stub — no `contract.yaml`; scaffolded skeleton only |
 
-> Both reducer nodes are currently scaffolded. Implementation is in progress as
-> part of the Core 8 memory pipeline.
+> `node_statistics_reducer` was decommissioned in OMN-12172 and is no longer present in the repository.
 
 ### ORCHESTRATOR Nodes
 
@@ -136,8 +139,10 @@ They do not perform I/O directly — they delegate to EFFECT nodes.
 
 | Directory | Handler | Responsibility |
 |-----------|---------|----------------|
-| `nodes/memory_lifecycle_orchestrator/` | `HandlerMemoryTick`, `HandlerMemoryArchive`, `HandlerMemoryExpire` | Drives time-based lifecycle: ticking expiry counters, archiving old memories, expiring stale records |
-| `nodes/agent_coordinator_orchestrator/` | (in progress) | Routes memory requests across agents, coordinates cross-service memory operations |
+| `nodes/node_memory_lifecycle_orchestrator/` | `HandlerMemoryTick`, `HandlerMemoryArchive`, `HandlerMemoryExpire` | Drives time-based lifecycle: ticking expiry counters, archiving old memories, expiring stale records |
+| `nodes/node_agent_coordinator_orchestrator/` | (in progress) | Routes memory requests across agents, coordinates cross-service memory operations |
+
+> `node_persona_lifecycle_orchestrator` was decommissioned in OMN-12172 (never had a `contract.yaml`) and is no longer present in the repository.
 
 ---
 

--- a/docs/ci/CI_MONITORING_GUIDE.md
+++ b/docs/ci/CI_MONITORING_GUIDE.md
@@ -9,20 +9,26 @@
 
 ## Overview
 
-OmniMemory CI runs on GitHub Actions and is defined in two workflow files:
+OmniMemory CI runs on GitHub Actions and is defined in the following workflow files:
 
 | File | Trigger | Purpose |
 |------|---------|---------|
-| `.github/workflows/test.yml` | Push to `main`/`develop`, all PRs | Full validation pipeline |
-| `.github/workflows/pre-commit.yml` | Push to `main`, all PRs | Pre-commit hook validation |
+| `.github/workflows/ci.yml` | Push to `dev`/`main`, all PRs | Full validation pipeline |
+| `.github/workflows/pre-commit.yml` | Push to `dev`/`main`, all PRs | Pre-commit hook validation |
+| `.github/workflows/imperative-contract-guard.yml` | All PRs | Enforces no imperative I/O in contract-managed paths |
+| `.github/workflows/omni-standards-compliance.yml` | All PRs | Platform-wide naming, typing, and pattern compliance |
+| `.github/workflows/stale-todo-gate.yml` | All PRs | Blocks unresolved TODO annotations |
+| `.github/workflows/docs-validate.yml` | All PRs | Validates documentation structure and links |
+| `.github/workflows/cr-thread-gate.yml` | All PRs | Fails if unresolved CodeRabbit review threads exist |
+| `.github/workflows/pr-title-check.yml` | All PRs | Enforces `OMN-XXXX` ticket reference in PR title |
 
-The full pipeline runs in three phases:
+The full validation pipeline (`ci.yml`) runs in three phases:
 
 - **Phase 1** (parallel, ~5 min): `migration-freeze`, `lint`, `pyright`, `onex-validation`, `transport-import-guard`, `contract-validation`, `io-audit`, `check-handshake`
 - **Phase 2** (after Phase 1): `test` — full test suite with coverage
 - **Phase 3** (aggregation): `test-summary` — gates the overall pass/fail result
 
-Every CI validation job has a corresponding pre-commit hook so that "works locally, fails in CI" drift is prevented. The synchronization map is documented in `.pre-commit-config.yaml` and `.github/workflows/test.yml`.
+Every CI validation job has a corresponding pre-commit hook so that "works locally, fails in CI" drift is prevented. The synchronization map is documented in `.pre-commit-config.yaml` and `.github/workflows/ci.yml`.
 
 ---
 
@@ -33,7 +39,7 @@ Every CI validation job has a corresponding pre-commit hook so that "works local
 **What it checks**: Prevents direct Kafka client imports (`aiokafka`, `kafka`, `confluent_kafka`) from appearing in `src/omnimemory/nodes/`. This enforces ARCH-002: "Runtime owns all Kafka plumbing." Nodes must consume events through the abstract `EventBus` SPI provided by the runtime layer.
 
 **Where defined**:
-- CI job: `onex-validation` step "Validate Kafka import boundary (ARCH-002)" in `.github/workflows/test.yml`
+- CI job: `onex-validation` step "Validate Kafka import boundary (ARCH-002)" in `.github/workflows/ci.yml`
 - Script: `scripts/validation/validate_kafka_imports.py`
 - Pre-commit hook: `validate-kafka-imports` in `.pre-commit-config.yaml` (stage: `pre-commit`)
 
@@ -77,7 +83,7 @@ poetry run python scripts/validation/validate_kafka_imports.py src/
 **What it enforces**: While `.migration_freeze` exists at the repository root, no new migration files may be added to `deployment/database/migrations/`. This freeze was activated during the DB-per-repo refactor (OMN-2055) on 2026-02-10. Modifications to existing migration files (bug fixes, comment tweaks) are allowed during the freeze.
 
 **Where defined**:
-- CI job: `migration-freeze` in `.github/workflows/test.yml`
+- CI job: `migration-freeze` in `.github/workflows/ci.yml`
 - Script: `scripts/check_migration_freeze.sh`
 - Freeze sentinel: `.migration_freeze` (root of repo)
 - Pre-commit hook: `migration-freeze-check` in `.pre-commit-config.yaml` (stage: `pre-commit`, triggered by changes to `deployment/database/migrations/` or `.migration_freeze`)
@@ -112,7 +118,7 @@ New migrations are blocked while `.migration_freeze` exists. To proceed:
 **What it checks**: An AST-based validator that ensures nodes do not import transport or I/O libraries at runtime. This is the stricter, AST-aware counterpart to the regex-based Kafka import guard above. It covers a broader set of banned modules across all of `src/omnimemory/` (excluding `src/omnimemory/runtime/`).
 
 **Where defined**:
-- CI job: `transport-import-guard` in `.github/workflows/test.yml`
+- CI job: `transport-import-guard` in `.github/workflows/ci.yml`
 - Script: `scripts/validate_no_transport_imports.py`
 - Whitelist: `tests/audit/transport_import_whitelist.yaml`
 - Pre-commit hook: `validate-no-transport-imports` in `.pre-commit-config.yaml` (stage: `pre-commit`)
@@ -180,12 +186,12 @@ poetry run python scripts/validate_no_transport_imports.py \
 | `contract-validation` | `contract-linter` | OMN-2218 |
 | `io-audit` | `io-audit` | OMN-2218 |
 
-**Current CI tooling versions** (from `.github/workflows/test.yml` and `.pre-commit-config.yaml`):
+**Current CI tooling versions** (from `.github/workflows/ci.yml` and `.pre-commit-config.yaml`):
 
 | Tool | Version | Configuration |
 |------|---------|---------------|
-| Python | 3.12 | `env.PYTHON_VERSION` in `test.yml` |
-| Poetry | 2.2.1 | `env.POETRY_VERSION` in `test.yml` |
+| Python | 3.12 | `env.PYTHON_VERSION` in `ci.yml` |
+| Poetry | 2.2.1 | `env.POETRY_VERSION` in `ci.yml` |
 | ruff | 0.8.6 | `.pre-commit-config.yaml` rev; `pyproject.toml [tool.ruff]` |
 | mypy | ^1.14.0 | `pyproject.toml [tool.mypy]`; CI uses Poetry env |
 | pyright | 1.1.391 | `.pre-commit-config.yaml` rev; `pyrightconfig.json` |

--- a/docs/handler_reuse_matrix.md
+++ b/docs/handler_reuse_matrix.md
@@ -15,7 +15,7 @@ This document maps existing handlers from `omnibase_infra` to the Core 8 memory 
 ## Existing Handlers in omnibase_infra
 
 > **Note**: All paths below are Python module paths within the `omnibase_infra` package.
-> Install via PyPI: `poetry add omnibase-infra`. Handler classes follow the naming
+> Install via PyPI: `uv add omnibase-infra`. Handler classes follow the naming
 > convention `Handler<Name>` (e.g., `HandlerDb`, `HandlerQdrant`).
 
 ### Core Infrastructure Handlers (`omnibase_infra.handlers`)
@@ -486,10 +486,10 @@ Install the `omnibase-infra` package from PyPI:
 
 ```bash
 # Add as development dependency
-poetry add --group dev omnibase-infra
+uv add --group dev omnibase-infra
 
 # Or add as a regular dependency
-poetry add omnibase-infra
+uv add omnibase-infra
 ```
 
 > **Naming Convention**: The PyPI package name uses hyphens (`omnibase-infra`) while

--- a/docs/migrations/MARKET_MIGRATION_BOUNDARY.md
+++ b/docs/migrations/MARKET_MIGRATION_BOUNDARY.md
@@ -11,7 +11,7 @@
 
 ## Migration Goal
 
-Migrate all 17 runnable ONEX nodes from `omnimemory` into `omnimarket`, leaving `omnimemory` as a **pure primitives package**: models, protocols, and storage adapters.
+Migrate all 15 runnable ONEX nodes from `omnimemory` into `omnimarket`, leaving `omnimemory` as a **pure primitives package**: models, protocols, and storage adapters.
 
 After migration, nodes auto-wire via the ONEX runtime's `importlib.metadata` discovery using the `onex.nodes` entry point — exactly like every other omnimarket node. `omnimemory` retains the `onex.domain_plugins` entry point (`PluginMemory`) for runtime plugin lifecycle management.
 
@@ -74,7 +74,7 @@ Qdrant, Memgraph, Valkey, and Kreuzberg remain omnimemory-owned. See [Memory Dat
 
 ## What Moves to omnimarket
 
-All 17 runnable nodes (those with a `contract.yaml`) move to `omnimarket/src/omnimarket/nodes/`:
+All 15 runnable nodes (those with a `contract.yaml`) move to `omnimarket/src/omnimarket/nodes/`:
 
 | Node | Type | Domain |
 |------|------|--------|
@@ -92,17 +92,18 @@ All 17 runnable nodes (those with a `contract.yaml`) move to `omnimarket/src/omn
 | `node_intent_storage_effect` | EFFECT | Intent |
 | `node_navigation_history_reducer` | REDUCER | Navigation |
 | `node_persona_builder_compute` | COMPUTE | Persona |
-| `node_persona_lifecycle_orchestrator` | ORCHESTRATOR | Persona |
-| `node_persona_retrieval_effect` | EFFECT | Persona |
 | `node_persona_storage_effect` | EFFECT | Persona |
 
 **What moves with each node:** handler implementations, node-local models, `contract.yaml`, clients, registry, utils, validators.
 
 **What stays in omnimemory:** each node's `adapters/` subdirectory (concrete protocol implementations injected at runtime via DI).
 
-**Stub nodes (no contract.yaml) — not migrated:**
-- `node_memory_consolidator_reducer` — `__init__.py` skeleton only
-- `node_statistics_reducer` — `__init__.py` skeleton only
+**Stub node (no contract.yaml) — not migrated:**
+- `node_memory_consolidator_reducer` — skeleton only; no `contract.yaml`
+
+**Decommissioned nodes (OMN-12172) — not migrated, not present:**
+- `node_persona_lifecycle_orchestrator` — removed; never had a `contract.yaml`
+- `node_persona_retrieval_effect` — removed; never had a `contract.yaml`
 
 ---
 
@@ -114,7 +115,7 @@ All 17 runnable nodes (those with a `contract.yaml`) move to `omnimarket/src/omn
 | 2 | `node_memory_storage_effect`, `node_memory_retrieval_effect`, `node_persona_storage_effect`, `node_persona_retrieval_effect`, `node_agent_learning_retrieval_effect` | OMN-8298 |
 | 3 | `node_filesystem_crawler_effect`, `node_kreuzberg_parse_effect` | OMN-8299 |
 | 4 | `node_intent_storage_effect`, `node_intent_query_effect`, `node_intent_event_consumer_effect` | OMN-8300 |
-| 5 | `node_memory_lifecycle_orchestrator`, `node_navigation_history_reducer`, `node_persona_lifecycle_orchestrator`, `node_agent_coordinator_orchestrator` | OMN-8301 |
+| 5 | `node_memory_lifecycle_orchestrator`, `node_navigation_history_reducer`, `node_agent_coordinator_orchestrator` | OMN-8301 |
 
 Pre-work: add `omninode-memory` dependency to omnimarket (OMN-8296, blocks Wave 1).
 
@@ -146,7 +147,7 @@ Pre-work: add `omninode-memory` dependency to omnimarket (OMN-8296, blocks Wave 
 
 ## Post-Migration omnimemory State
 
-After all 17 nodes move:
+After all 15 nodes move:
 
 - `nodes/` retains only adapter subdirectories and stub nodes
 - The `onex.node_package` entry point (if present) is removed from `pyproject.toml`

--- a/docs/runtime/RUNTIME_PLUGINS.md
+++ b/docs/runtime/RUNTIME_PLUGINS.md
@@ -30,7 +30,8 @@ All runtime modules live under `src/omnimemory/runtime/`:
 | `dispatch_handlers.py` | `create_memory_dispatch_engine`, bridge handlers |
 | `contract_topics.py` | Contract-driven topic discovery |
 | `adapters.py` | `AdapterKafkaPublisher`, event bus protocols |
-| `introspection.py` | `publish_memory_introspection`, `MemoryNodeIntrospectionProxy` |
+| `introspection.py` | `publish_memory_introspection`, `MemoryNodeIntrospectionProxy`, dynamic node discovery |
+| `handler_lifecycle.py` | Lifecycle handler for runtime tick and shutdown signals |
 
 ---
 
@@ -97,11 +98,11 @@ if plugin and plugin.should_activate(config):
 The plugin is declared in `pyproject.toml` so ONEX kernels can discover it automatically via `importlib.metadata`:
 
 ```toml
-[tool.poetry.plugins."onex.domain_plugins"]
+[project.entry-points."onex.domain_plugins"]
 memory = "omnimemory.runtime.plugin:PluginMemory"
 ```
 
-The entry point group `onex.domain_plugins` is the shared discovery namespace. The key `memory` matches `PluginMemory.plugin_id`.
+The entry point group `onex.domain_plugins` is the shared discovery namespace. The key `memory` matches `PluginMemory.plugin_id`. This uses the hatchling build backend (`[project.entry-points]`), not the legacy Poetry plugin table.
 
 ---
 
@@ -392,21 +393,14 @@ During `wire_dispatchers`, the plugin publishes STARTUP introspection events for
 
 ### Registered Memory Nodes
 
+`MEMORY_NODES` is no longer a hardcoded tuple. It is built dynamically at module import time via contract discovery:
+
 ```python
-MEMORY_NODES: tuple[_NodeDescriptor, ...] = (
-    # Orchestrators
-    _NodeDescriptor("memory_lifecycle_orchestrator", EnumNodeKind.ORCHESTRATOR),
-    _NodeDescriptor("agent_coordinator_orchestrator", EnumNodeKind.ORCHESTRATOR),
-    # Compute nodes
-    _NodeDescriptor("similarity_compute", EnumNodeKind.COMPUTE),
-    _NodeDescriptor("semantic_analyzer_compute", EnumNodeKind.COMPUTE),
-    # Effect nodes (also receive heartbeat tasks)
-    _NodeDescriptor("intent_event_consumer_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("intent_query_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("intent_storage_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("memory_retrieval_effect", EnumNodeKind.EFFECT),
-    _NodeDescriptor("memory_storage_effect", EnumNodeKind.EFFECT),
-)
+MEMORY_NODES: tuple[_NodeDescriptor, ...] = discover_memory_nodes()
 ```
+
+`discover_memory_nodes()` calls `_discover_nodes_from_contracts(base_package="omnimemory.nodes")`, which scans every `node_*/contract.yaml` under the `omnimemory.nodes` package using `importlib.resources`. Each contract's `node_type` field determines the `EnumNodeKind`. Nodes without a `contract.yaml` are skipped automatically.
+
+This means the registered set reflects the actual on-disk contracts at import time. As of the current codebase, 15 nodes with `contract.yaml` are discovered (see README for the full inventory).
 
 Node IDs are deterministic: `uuid5(NAMESPACE_DNS, f"omnimemory.{node_name}")`. This ensures STARTUP and SHUTDOWN events for the same logical node always carry the same `node_id`, regardless of which proxy object published them.

--- a/docs/stub_protocols.md
+++ b/docs/stub_protocols.md
@@ -4,146 +4,17 @@
 
 ## Overview
 
-OmniMemory includes a compatibility layer (`src/omnimemory/compat/`) that provides local implementations for `omnibase_core` components that are not yet available in the installed package version. This document tracks these stubs and their migration path.
+OmniMemory previously included a compatibility layer at `src/omnimemory/compat/` providing local stubs for `omnibase_core` components that were not yet available upstream. The `compat/` directory has been removed. The only remaining compat artifact is `src/omnimemory/_compat_imports.py`, which re-exports `ErrorCodeType` and `SeverityType` type aliases for backward import compatibility.
 
-**Location**: `src/omnimemory/compat/`
+All former stubs (`NodeResult`, `OnexError`/`BaseOnexError`, `ModelONEXContainer`) have been fully migrated to upstream `omnibase_core` equivalents or removed.
 
----
+### Migrated Components (for historical reference)
 
-## Current Stub Implementations
-
-### 1. NodeResult (Monadic Pattern) - MIGRATED
-
-**File**: `src/omnimemory/compat/node_result.py` (deprecated)
-
-**Purpose**: Provides the monadic result pattern for node operations, enabling clean error handling without exceptions.
-
-**Status**: **MIGRATED** - Now using `omnibase_core.models.core.model_base_result.ModelBaseResult`
-
-**Migration Notes**:
-- All protocol return types changed from `NodeResult[T]` to `ModelBaseResult`
-- `result.is_success` changed to `result.success`
-- Success/failure creation now uses direct construction instead of class methods
-- Result values stored in `metadata.custom_fields` instead of direct `.value` access
-
-**New Usage**:
-```python
-from omnibase_core.models.core.model_base_result import ModelBaseResult
-from omnibase_core.models.core.model_error_details import ModelErrorDetails
-from omnibase_core.models.results.model_simple_metadata import ModelGenericMetadata
-
-# Create success result
-result = ModelBaseResult(
-    success=True,
-    exit_code=0,
-    errors=[],
-    metadata=ModelGenericMetadata(custom_fields={"data": {"key": "value"}})
-)
-
-# Create failure result
-result = ModelBaseResult(
-    success=False,
-    exit_code=1,
-    errors=[ModelErrorDetails(error_message="Operation failed", error_code="ERR_001", error_type="runtime", component="memory_operation")]
-)
-
-# Check result
-if result.success:
-    process(result.metadata.custom_fields["data"])
-else:
-    handle_error(result.errors)
-```
-
----
-
-### 2. OnexError / BaseOnexError
-
-**File**: `src/omnimemory/compat/onex_error.py`
-
-**Purpose**: Structured error types for ONEX-compliant error handling with correlation IDs and error codes.
-
-**Upstream Target**: `omnibase_core.core.errors.core_errors.OnexError`
-
-**Status**: Active (core 0.17) - Local stub still required. The upstream package exposes `ModelOnexError` (at `omnibase_core.models.errors.model_onex_error.ModelOnexError`) but does not export `OnexError` or `BaseOnexError` under the originally targeted module path. The local stub remains the canonical source until upstream aligns naming or an explicit migration is performed. Target: tracked in omnibase-core upstream; check CHANGELOG for resolution.
-
-**Usage**:
-```python
-from omnimemory.compat import OnexError, BaseOnexError
-
-# Raise structured error
-raise OnexError(
-    message="Memory storage failed",
-    error_code="MEM_001",
-    correlation_id="abc-123",
-    details={"operation": "store"}
-)
-```
-
----
-
-### 3. ModelOnexContainer / ModelONEXContainer
-
-**File**: `src/omnimemory/compat/model_onex_container.py`
-
-**Purpose**: Dependency injection container for ONEX nodes, providing service registration and resolution.
-
-**Upstream Target**: `omnibase_core.container.ModelONEXContainer`
-
-**Status**: **MIGRATED** — use `omnibase_core` directly. `ModelONEXContainer` is now available in the installed package (omnibase-core 0.17+) at:
-
-```python
-from omnibase_core.container import ModelONEXContainer
-```
-
-Any remaining imports from `omnimemory.compat` for this class should be updated to the upstream path above. The local stub file (`src/omnimemory/compat/model_onex_container.py`) can be deleted once all callers are migrated.
-
----
-
-## Migration Path
-
-### Phase 1: Monitoring (Current)
-
-Monitor `omnibase_core` releases for availability of:
-- `omnibase_core.core.errors.core_errors` (OnexError, BaseOnexError)
-
-**Already migrated** (no longer monitoring):
-- ~~`omnibase_core.core.monadic.model_node_result`~~ - Migrated to `ModelBaseResult` (see Section 1)
-- ~~`omnibase_core.core.model_onex_container`~~ - Migrated to `omnibase_core.container.ModelONEXContainer` (see Section 3)
-
-### Phase 2: Migration
-
-When upstream components become available:
-
-1. **Update Imports**:
-   ```python
-   # Before (using stub)
-   from omnimemory.compat import NodeResult
-
-   # After (using upstream ModelBaseResult)
-   from omnibase_core.models.core.model_base_result import ModelBaseResult
-   ```
-
-   **Note**: NodeResult has been migrated to ModelBaseResult (see section 1 above).
-
-2. **Run Test Suite**:
-   ```bash
-   pytest tests/ -v
-   ```
-
-3. **Verify API Compatibility**:
-   - Ensure upstream API matches local stub
-   - Update any incompatible usages
-
-4. **Remove Stubs**:
-   - Delete files from `src/omnimemory/compat/`
-   - Remove exports from `__init__.py`
-   - Update `docs/stub_protocols.md`
-
-### Phase 3: Cleanup
-
-- Remove `src/omnimemory/compat/` directory
-- Update this documentation
-- Remove migration notes from code
+| Former stub | Upstream replacement | Status |
+|-------------|---------------------|--------|
+| `omnimemory.compat.node_result.NodeResult` | `omnibase_core.models.core.model_base_result.ModelBaseResult` | MIGRATED |
+| `omnimemory.compat.onex_error.OnexError` / `BaseOnexError` | `omnibase_core.models.errors.model_onex_error.ModelOnexError` | MIGRATED |
+| `omnimemory.compat.model_onex_container.ModelONEXContainer` | `omnibase_core.container.ModelONEXContainer` | MIGRATED |
 
 ---
 
@@ -153,7 +24,7 @@ The following features are defined but not fully implemented:
 
 ### PII Detection - Partial Implementation
 
-**File**: `src/omnimemory/utils/pii_detector.py`
+**File**: `src/omnimemory/adapters/adapter_pii_detector.py`
 
 The following `PIIType` values are defined but do not have detection patterns:
 
@@ -167,14 +38,9 @@ See [PII Handling Guide](./pii_handling.md) for details.
 
 ### Health Manager - Placeholder
 
-**File**: `src/omnimemory/utils/health_manager.py`
+**File**: `src/omnimemory/adapters/adapter_health_manager.py`
 
-Contains a placeholder for health check aggregation logic that returns healthy status. Full implementation pending:
-
-```python
-# Current placeholder (line 646)
-# For now, return healthy as a placeholder
-```
+Contains a placeholder for health check aggregation logic that returns healthy status. Full implementation pending.
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes omnimemory documentation to accurately reflect the current codebase state after two PRs that were not accompanied by doc updates:

- **OMN-11575** (PR #335, 2026-05-26): renamed `src/omnimemory/utils/` to `src/omnimemory/adapters/` with `adapter_*` prefix convention.
- **OMN-12172** (PR #333, 2026-05-26): decommissioned 3 stub nodes; refactored `introspection.py` to dynamic contract-driven discovery; added `handler_lifecycle.py`; renamed CI workflow `test.yml` → `ci.yml`.

Ticket: OMN-13181
Parent: OMN-13172

## Files changed

| File | Change |
|------|--------|
| `README.md` | Node count 17→15; removed decommissioned nodes from inventory; `utils/`→`adapters/` in directory tree; completed EFFECT node list to 9 |
| `CLAUDE.md` | Added `--strict` to mypy command (matches `pyproject.toml strict=true`) |
| `AGENT.md` | Added `--strict` to mypy command |
| `docs/stub_protocols.md` | Removed all references to deleted `src/omnimemory/compat/` directory; documented `_compat_imports.py` as sole remaining artifact; updated file paths `utils/`→`adapters/` |
| `docs/runtime/RUNTIME_PLUGINS.md` | Fixed entry-point key `[tool.poetry.plugins]`→`[project.entry-points]` (hatchling); added `handler_lifecycle.py` to module map; replaced stale hardcoded MEMORY_NODES tuple with accurate dynamic discovery description |
| `docs/architecture/ONEX_FOUR_NODE_ARCHITECTURE.md` | Added 4 missing EFFECT nodes; fixed REDUCER section; removed decommissioned orchestrator; updated Last Updated date |
| `docs/migrations/MARKET_MIGRATION_BOUNDARY.md` | Node count 17→15; removed decommissioned nodes; fixed Wave 5 |
| `docs/ci/CI_MONITORING_GUIDE.md` | `test.yml`→`ci.yml` throughout; added 6 additional workflow files to overview table |
| `docs/handler_reuse_matrix.md` | `poetry add`→`uv add` |

## dod_evidence

- Node count (15 runnable with `contract.yaml`, 1 stub) verified by iterating `src/omnimemory/nodes/node_*/contract.yaml`.
- `adapters/` directory existence and `utils/` absence verified by `ls src/omnimemory/`.
- `handler_lifecycle.py` verified by `ls src/omnimemory/runtime/`.
- Dynamic MEMORY_NODES discovery verified from `introspection.py` lines 105–180.
- `[project.entry-points]` format verified from `pyproject.toml`.
- CI workflow filenames verified by `ls .github/workflows/`.
- `pre-commit run --all-files` — all 36 hooks passed.
- The doc diff is the evidence: every change is a direct correction from observed code state at `origin/dev HEAD` (a7c2b6b).

All changes are AI-generated.