### PR TITLE
chore(OMN-13187): refresh omnimemory dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pydantic>=2.13.4,<3.0.0",
 
     # FastAPI web framework for production API
-    "fastapi>=0.136.3,<1.0.0",
+    "fastapi>=0.137.1,<1.0.0",
     "uvicorn[standard]>=0.49.0,<1.0.0",
 
     # Memory and storage components

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dev = [
     # Code formatting and linting (ruff replaces black, isort, flake8 - 10-100x faster)
     # VERSION SYNC: Poetry uses ^0.8.0 (allows updates), pre-commit pins v0.8.6
     # UP007 (PEP 604 union syntax) is ENABLED and organizationally mandated
-    "ruff>=0.8.0,<1.0.0",
+    "ruff>=0.15.17,<1.0.0",
 
     # Type checking (dual checker: mypy strict + pyright basic)
     # VERSION SYNC: Poetry uses caret versions, pre-commit pins exact versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pydantic>=2.13.4,<3.0.0",
 
     # FastAPI web framework for production API
-    "fastapi>=0.137.1,<1.0.0",
+    "fastapi>=0.136.3,<1.0.0",
     "uvicorn[standard]>=0.49.0,<1.0.0",
 
     # Memory and storage components
@@ -65,7 +65,7 @@ dependencies = [
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
-    "structlog>=26.1.0,<27.0.0",
+    "structlog>=25.5.0,<26.0.0",
 
     # Runtime configuration and utilities
     "pydantic-settings>=2.14.1,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 
     # Logging and monitoring
     # Version ^23.3.0 required for compatibility with omnibase-infra (requires ^23.2.0)
-    "structlog>=25.5.0,<26.0.0",
+    "structlog>=26.1.0,<27.0.0",
 
     # Runtime configuration and utilities
     "pydantic-settings>=2.14.1,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [{ name = "OmniNode.ai", email = "contact@omninode.ai" }]
 keywords = ["omninode", "memory", "rag", "embeddings", "semantic-search", "onex"]
 dependencies = [
     # Core MCP integration for Archon connectivity
-    "mcp>=1.27.1,<2.0.0",
+    "mcp>=1.27.2,<2.0.0",
 
     # HTTP client for MCP calls and API communication
     "httpx>=0.28.1,<1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1067,7 +1067,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1085,9 +1085,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -1394,7 +1394,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.3,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'graph'", specifier = ">=0.28.1,<1.0.0" },
-    { name = "mcp", specifier = ">=1.27.1,<2.0.0" },
+    { name = "mcp", specifier = ">=1.27.2,<2.0.0" },
     { name = "neo4j", marker = "extra == 'graph'", specifier = ">=5.0.0,<6.0.0" },
     { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?tag=v0.43.0" },
     { name = "omnibase-infra", git = "https://github.com/OmniNode-ai/omnibase_infra.git?branch=main" },
@@ -1430,7 +1430,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.11.0,<1.0.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0,<3.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
-    { name = "ruff", specifier = ">=0.8.0,<1.0.0" },
+    { name = "ruff", specifier = ">=0.15.17,<1.0.0" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260518" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]


### PR DESCRIPTION
Evidence-Source: OCC#2662
Evidence-Ticket: OMN-13187

Maintainer-owned replacement for uneditable Dependabot dependency PRs. Central OCC evidence binds this PR head before merge.
