### PR TITLE
feat(OMN-13297): wire runtime-profiles gate into omnimemory

### DIFF
--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+---
+# Runtime Profiles — ValidatorRuntimeProfiles gate [OMN-12957]
+#
+# Wires omnibase_core.validation.validator_runtime_profiles as a required
+# status check on omnimemory node contracts. Enforces:
+#   - runtime_profiles_missing (OMN-9886) — command-consuming contracts must
+#     declare a runtime lane so the runtime knows how to wire their subscriptions.
+#
+# Pre-existing violators are frozen in
+# validation/runtime_profiles_allowlist.yaml (drain tracked by OMN-12982); the
+# gate blocks NEW orphans without forcing mass remediation.
+#
+# Wired via OMN-13297 (W3: runtime-profiles gate fleet wiring).
+# Required status check context: "Runtime Profiles / validate".
+
+name: Runtime Profiles
+
+on:
+  push:
+    branches: [main, develop, dev, "hotfix/**"]
+  pull_request:
+    branches: [main, develop, dev]
+  merge_group:
+    branches: [main, develop, dev]
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.8.3"
+
+concurrency:
+  group: runtime-profiles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout omnimemory
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Validate runtime_profiles on omnimemory contracts
+        run: uv run python scripts/ci/run_runtime_profiles_validator.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -503,6 +503,20 @@ repos:
 
   - repo: local
     hooks:
+      # OMN-12957: runtime_profiles contract validator (omnibase_core).
+      # Enforces runtime_profiles_missing (OMN-9886) — command-consuming contracts
+      # must declare a runtime lane. Pre-existing violators are frozen in
+      # validation/runtime_profiles_allowlist.yaml (drain tracked by OMN-12982).
+      # The wrapper script is used (instead of the bare module) so the repo-local
+      # allowlist is loaded the same way as the CI gate (OMN-13297 / mirrors OMN-12955).
+      - id: onex-validate-runtime-profiles
+        name: Validate runtime_profiles on node contracts (OMN-12957)
+        language: system
+        entry: uv run python scripts/ci/run_runtime_profiles_validator.py
+        files: ^src/omnimemory/nodes/node_.*/contract\.yaml$
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: normalization-symmetry
         name: normalization-symmetry
         entry: uv run python -m omnibase_core.validators.normalization-symmetry

--- a/scripts/ci/run_runtime_profiles_validator.py
+++ b/scripts/ci/run_runtime_profiles_validator.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Run the runtime_profiles contract validator with the omnimemory allowlist.
+
+Mirrors the required CI gate `.github/workflows/validator-runtime-profiles.yml`
+exactly: it constructs `ValidatorRuntimeProfiles` with the repo-local
+`validation/runtime_profiles_allowlist.yaml` and validates `src/`.
+
+This script exists so the local pre-commit hook and CI run the SAME invocation.
+The validator's module `__main__` entry point resolves its allowlist from the
+omnibase_core *package* directory, which does not contain the omnimemory
+repo's frozen-violator allowlist — so invoking the bare module locally flags
+every pre-existing allowlisted contract while CI passes. Pointing the hook at
+this script removes that local/CI drift (OMN-13297, mirrors OMN-12955 for
+omnimarket).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omnibase_core.validation.validator_runtime_profiles import (
+    ValidatorRuntimeProfiles,
+)
+
+ALLOWLIST_PATH = Path("validation/runtime_profiles_allowlist.yaml")
+SRC_ROOT = Path("src")
+
+
+def main() -> int:
+    result = ValidatorRuntimeProfiles(allowlist_path=ALLOWLIST_PATH).validate(SRC_ROOT)
+    for issue in result.issues:
+        print(  # noqa: T201
+            f"[{issue.severity.value}] {issue.file_path}:{issue.line_number}: {issue.message}"
+        )
+    return 0 if result.is_valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/runtime_profiles_allowlist.yaml
+++ b/validation/runtime_profiles_allowlist.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OMN-13297 baseline allowlist: freezes pre-existing runtime_profiles violators
+# so the gate blocks NEW orphans without forcing a mass remediation.
+# Drain tracked by OMN-12982 — fix each node's lane and delete its entry here.
+# ValidatorRuntimeProfiles discovers this file deterministically by walking up
+# from each scanned contract to the repo root (pyproject.toml); no env var.
+allowlist:
+  - node_id: node_agent_learning_retrieval_effect
+    reason: OMN-13297 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_filesystem_crawler_effect
+    reason: OMN-13297 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_intent_query_effect
+    reason: OMN-13297 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_memory_lifecycle_orchestrator
+    reason: OMN-13297 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)
+  - node_id: node_memory_retrieval_effect
+    reason: OMN-13297 baseline freeze; remediate via OMN-12982 (assign correct runtime lane or document runtime-exempt)


### PR DESCRIPTION
## Summary

W3 from the validator standardization remediation plan (2026-06-18-validator-standardization-remediation-plan.md, GAP-7).

Wires the existing `ValidatorRuntimeProfiles` pre-commit + CI gate into omnimemory. The gate was already present in omnibase_core, omnibase_infra, and omnimarket but absent here.

## Verification (F1 pre-file grep — confirmed absent before this PR)

```
rg "runtime_profile" .pre-commit-config.yaml  → ABSENT (before this PR)
```

omnimemory had 15 node contracts, 0 with `runtime_profiles`.

## Changes

- `validation/runtime_profiles_allowlist.yaml` — baseline-freezes 5 pre-existing command-consuming nodes that lack `runtime_profiles` (drain tracked by OMN-12982)
- `scripts/ci/run_runtime_profiles_validator.py` — wrapper script that loads the repo-local allowlist (mirrors OMN-12955 pattern from omnimarket so local pre-commit and CI use the same invocation)
- `.pre-commit-config.yaml` — adds `onex-validate-runtime-profiles` hook targeting `src/omnimemory/nodes/node_.*/contract\.yaml$`
- `.github/workflows/validator-runtime-profiles.yml` — CI gate (required status check context: "Runtime Profiles / validate")

## Fail-Closed Proof (same validator, same proof)

Planted a contract `node_test_violation_effect` subscribing to `onex.cmd.test.violation.v1` with no `runtime_profiles` and not in the allowlist:

```
[error] .../node_test_violation_effect/contract.yaml:1: runtime_profiles missing on
command-consuming contract 'node_test_violation_effect': declare
'runtime_profiles: [<profile>]' at the top level or under 'descriptor', or add
the node id to validation/runtime_profiles_allowlist.yaml with a reason.
EXIT: 1
```

Reverted → clean tree passes with exit 0.

Evidence-Source: OCC#2772
Evidence-Ticket: OMN-13297
