### PR TITLE
ci(OMN-13344): run title check for merge queue

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,8 @@ name: PR Title Check
 on:
   pull_request:
     types: [opened, edited]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   pr-title:


### PR DESCRIPTION
## Summary

Adds the `merge_group` trigger to the existing PR Title Check workflow so the required `pr-title / check-title` context can be produced on merge-queue refs.

This unblocks OMN-13344 omnimemory #374, which is clean on the PR head but stuck in merge queue because the required title-check context is not generated for merge-group SHAs.

## Verification

- `uv run python - <<'PY' ... yaml.safe_load(...)` validated `.github/workflows/pr-title-check.yml`.

Evidence-Ticket: OMN-13344
Evidence-Source: OCC#2822